### PR TITLE
Improve run context functions

### DIFF
--- a/src/vm/run_context.rs
+++ b/src/vm/run_context.rs
@@ -1,7 +1,7 @@
-use crate::compiler::instruction::Instruction;
-use crate::compiler::instruction::Op1Addr;
-use crate::compiler::instruction::Register;
-use crate::vm::memory_dict::Memory;
+use crate::vm::instruction::Instruction;
+use crate::vm::instruction::Op1Addr;
+use crate::vm::instruction::Register;
+use crate::vm::memory::Memory;
 use crate::vm::relocatable::MaybeRelocatable;
 use crate::vm::vm_core::VirtualMachineError;
 use num_bigint::BigInt;

--- a/src/vm/run_context.rs
+++ b/src/vm/run_context.rs
@@ -54,16 +54,12 @@ impl RunContext {
     pub fn compute_op0_addr(
         &self,
         instruction: &Instruction,
-    ) -> Result<MaybeRelocatable, VirtualMachineError> {
+    ) -> MaybeRelocatable {
         let base_addr = match instruction.op0_register {
-            Register::AP => Some(&self.ap),
-            Register::FP => Some(&self.fp),
+            Register::AP => &self.ap,
+            Register::FP => &self.fp,
         };
-        if let Some(addr) = base_addr {
-            return Ok(addr.add_num_addr(instruction.off1.clone(), Some(self.prime.clone())));
-        } else {
-            return Err(VirtualMachineError::InvalidOp0RegError);
-        }
+        return base_addr.add_num_addr(instruction.off1.clone(), Some(self.prime.clone()));
     }
 
     pub fn compute_op1_addr(

--- a/src/vm/run_context.rs
+++ b/src/vm/run_context.rs
@@ -35,26 +35,15 @@ impl RunContext {
         };
     }
 
-    pub fn compute_dst_addr(
-        &self,
-        instruction: &Instruction,
-    ) -> Result<MaybeRelocatable, VirtualMachineError> {
+    pub fn compute_dst_addr(&self, instruction: &Instruction) -> MaybeRelocatable {
         let base_addr = match instruction.dst_register {
-            Register::AP => Some(&self.ap),
-            Register::FP => Some(&self.fp),
+            Register::AP => &self.ap,
+            Register::FP => &self.fp,
         };
-        match base_addr {
-            Some(addr) => {
-                return Ok(addr.add_num_addr(instruction.off0.clone(), Some(self.prime.clone())))
-            }
-            _ => return Err(VirtualMachineError::InvalidDstRegError),
-        };
+        return base_addr.add_num_addr(instruction.off0.clone(), Some(self.prime.clone()));
     }
 
-    pub fn compute_op0_addr(
-        &self,
-        instruction: &Instruction,
-    ) -> MaybeRelocatable {
+    pub fn compute_op0_addr(&self, instruction: &Instruction) -> MaybeRelocatable {
         let base_addr = match instruction.op0_register {
             Register::AP => &self.ap,
             Register::FP => &self.fp,
@@ -68,20 +57,16 @@ impl RunContext {
         op0: Option<MaybeRelocatable>,
     ) -> Result<MaybeRelocatable, VirtualMachineError> {
         let base_addr = match instruction.op1_addr {
-            Op1Addr::FP =>  &self.fp,
-            Op1Addr::AP =>  &self.ap,
-            Op1Addr::IMM => {
-                match instruction.off2 == BigInt::from_i32(1).unwrap() {
-                    true => &self.pc,
-                    false => return Err(VirtualMachineError::ImmShouldBe1Error),
-                }
-            }
-            Op1Addr::OP0 => {
-                match op0 {
-                    Some(addr) => return Ok(addr + instruction.off1.clone() % self.prime.clone()),
-                    None => return Err(VirtualMachineError::UnknownOp0Error),
-                }
-            }
+            Op1Addr::FP => &self.fp,
+            Op1Addr::AP => &self.ap,
+            Op1Addr::IMM => match instruction.off2 == BigInt::from_i32(1).unwrap() {
+                true => &self.pc,
+                false => return Err(VirtualMachineError::ImmShouldBe1Error),
+            },
+            Op1Addr::OP0 => match op0 {
+                Some(addr) => return Ok(addr + instruction.off1.clone() % self.prime.clone()),
+                None => return Err(VirtualMachineError::UnknownOp0Error),
+            },
         };
         return Ok(base_addr.add_num_addr(instruction.off1.clone(), Some(self.prime.clone())));
     }


### PR DESCRIPTION
Removed useless code and unnecessary error handling from the functions compute_op0_address, compute_op1_address and compute_dst_address