### PR TITLE
Remove Memory from MemorySegmentManager

### DIFF
--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -79,9 +79,9 @@ impl CairoRunner {
     pub fn initialize_segments(&mut self, program_base: Option<Relocatable>) {
         self.program_base = match program_base {
             Some(base) => Some(base),
-            None => Some(self.segments.add(None)),
+            None => Some(self.segments.add(&self.vm.memory, None)),
         };
-        self.execution_base = Some(self.segments.add(None));
+        self.execution_base = Some(self.segments.add(&self.vm.memory, None));
         for (_key, builtin_runner) in self.vm.builtin_runners.iter_mut() {
             builtin_runner.initialize_segments(&mut self.segments);
         }
@@ -95,11 +95,13 @@ impl CairoRunner {
             };
             self.initial_pc = Some(initial_pc);
             self.segments.load_data(
+                &self.vm.memory,
                 &MaybeRelocatable::RelocatableValue(prog_base),
                 self.program.data.clone(),
             );
             if let Some(exec_base) = &self.execution_base {
                 self.segments.load_data(
+                    &self.vm.memory,
                     &MaybeRelocatable::RelocatableValue(exec_base.clone()),
                     stack,
                 );
@@ -117,7 +119,7 @@ impl CairoRunner {
         mut stack: Vec<MaybeRelocatable>,
         return_fp: MaybeRelocatable,
     ) -> Relocatable {
-        let end = self.segments.add(None);
+        let end = self.segments.add(&self.vm.memory, None);
         stack.append(&mut vec![
             return_fp,
             MaybeRelocatable::RelocatableValue(end.clone()),
@@ -145,7 +147,7 @@ impl CairoRunner {
             stack.append(&mut builtin_runner.initial_stack());
         }
         //Different process if proof_mode is enabled
-        let return_fp = self.segments.add(None);
+        let return_fp = self.segments.add(&self.vm.memory, None);
         if let Some(main) = &self.program.main {
             let main_clone = *main;
             self.initialize_function_entrypoint(
@@ -166,11 +168,9 @@ impl CairoRunner {
             MaybeRelocatable::RelocatableValue(self.initial_ap.clone().unwrap());
         self.vm.run_context.fp =
             MaybeRelocatable::RelocatableValue(self.initial_fp.clone().unwrap());
-        self.vm.memory = self.segments.memory.clone();
         self.vm._program_base = Some(MaybeRelocatable::RelocatableValue(
             self.program_base.clone().unwrap(),
         ));
-        self.vm.memory = self.segments.memory.clone();
         for (_key, builtin) in self.vm.builtin_runners.iter() {
             let vec = builtin.validate_existing_memory(
                 &self.vm.memory.data[builtin.base().unwrap().segment_index],
@@ -197,7 +197,7 @@ impl CairoRunner {
         );
         //Relocated addresses start at 1
         self.relocated_memory.push(None);
-        for (index, segment) in self.segments.memory.data.iter().enumerate() {
+        for (index, segment) in self.vm.memory.data.iter().enumerate() {
             //Check that each segment was relocated correctly
             assert!(
                 self.relocated_memory.len() == relocation_table[index],
@@ -232,7 +232,7 @@ impl CairoRunner {
     }
 
     fn relocate(&mut self) {
-        self.segments.compute_effective_sizes();
+        self.segments.compute_effective_sizes(&self.vm.memory);
         let relocation_table = self.segments.relocate_segments();
         self.relocate_memory(&relocation_table);
         self.relocate_trace(&relocation_table);
@@ -389,7 +389,7 @@ mod tests {
         };
         let mut cairo_runner = CairoRunner::new(&program);
         for _ in 0..2 {
-            cairo_runner.segments.add(None);
+            cairo_runner.segments.add(&cairo_runner.vm.memory, None);
         }
         cairo_runner.program_base = Some(Relocatable {
             segment_index: 1,
@@ -400,7 +400,7 @@ mod tests {
         cairo_runner.initialize_state(1, stack);
         assert_eq!(
             cairo_runner
-                .segments
+                .vm
                 .memory
                 .get(&MaybeRelocatable::RelocatableValue(
                     cairo_runner.program_base.unwrap()
@@ -408,10 +408,7 @@ mod tests {
             Some(&MaybeRelocatable::from(bigint!(4)))
         );
         assert_eq!(
-            cairo_runner
-                .segments
-                .memory
-                .get(&MaybeRelocatable::from((1, 1))),
+            cairo_runner.vm.memory.get(&MaybeRelocatable::from((1, 1))),
             Some(&MaybeRelocatable::from(bigint!(6)))
         );
     }
@@ -427,7 +424,7 @@ mod tests {
         };
         let mut cairo_runner = CairoRunner::new(&program);
         for _ in 0..3 {
-            cairo_runner.segments.add(None);
+            cairo_runner.segments.add(&cairo_runner.vm.memory, None);
         }
         cairo_runner.program_base = Some(relocatable!(1, 0));
         cairo_runner.execution_base = Some(relocatable!(2, 0));
@@ -438,7 +435,7 @@ mod tests {
         cairo_runner.initialize_state(1, stack);
         assert_eq!(
             cairo_runner
-                .segments
+                .vm
                 .memory
                 .get(&MaybeRelocatable::RelocatableValue(
                     cairo_runner.execution_base.unwrap()
@@ -446,10 +443,7 @@ mod tests {
             Some(&MaybeRelocatable::from(bigint!(4)))
         );
         assert_eq!(
-            cairo_runner
-                .segments
-                .memory
-                .get(&MaybeRelocatable::from((2, 1))),
+            cairo_runner.vm.memory.get(&MaybeRelocatable::from((2, 1))),
             Some(&MaybeRelocatable::from(bigint!(6)))
         );
     }
@@ -466,7 +460,7 @@ mod tests {
         };
         let mut cairo_runner = CairoRunner::new(&program);
         for _ in 0..2 {
-            cairo_runner.segments.add(None);
+            cairo_runner.segments.add(&cairo_runner.vm.memory, None);
         }
         cairo_runner.execution_base = Some(Relocatable {
             segment_index: 2,
@@ -491,7 +485,7 @@ mod tests {
         };
         let mut cairo_runner = CairoRunner::new(&program);
         for _ in 0..2 {
-            cairo_runner.segments.add(None);
+            cairo_runner.segments.add(&cairo_runner.vm.memory, None);
         }
         cairo_runner.program_base = Some(relocatable!(1, 0));
         let stack = vec![
@@ -512,7 +506,7 @@ mod tests {
         };
         let mut cairo_runner = CairoRunner::new(&program);
         for _ in 0..2 {
-            cairo_runner.segments.add(None);
+            cairo_runner.segments.add(&cairo_runner.vm.memory, None);
         }
         cairo_runner.program_base = Some(relocatable!(0, 0));
         cairo_runner.execution_base = Some(relocatable!(1, 0));
@@ -522,17 +516,11 @@ mod tests {
         assert_eq!(cairo_runner.initial_fp, cairo_runner.initial_ap);
         assert_eq!(cairo_runner.initial_fp, Some(relocatable!(1, 2)));
         assert_eq!(
-            cairo_runner
-                .segments
-                .memory
-                .get(&MaybeRelocatable::from((1, 0))),
+            cairo_runner.vm.memory.get(&MaybeRelocatable::from((1, 0))),
             Some(&MaybeRelocatable::from(bigint!(9)))
         );
         assert_eq!(
-            cairo_runner
-                .segments
-                .memory
-                .get(&MaybeRelocatable::from((1, 1))),
+            cairo_runner.vm.memory.get(&MaybeRelocatable::from((1, 1))),
             Some(&MaybeRelocatable::from((2, 0)))
         );
     }
@@ -548,7 +536,7 @@ mod tests {
         };
         let mut cairo_runner = CairoRunner::new(&program);
         for _ in 0..2 {
-            cairo_runner.segments.add(None);
+            cairo_runner.segments.add(&cairo_runner.vm.memory, None);
         }
         cairo_runner.program_base = Some(relocatable!(0, 0));
         cairo_runner.execution_base = Some(relocatable!(1, 0));
@@ -558,24 +546,15 @@ mod tests {
         assert_eq!(cairo_runner.initial_fp, cairo_runner.initial_ap);
         assert_eq!(cairo_runner.initial_fp, Some(relocatable!(1, 3)));
         assert_eq!(
-            cairo_runner
-                .segments
-                .memory
-                .get(&MaybeRelocatable::from((1, 0))),
+            cairo_runner.vm.memory.get(&MaybeRelocatable::from((1, 0))),
             Some(&MaybeRelocatable::from(bigint!(7)))
         );
         assert_eq!(
-            cairo_runner
-                .segments
-                .memory
-                .get(&MaybeRelocatable::from((1, 1))),
+            cairo_runner.vm.memory.get(&MaybeRelocatable::from((1, 1))),
             Some(&MaybeRelocatable::from(bigint!(9)))
         );
         assert_eq!(
-            cairo_runner
-                .segments
-                .memory
-                .get(&MaybeRelocatable::from((1, 2))),
+            cairo_runner.vm.memory.get(&MaybeRelocatable::from((1, 2))),
             Some(&MaybeRelocatable::from((2, 0)))
         );
     }
@@ -673,11 +652,11 @@ mod tests {
         cairo_runner.initial_ap = Some(relocatable!(1, 2));
         cairo_runner.initial_fp = Some(relocatable!(1, 2));
         cairo_runner.initialize_segments(None);
-        cairo_runner.segments.memory.insert(
+        cairo_runner.vm.memory.insert(
             &MaybeRelocatable::from((2, 0)),
             &MaybeRelocatable::from(bigint!(23)),
         );
-        cairo_runner.segments.memory.insert(
+        cairo_runner.vm.memory.insert(
             &MaybeRelocatable::from((2, 1)),
             &MaybeRelocatable::from(bigint!(233)),
         );
@@ -712,11 +691,11 @@ mod tests {
         cairo_runner.initial_ap = Some(relocatable!(1, 2));
         cairo_runner.initial_fp = Some(relocatable!(1, 2));
         cairo_runner.initialize_segments(None);
-        cairo_runner.segments.memory.insert(
+        cairo_runner.vm.memory.insert(
             &MaybeRelocatable::from((2, 1)),
             &MaybeRelocatable::from(bigint!(23)),
         );
-        cairo_runner.segments.memory.insert(
+        cairo_runner.vm.memory.insert(
             &MaybeRelocatable::from((2, 4)),
             &MaybeRelocatable::from(bigint!(-1)),
         );
@@ -1984,33 +1963,35 @@ mod tests {
         };
         let mut cairo_runner = CairoRunner::new(&program);
         for _ in 0..4 {
-            cairo_runner.segments.add(None);
+            cairo_runner.segments.add(&cairo_runner.vm.memory, None);
         }
-        cairo_runner.segments.memory.insert(
+        cairo_runner.vm.memory.insert(
             &MaybeRelocatable::from((0, 0)),
             &MaybeRelocatable::from(bigint64!(4613515612218425347)),
         );
-        cairo_runner.segments.memory.insert(
+        cairo_runner.vm.memory.insert(
             &MaybeRelocatable::from((0, 1)),
             &MaybeRelocatable::from(bigint!(5)),
         );
-        cairo_runner.segments.memory.insert(
+        cairo_runner.vm.memory.insert(
             &MaybeRelocatable::from((0, 2)),
             &MaybeRelocatable::from(bigint64!(2345108766317314046)),
         );
-        cairo_runner.segments.memory.insert(
+        cairo_runner.vm.memory.insert(
             &MaybeRelocatable::from((1, 0)),
             &MaybeRelocatable::from((2, 0)),
         );
-        cairo_runner.segments.memory.insert(
+        cairo_runner.vm.memory.insert(
             &MaybeRelocatable::from((1, 1)),
             &MaybeRelocatable::from((3, 0)),
         );
-        cairo_runner.segments.memory.insert(
+        cairo_runner.vm.memory.insert(
             &MaybeRelocatable::from((1, 5)),
             &MaybeRelocatable::from(bigint!(5)),
         );
-        cairo_runner.segments.compute_effective_sizes();
+        cairo_runner
+            .segments
+            .compute_effective_sizes(&cairo_runner.vm.memory);
         let rel_table = cairo_runner.segments.relocate_segments();
         cairo_runner.relocate_memory(&rel_table);
         assert_eq!(cairo_runner.relocated_memory[0], None);
@@ -2108,8 +2089,9 @@ mod tests {
             cairo_runner.run_until_pc(MaybeRelocatable::RelocatableValue(end)),
             Ok(())
         );
-        cairo_runner.segments.memory = cairo_runner.vm.memory.clone();
-        cairo_runner.segments.compute_effective_sizes();
+        cairo_runner
+            .segments
+            .compute_effective_sizes(&cairo_runner.vm.memory);
         let rel_table = cairo_runner.segments.relocate_segments();
         cairo_runner.relocate_memory(&rel_table);
         assert_eq!(cairo_runner.relocated_memory[0], None);
@@ -2237,8 +2219,9 @@ mod tests {
             cairo_runner.run_until_pc(MaybeRelocatable::RelocatableValue(end)),
             Ok(())
         );
-        cairo_runner.segments.memory = cairo_runner.vm.memory.clone();
-        cairo_runner.segments.compute_effective_sizes();
+        cairo_runner
+            .segments
+            .compute_effective_sizes(&cairo_runner.vm.memory);
         let rel_table = cairo_runner.segments.relocate_segments();
         cairo_runner.relocate_trace(&rel_table);
         assert_eq!(cairo_runner.relocated_trace.len(), 12);

--- a/src/vm/vm_memory/memory_segments.rs
+++ b/src/vm/vm_memory/memory_segments.rs
@@ -2,7 +2,6 @@ use crate::types::relocatable::{MaybeRelocatable, Relocatable};
 use crate::vm::vm_memory::memory::Memory;
 
 pub struct MemorySegmentManager {
-    pub memory: Memory,
     pub num_segments: usize,
     pub segment_used_sizes: Option<Vec<usize>>,
 }
@@ -11,13 +10,13 @@ pub struct MemorySegmentManager {
 impl MemorySegmentManager {
     ///Adds a new segment and returns its starting location as a RelocatableValue.
     ///If size is not None the segment is finalized with the given size. (size will be always none for initialization)
-    pub fn add(&mut self, size: Option<usize>) -> Relocatable {
+    pub fn add(&mut self, memory: &Memory, size: Option<usize>) -> Relocatable {
         let segment_index = self.num_segments;
         self.num_segments += 1;
         if let Some(_segment_size) = size {
             //TODO self.finalize(segment_index, size);
         }
-        self.memory.data.push(Vec::new());
+        memory.data.push(Vec::new());
         Relocatable {
             segment_index,
             offset: 0,
@@ -26,30 +25,30 @@ impl MemorySegmentManager {
     ///Writes data into the memory at address ptr and returns the first address after the data.
     pub fn load_data(
         &mut self,
+        memory: &Memory,
         ptr: &MaybeRelocatable,
         data: Vec<MaybeRelocatable>,
     ) -> MaybeRelocatable {
         for (num, value) in data.iter().enumerate() {
-            self.memory.insert(&ptr.add_usize_mod(num, None), value);
+            memory.insert(&ptr.add_usize_mod(num, None), value);
         }
         ptr.add_usize_mod(data.len(), None)
     }
 
     pub fn new() -> MemorySegmentManager {
         MemorySegmentManager {
-            memory: Memory::new(),
             num_segments: 0,
             segment_used_sizes: None,
         }
     }
 
     ///Calculates the size (number of non-none elements) of each memory segment
-    pub fn compute_effective_sizes(&mut self) {
+    pub fn compute_effective_sizes(&mut self, memory: &Memory) {
         if self.segment_used_sizes != None {
             return;
         }
         let mut segment_used_sizes = Vec::new();
-        for segment in self.memory.data.iter() {
+        for segment in memory.data.iter() {
             segment_used_sizes.push(segment.len());
         }
         self.segment_used_sizes = Some(segment_used_sizes);
@@ -83,7 +82,8 @@ mod tests {
     #[test]
     fn add_segment_no_size() {
         let mut segments = MemorySegmentManager::new();
-        let base = segments.add(None);
+        let mut memory = Memory::new();
+        let base = segments.add(&memory, None);
         assert_eq!(base, relocatable!(0, 0));
         assert_eq!(segments.num_segments, 1);
     }
@@ -91,8 +91,9 @@ mod tests {
     #[test]
     fn add_segment_no_size_test_two_segments() {
         let mut segments = MemorySegmentManager::new();
-        let mut _base = segments.add(None);
-        _base = segments.add(None);
+        let memory = Memory::new();
+        let mut _base = segments.add(&memory, None);
+        _base = segments.add(&memory, None);
         assert_eq!(
             _base,
             Relocatable {
@@ -108,7 +109,8 @@ mod tests {
         let data = Vec::new();
         let ptr = MaybeRelocatable::from((0, 3));
         let mut segments = MemorySegmentManager::new();
-        let current_ptr = segments.load_data(&ptr, data);
+        let mut memory = Memory::new();
+        let current_ptr = segments.load_data(&memory, &ptr, data);
         assert_eq!(current_ptr, MaybeRelocatable::from((0, 3)))
     }
 
@@ -117,13 +119,11 @@ mod tests {
         let data = vec![MaybeRelocatable::from(bigint!(4))];
         let ptr = MaybeRelocatable::from((0, 0));
         let mut segments = MemorySegmentManager::new();
-        segments.add(None);
-        let current_ptr = segments.load_data(&ptr, data);
+        let memory = Memory::new();
+        segments.add(&memory, None);
+        let current_ptr = segments.load_data(&memory, &ptr, data);
         assert_eq!(current_ptr, MaybeRelocatable::from((0, 1)));
-        assert_eq!(
-            segments.memory.get(&ptr),
-            Some(&MaybeRelocatable::from(bigint!(4)))
-        );
+        assert_eq!(memory.get(&ptr), Some(&MaybeRelocatable::from(bigint!(4))));
     }
 
     #[test]
@@ -135,167 +135,171 @@ mod tests {
         ];
         let ptr = MaybeRelocatable::from((0, 0));
         let mut segments = MemorySegmentManager::new();
-        segments.add(None);
-        let current_ptr = segments.load_data(&ptr, data);
+        let mut memory = Memory::new();
+        segments.add(&memory, None);
+        let current_ptr = segments.load_data(&memory, &ptr, data);
         assert_eq!(current_ptr, MaybeRelocatable::from((0, 3)));
 
+        assert_eq!(memory.get(&ptr), Some(&MaybeRelocatable::from(bigint!(4))));
         assert_eq!(
-            segments.memory.get(&ptr),
-            Some(&MaybeRelocatable::from(bigint!(4)))
-        );
-        assert_eq!(
-            segments.memory.get(&MaybeRelocatable::from((0, 1))),
+            memory.get(&MaybeRelocatable::from((0, 1))),
             Some(&MaybeRelocatable::from(bigint!(5)))
         );
         assert_eq!(
-            segments.memory.get(&MaybeRelocatable::from((0, 2))),
+            memory.get(&MaybeRelocatable::from((0, 2))),
             Some(&MaybeRelocatable::from(bigint!(6)))
         );
     }
     #[test]
     fn compute_effective_sizes_for_one_segment_memory() {
         let mut segments = MemorySegmentManager::new();
-        segments.add(None);
-        segments.memory.insert(
+        let memory = Memory::new();
+        segments.add(&memory, None);
+        memory.insert(
             &MaybeRelocatable::from((0, 0)),
             &MaybeRelocatable::from(bigint!(1)),
         );
-        segments.memory.insert(
+        memory.insert(
             &MaybeRelocatable::from((0, 1)),
             &MaybeRelocatable::from(bigint!(1)),
         );
-        segments.memory.insert(
+        memory.insert(
             &MaybeRelocatable::from((0, 2)),
             &MaybeRelocatable::from(bigint!(1)),
         );
-        segments.compute_effective_sizes();
+        segments.compute_effective_sizes(&memory);
         assert_eq!(Some(vec![3]), segments.segment_used_sizes);
     }
 
     #[test]
     fn compute_effective_sizes_for_one_segment_memory_with_gap() {
         let mut segments = MemorySegmentManager::new();
-        segments.add(None);
-        segments.memory.insert(
+        let mut memory = Memory::new();
+        segments.add(&memory, None);
+        memory.insert(
             &MaybeRelocatable::from((0, 6)),
             &MaybeRelocatable::from(bigint!(1)),
         );
-        segments.compute_effective_sizes();
+        segments.compute_effective_sizes(&memory);
         assert_eq!(Some(vec![7]), segments.segment_used_sizes);
     }
 
     #[test]
     fn compute_effective_sizes_for_one_segment_memory_with_gaps() {
         let mut segments = MemorySegmentManager::new();
-        segments.add(None);
-        segments.memory.insert(
+        let memory = Memory::new();
+        segments.add(&memory, None);
+        memory.insert(
             &MaybeRelocatable::from((0, 3)),
             &MaybeRelocatable::from(bigint!(1)),
         );
-        segments.memory.insert(
+        memory.insert(
             &MaybeRelocatable::from((0, 4)),
             &MaybeRelocatable::from(bigint!(1)),
         );
-        segments.memory.insert(
+        memory.insert(
             &MaybeRelocatable::from((0, 7)),
             &MaybeRelocatable::from(bigint!(1)),
         );
-        segments.memory.insert(
+        memory.insert(
             &MaybeRelocatable::from((0, 9)),
             &MaybeRelocatable::from(bigint!(1)),
         );
-        segments.compute_effective_sizes();
+        segments.compute_effective_sizes(&memory);
         assert_eq!(Some(vec![10]), segments.segment_used_sizes);
     }
 
     #[test]
     fn compute_effective_sizes_for_three_segment_memory() {
         let mut segments = MemorySegmentManager::new();
-        segments.add(None);
-        segments.add(None);
-        segments.add(None);
-        segments.memory.insert(
+        let mut memory = Memory::new();
+        segments.add(&memory, None);
+        segments.add(&memory, None);
+        segments.add(&memory, None);
+        memory.insert(
             &MaybeRelocatable::from((0, 0)),
             &MaybeRelocatable::from(bigint!(1)),
         );
-        segments.memory.insert(
+        memory.insert(
             &MaybeRelocatable::from((0, 1)),
             &MaybeRelocatable::from(bigint!(1)),
         );
-        segments.memory.insert(
+        memory.insert(
             &MaybeRelocatable::from((0, 2)),
             &MaybeRelocatable::from(bigint!(1)),
         );
-        segments.memory.insert(
+        memory.insert(
             &MaybeRelocatable::from((1, 0)),
             &MaybeRelocatable::from(bigint!(1)),
         );
-        segments.memory.insert(
+        memory.insert(
             &MaybeRelocatable::from((1, 1)),
             &MaybeRelocatable::from(bigint!(1)),
         );
-        segments.memory.insert(
+        memory.insert(
             &MaybeRelocatable::from((1, 2)),
             &MaybeRelocatable::from(bigint!(1)),
         );
-        segments.memory.insert(
+        memory.insert(
             &MaybeRelocatable::from((2, 0)),
             &MaybeRelocatable::from(bigint!(1)),
         );
-        segments.memory.insert(
+        memory.insert(
             &MaybeRelocatable::from((2, 1)),
             &MaybeRelocatable::from(bigint!(1)),
         );
-        segments.memory.insert(
+        memory.insert(
             &MaybeRelocatable::from((2, 2)),
             &MaybeRelocatable::from(bigint!(1)),
         );
 
-        segments.compute_effective_sizes();
+        segments.compute_effective_sizes(&memory);
         assert_eq!(Some(vec![3, 3, 3]), segments.segment_used_sizes);
     }
 
     #[test]
     fn compute_effective_sizes_for_three_segment_memory_with_gaps() {
         let mut segments = MemorySegmentManager::new();
-        segments.add(None);
-        segments.add(None);
-        segments.add(None);
-        segments.memory.insert(
+        let memory = Memory::new();
+        segments.add(&memory, None);
+        segments.add(&memory, None);
+        segments.add(&memory, None);
+        memory.insert(
             &MaybeRelocatable::from((0, 2)),
             &MaybeRelocatable::from(bigint!(1)),
         );
-        segments.memory.insert(
+        memory.insert(
             &MaybeRelocatable::from((0, 5)),
             &MaybeRelocatable::from(bigint!(1)),
         );
-        segments.memory.insert(
+        memory.insert(
             &MaybeRelocatable::from((0, 7)),
             &MaybeRelocatable::from(bigint!(1)),
         );
-        segments.memory.insert(
+        memory.insert(
             &MaybeRelocatable::from((1, 1)),
             &MaybeRelocatable::from(bigint!(1)),
         );
-        segments.memory.insert(
+        memory.insert(
             &MaybeRelocatable::from((2, 2)),
             &MaybeRelocatable::from(bigint!(1)),
         );
-        segments.memory.insert(
+        memory.insert(
             &MaybeRelocatable::from((2, 4)),
             &MaybeRelocatable::from(bigint!(1)),
         );
-        segments.memory.insert(
+        memory.insert(
             &MaybeRelocatable::from((2, 7)),
             &MaybeRelocatable::from(bigint!(1)),
         );
-        segments.compute_effective_sizes();
+        segments.compute_effective_sizes(&memory);
         assert_eq!(Some(vec![8, 2, 8]), segments.segment_used_sizes);
     }
 
     #[test]
     fn relocate_segments_one_segment() {
         let mut segments = MemorySegmentManager::new();
+        let mut memory = Memory::new();
         segments.segment_used_sizes = Some(vec![3]);
         assert_eq!(segments.relocate_segments(), vec![1])
     }
@@ -303,6 +307,7 @@ mod tests {
     #[test]
     fn relocate_segments_five_segment() {
         let mut segments = MemorySegmentManager::new();
+        let memory = Memory::new();
         segments.segment_used_sizes = Some(vec![3, 3, 56, 78, 8]);
         assert_eq!(segments.relocate_segments(), vec![1, 4, 7, 63, 141])
     }


### PR DESCRIPTION
Motivation: 
On the current implementation, both the MemorySegmentManager and VirtualMachine on CairoRunner contain Memory, referring to the vm's memory. As the MemorySegmentManager takes care of initialization and relocation, memory needs to be cloned from the manager to the vm and then back to the manager before and after execution. This PR aims to remove this cloning by removing the memory from the MemorySegmentManager

What was changed in this PR:
- Remove field memory from MemorySegmentManager
- Methods on MemorySegmentManager now receive a mutable reference to the vm's memory
- Fix affected tests and functions

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
