### PR TITLE
Add method print_output

### DIFF
--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -9,5 +9,6 @@ pub fn cairo_run(path: &str) {
     let end = cairo_runner.initialize_main_entrypoint();
     cairo_runner.initialize_vm();
     assert!(cairo_runner.run_until_pc(end) == Ok(()), "Execution failed");
-    cairo_runner.relocate()
+    cairo_runner.relocate();
+    cairo_runner.print_output();
 }

--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -1,5 +1,6 @@
 use crate::types::program::Program;
 use crate::vm::runners::cairo_runner::CairoRunner;
+use std::io;
 
 #[allow(dead_code)]
 pub fn cairo_run(path: &str) {
@@ -10,5 +11,5 @@ pub fn cairo_run(path: &str) {
     cairo_runner.initialize_vm();
     assert!(cairo_runner.run_until_pc(end) == Ok(()), "Execution failed");
     cairo_runner.relocate();
-    cairo_runner.print_output();
+    cairo_runner.print_output(&mut io::stdout());
 }

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -239,12 +239,11 @@ impl CairoRunner {
         self.relocate_trace(&relocation_table);
     }
 
-    pub fn print_output(&self, stdout: &mut dyn io::Write) {
+    pub fn print_output(&mut self, stdout: &mut dyn io::Write) {
         if let Some(builtin) = self.vm.builtin_runners.get("output") {
-            assert!(
-                self.segments.segment_used_sizes != None,
-                "compute_effective_sizes should be called before print_output"
-            );
+            if self.segments.segment_used_sizes == None {
+                self.segments.compute_effective_sizes(&self.vm.memory);
+            }
             let base = match builtin.base() {
                 Some(base) => base,
                 None => panic!("Uninitialized Output Builtin Base"),
@@ -2410,9 +2409,6 @@ mod tests {
         cairo_runner.initialize_vm();
         //Execution Phase
         assert_eq!(cairo_runner.run_until_pc(end), Ok(()));
-        cairo_runner
-            .segments
-            .compute_effective_sizes(&cairo_runner.vm.memory);
         let mut stdout = Vec::<u8>::new();
         cairo_runner.print_output(&mut stdout);
         assert_eq!(

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -237,6 +237,26 @@ impl CairoRunner {
         self.relocate_memory(&relocation_table);
         self.relocate_trace(&relocation_table);
     }
+
+    pub fn print_output(&self) {
+        if let Some(builtin) = self.vm.builtin_runners.get("output") {
+            assert!(
+                self.segments.segment_used_sizes != None,
+                "compute_effective_sizes should be called before print_output"
+            );
+            println!("Program Output: ");
+            let base = builtin.base().unwrap();
+            for i in 0..self.segments.segment_used_sizes.as_ref().unwrap()[base.segment_index] {
+                let value = self
+                    .vm
+                    .memory
+                    .get(&MaybeRelocatable::RelocatableValue(base.clone()).add_usize_mod(i, None));
+                if let Some(&MaybeRelocatable::Int(ref num)) = value {
+                    println!("{}", num);
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -244,8 +244,11 @@ impl CairoRunner {
                 self.segments.segment_used_sizes != None,
                 "compute_effective_sizes should be called before print_output"
             );
+            let base = match builtin.base() {
+                Some(base) => base,
+                None => panic!("Uninitialized Output Builtin Base"),
+            };
             println!("Program Output: ");
-            let base = builtin.base().unwrap();
             for i in 0..self.segments.segment_used_sizes.as_ref().unwrap()[base.segment_index] {
                 let value = self
                     .vm


### PR DESCRIPTION
Motivation:
Add the method print_output, needed to print the program's output when the output builtin is used in a cairo program

Changes:
- Add method print_output
- Add call to print_output in cairo_run
- Add tests

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [x] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
