### PR TITLE
Fix cairo_run ad add checks for relocatable addition

### DIFF
--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -7,6 +7,7 @@ pub fn cairo_run(path: &str) {
     let mut cairo_runner = CairoRunner::new(&program);
     cairo_runner.initialize_segments(None);
     let end = cairo_runner.initialize_main_entrypoint();
+    cairo_runner.initialize_vm();
     assert!(cairo_runner.run_until_pc(end) == Ok(()), "Execution failed");
     cairo_runner.relocate()
 }

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -45,12 +45,15 @@ impl MaybeRelocatable {
                 MaybeRelocatable::Int(num)
             }
             MaybeRelocatable::RelocatableValue(ref rel) => {
-                let mut new_offset = rel.offset + other;
-                new_offset %= prime;
+                let mut big_offset = rel.offset + other;
+                big_offset %= prime;
+                let new_offset = match big_offset.to_usize() {
+                    Some(usize) => usize,
+                    None => panic!("Offset exeeds maximum offset value"),
+                };
                 MaybeRelocatable::RelocatableValue(Relocatable {
                     segment_index: rel.segment_index,
-                    //TODO: check this unwrap
-                    offset: new_offset.to_usize().unwrap(),
+                    offset: new_offset,
                 })
             }
         }

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -1,4 +1,4 @@
-use crate::vm::vm_core::VirtualMachineError;
+use crate::{bigint, vm::vm_core::VirtualMachineError};
 use num_bigint::BigInt;
 use num_traits::{FromPrimitive, ToPrimitive};
 
@@ -46,6 +46,9 @@ impl MaybeRelocatable {
             }
             MaybeRelocatable::RelocatableValue(ref rel) => {
                 let mut big_offset = rel.offset + other;
+                if big_offset < bigint!(0) {
+                    panic!("Address Offset cant be negative");
+                }
                 big_offset %= prime;
                 let new_offset = match big_offset.to_usize() {
                     Some(usize) => usize,


### PR DESCRIPTION
- Add missing function call on cairo_run
- Add checks for negative values when adding a BigInt to a Relocatable value

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
