### PR TITLE
add deny warnings-lint

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 mod vm;
 
 fn main() {}


### PR DESCRIPTION
Add `#![deny(warnings)]` lint to prevent adding warnings to the code.