### PR TITLE
Allow non-contiguous memory

### DIFF
--- a/src/vm/runners/builtin_runner.rs
+++ b/src/vm/runners/builtin_runner.rs
@@ -29,7 +29,7 @@ pub trait BuiltinRunner {
     fn base(&self) -> Option<Relocatable>;
     fn validate_existing_memory(
         &self,
-        memory: &[MaybeRelocatable],
+        memory: &[Option<MaybeRelocatable>],
     ) -> Option<Vec<MaybeRelocatable>>;
 }
 
@@ -71,11 +71,11 @@ impl BuiltinRunner for RangeCheckBuiltinRunner {
 
     fn validate_existing_memory(
         &self,
-        builtin_memory: &[MaybeRelocatable],
+        builtin_memory: &[Option<MaybeRelocatable>],
     ) -> Option<Vec<MaybeRelocatable>> {
         let mut validated_addresses = Vec::<MaybeRelocatable>::new();
         for (offset, value) in builtin_memory.iter().enumerate() {
-            if let MaybeRelocatable::Int(ref num) = value {
+            if let Some(MaybeRelocatable::Int(ref num)) = value {
                 if bigint!(0) <= num.clone() && num.clone() < self._bound {
                     validated_addresses.push(MaybeRelocatable::RelocatableValue(Relocatable {
                         segment_index: self.base()?.segment_index,
@@ -127,7 +127,7 @@ impl BuiltinRunner for OutputBuiltinRunner {
     }
     fn validate_existing_memory(
         &self,
-        _memory: &[MaybeRelocatable],
+        _memory: &[Option<MaybeRelocatable>],
     ) -> Option<Vec<MaybeRelocatable>> {
         None
     }

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -2,15 +2,18 @@ use crate::{types::relocatable::MaybeRelocatable, utils::from_relocatable_to_ind
 
 #[derive(Clone)]
 pub struct Memory {
-    pub data: Vec<Vec<MaybeRelocatable>>,
+    pub data: Vec<Vec<Option<MaybeRelocatable>>>,
 }
 
 impl Memory {
     pub fn new() -> Memory {
         Memory {
-            data: Vec::<Vec<MaybeRelocatable>>::new(),
+            data: Vec::<Vec<Option<MaybeRelocatable>>>::new(),
         }
     }
+    ///Inserts an MaybeRelocatable value into an address given by a MaybeRelocatable::Relocatable
+    /// Will panic if the segment index given by the address corresponds to a non-allocated segment
+    /// If the address isnt contiguous with previously inserted data, memory gaps will be represented by inserting None values
     pub fn insert(&mut self, key: &MaybeRelocatable, val: &MaybeRelocatable) {
         if let MaybeRelocatable::RelocatableValue(relocatable) = key {
             let (i, j) = from_relocatable_to_indexes(relocatable.clone());
@@ -18,24 +21,29 @@ impl Memory {
             if self.data.len() < i + 1 {
                 panic!("Cant insert to a non-allocated memory segment")
             }
-            //Check that the element is inserted next to the las one on the segment
+            //Check if the element is inserted next to the last one on the segment
             //Forgoing this check would allow data to be inserted in a different index
             if self.data[i].len() < j {
-                panic!("Memory must be continuous")
+                //Insert none values to represent gaps in memory
+                for _ in 0..(j - self.data[i].len()) {
+                    self.data[i].push(None)
+                }
             }
-            self.data[i].push(val.clone())
+            self.data[i].push(Some(val.clone()))
         } else {
             panic!("Memory addresses must be relocatable")
         }
     }
+
     pub fn get(&self, key: &MaybeRelocatable) -> Option<&MaybeRelocatable> {
         if let MaybeRelocatable::RelocatableValue(relocatable) = key {
             let (i, j) = from_relocatable_to_indexes(relocatable.clone());
             if self.data.len() > i && self.data[i].len() > j {
-                Some(&self.data[i][j])
-            } else {
-                None
+                if let Some(ref element) = self.data[i][j] {
+                    return Some(element);
+                }
             }
+            None
         } else {
             panic!("Memory addresses must be relocatable")
         }
@@ -107,14 +115,31 @@ mod memory_tests {
     }
 
     #[test]
-    #[should_panic]
     fn insert_non_contiguous_element() {
         let key_a = MaybeRelocatable::from((0, 0));
         let key_b = MaybeRelocatable::from((0, 2));
         let val = MaybeRelocatable::from(bigint!(5));
         let mut memory = Memory::new();
+        memory.data.push(Vec::new());
         memory.insert(&key_a, &val);
         memory.insert(&key_b, &val);
+        assert_eq!(memory.get(&key_b), Some(&val));
+    }
+
+    #[test]
+    fn insert_non_contiguous_element_memory_gaps_none() {
+        let key_a = MaybeRelocatable::from((0, 0));
+        let key_b = MaybeRelocatable::from((0, 5));
+        let val = MaybeRelocatable::from(bigint!(5));
+        let mut memory = Memory::new();
+        memory.data.push(Vec::new());
+        memory.insert(&key_a, &val);
+        memory.insert(&key_b, &val);
+        assert_eq!(memory.get(&key_b), Some(&val));
+        assert_eq!(memory.get(&MaybeRelocatable::from((0, 1))), None);
+        assert_eq!(memory.get(&MaybeRelocatable::from((0, 2))), None);
+        assert_eq!(memory.get(&MaybeRelocatable::from((0, 3))), None);
+        assert_eq!(memory.get(&MaybeRelocatable::from((0, 4))), None);
     }
 
     #[test]


### PR DESCRIPTION
Motivation:
Currently,  memory is contiguous, and doesn't allow memory gaps, which are undesired but supported.
This change will allow memory to represent these gaps as none values, allowing data to be inserted non-contiguously.

What was changed in this PR:
- Change Memory from Matrix of MaybeRelocatables to Matrix of Option(MaybeRelocatables)
- Remove check for contiguous data insertion in memory
- When data is inserted non-contiguously None values will be inserted to fill in the gaps
- Change and add extra test for when data is inserted non-contiguously


Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [x] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
