### PR TITLE
Add function cairo_run

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 #![deny(warnings)]
+mod cairo_run;
 mod serde;
 mod types;
 mod utils;

--- a/src/types/program.rs
+++ b/src/types/program.rs
@@ -11,7 +11,7 @@ pub struct Program {
 }
 #[allow(dead_code)]
 impl Program {
-    fn new(path: &str) -> Program {
+    pub fn new(path: &str) -> Program {
         deserialize_program::deserialize_program(path)
     }
 }


### PR DESCRIPTION
Motivation:
Add a function that will load  the  compiled program, initialize the vm, run it and perform the relocation process.

What was changed in this PR:
- Add the function cairo_run
- Change the return value of initialize_main_entrypoint and initialize_main_function_entrypoint to avoid performing data conversion in cairo-run

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
