### PR TITLE
Add method run_until_pc + Integration tests for initialization + execution phases

### DIFF
--- a/src/vm/cairo_runner.rs
+++ b/src/vm/cairo_runner.rs
@@ -5,12 +5,12 @@ use crate::vm::program::Program;
 use crate::vm::relocatable::MaybeRelocatable;
 use crate::vm::relocatable::Relocatable;
 use crate::vm::vm_core::VirtualMachine;
+use crate::vm::vm_core::VirtualMachineError;
 use num_bigint::BigInt;
 use num_traits::FromPrimitive;
 use std::collections::HashMap;
 
 pub struct CairoRunner {
-    //Uses segment's memory as memory, in order to avoid maintaining two references to the same data
     program: Program,
     pub vm: VirtualMachine,
     _layout: String,
@@ -156,6 +156,13 @@ impl CairoRunner {
                 self.vm.validated_addresses.append(&mut validated_addresses)
             }
         }
+    }
+
+    pub fn run_until_pc(&mut self, address: MaybeRelocatable) -> Result<(), VirtualMachineError> {
+        while self.vm.run_context.pc != address {
+            self.vm.step()?;
+        }
+        Ok(())
     }
 }
 

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -44,7 +44,7 @@ pub struct VirtualMachine {
     //auto_deduction: HashMap<BigInt, Vec<(Rule, ())>>,
     pub validated_addresses: Vec<MaybeRelocatable>,
     accessed_addresses: Vec<MaybeRelocatable>,
-    trace: Vec<TraceEntry>,
+    pub trace: Vec<TraceEntry>,
     current_step: BigInt,
     skip_instruction_execution: bool,
 }
@@ -85,7 +85,7 @@ impl VirtualMachine {
         }
     }
     ///Returns the encoded instruction (the value at pc) and the immediate value (the value at pc + 1, if it exists in the memory).
-    pub fn get_instruction_encoding(
+    fn get_instruction_encoding(
         &self,
     ) -> Result<(&BigInt, Option<&MaybeRelocatable>), VirtualMachineError> {
         let encoding_ref: &BigInt;
@@ -408,7 +408,7 @@ impl VirtualMachine {
         Ok(())
     }
 
-    pub fn decode_current_instruction(&self) -> Result<Instruction, VirtualMachineError> {
+    fn decode_current_instruction(&self) -> Result<Instruction, VirtualMachineError> {
         let (instruction_ref, imm) = self.get_instruction_encoding()?;
         let instruction = instruction_ref.clone().to_i64().unwrap();
         if let Some(&MaybeRelocatable::Int(ref imm_ref)) = imm {
@@ -426,7 +426,7 @@ impl VirtualMachine {
     }
     /// Compute operands and result, trying to deduce them if normal memory access returns a None
     /// value.
-    pub fn compute_operands(
+    fn compute_operands(
         &mut self,
         instruction: &Instruction,
     ) -> Result<(Operands, Vec<MaybeRelocatable>), VirtualMachineError> {

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -85,7 +85,7 @@ impl VirtualMachine {
         }
     }
     ///Returns the encoded instruction (the value at pc) and the immediate value (the value at pc + 1, if it exists in the memory).
-    fn get_instruction_encoding(
+    pub fn get_instruction_encoding(
         &self,
     ) -> Result<(&BigInt, Option<&MaybeRelocatable>), VirtualMachineError> {
         let encoding_ref: &BigInt;
@@ -408,7 +408,7 @@ impl VirtualMachine {
         Ok(())
     }
 
-    fn decode_current_instruction(&self) -> Result<Instruction, VirtualMachineError> {
+    pub fn decode_current_instruction(&self) -> Result<Instruction, VirtualMachineError> {
         let (instruction_ref, imm) = self.get_instruction_encoding()?;
         let instruction = instruction_ref.clone().to_i64().unwrap();
         if let Some(&MaybeRelocatable::Int(ref imm_ref)) = imm {


### PR DESCRIPTION
Add the method run_until_pc to CairoRunner, in order to loop over step.
Add integration tests that cover initialization + execution in the same manner as previous integration tests.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
