### PR TITLE
Pedersen builtin integration test

### DIFF
--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -28,7 +28,7 @@ pub struct CairoRunner {
     initial_fp: Option<Relocatable>,
     initial_pc: Option<Relocatable>,
     relocated_memory: Vec<Option<BigInt>>,
-    relocated_trace: Vec<RelocatedTraceEntry>,
+    pub relocated_trace: Vec<RelocatedTraceEntry>,
 }
 
 #[allow(dead_code)]

--- a/tests/pedersen_test.rs
+++ b/tests/pedersen_test.rs
@@ -1,0 +1,89 @@
+use cleopatra_cairo::{
+    types::program::Program, vm::runners::cairo_runner::CairoRunner,
+    vm::trace::trace_entry::RelocatedTraceEntry,
+};
+
+#[test]
+fn pedersen_integration_test() {
+    let program = Program::new("tests/support/pedersen_test.json");
+    let mut cairo_runner = CairoRunner::new(&program);
+    cairo_runner.initialize_segments(None);
+    let end = cairo_runner.initialize_main_entrypoint().unwrap();
+    assert!(cairo_runner.initialize_vm() == Ok(()), "Execution failed");
+    assert!(cairo_runner.run_until_pc(end) == Ok(()), "Execution failed");
+    assert!(cairo_runner.relocate() == Ok(()), "Execution failed");
+
+    let python_vm_relocated_trace: Vec<RelocatedTraceEntry> = vec![
+        RelocatedTraceEntry {
+            pc: 7,
+            ap: 25,
+            fp: 25,
+        },
+        RelocatedTraceEntry {
+            pc: 8,
+            ap: 26,
+            fp: 25,
+        },
+        RelocatedTraceEntry {
+            pc: 10,
+            ap: 27,
+            fp: 25,
+        },
+        RelocatedTraceEntry {
+            pc: 12,
+            ap: 28,
+            fp: 25,
+        },
+        RelocatedTraceEntry {
+            pc: 1,
+            ap: 30,
+            fp: 30,
+        },
+        RelocatedTraceEntry {
+            pc: 2,
+            ap: 30,
+            fp: 30,
+        },
+        RelocatedTraceEntry {
+            pc: 3,
+            ap: 30,
+            fp: 30,
+        },
+        RelocatedTraceEntry {
+            pc: 5,
+            ap: 31,
+            fp: 30,
+        },
+        RelocatedTraceEntry {
+            pc: 6,
+            ap: 32,
+            fp: 30,
+        },
+        RelocatedTraceEntry {
+            pc: 14,
+            ap: 32,
+            fp: 25,
+        },
+        RelocatedTraceEntry {
+            pc: 15,
+            ap: 32,
+            fp: 25,
+        },
+        RelocatedTraceEntry {
+            pc: 17,
+            ap: 33,
+            fp: 25,
+        },
+        RelocatedTraceEntry {
+            pc: 18,
+            ap: 34,
+            fp: 25,
+        },
+        RelocatedTraceEntry {
+            pc: 19,
+            ap: 35,
+            fp: 25,
+        },
+    ];
+    assert_eq!(cairo_runner.relocated_trace, python_vm_relocated_trace);
+}

--- a/tests/support/pedersen_test.cairo
+++ b/tests/support/pedersen_test.cairo
@@ -1,0 +1,11 @@
+%builtins output pedersen range_check
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.hash import hash2
+
+func main{output_ptr : felt*, pedersen_ptr : HashBuiltin*,range_check_ptr}():
+    let (seed) = hash2{hash_ptr=pedersen_ptr}(0,0)
+    assert [output_ptr] = seed
+    let output_ptr = output_ptr+1
+    return()
+end

--- a/tests/support/pedersen_test.json
+++ b/tests/support/pedersen_test.json
@@ -1,0 +1,982 @@
+{
+    "attributes": [],
+    "builtins": [
+        "output",
+        "pedersen",
+        "range_check"
+    ],
+    "data": [
+        "0x400380007ffb7ffc",
+        "0x400380017ffb7ffd",
+        "0x482680017ffb8000",
+        "0x3",
+        "0x480280027ffb8000",
+        "0x208b7fff7fff7ffe",
+        "0x480a7ffc7fff8000",
+        "0x480680017fff8000",
+        "0x0",
+        "0x480680017fff8000",
+        "0x0",
+        "0x1104800180018000",
+        "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff6",
+        "0x400280007ffb7fff",
+        "0x482680017ffb8000",
+        "0x1",
+        "0x48127ffd7fff8000",
+        "0x480a7ffd7fff8000",
+        "0x208b7fff7fff7ffe"
+    ],
+    "debug_info": {
+        "file_contents": {},
+        "instruction_locations": {
+            "0": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash",
+                    "starkware.cairo.common.hash.hash2"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash.hash2.hash_ptr": 2,
+                        "starkware.cairo.common.hash.hash2.x": 0,
+                        "starkware.cairo.common.hash.hash2.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 19,
+                    "end_line": 14,
+                    "input_file": {
+                        "filename": "/Users/lambda/Library/Python/3.8/lib/python/site-packages/starkware/cairo/common/hash.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 14
+                }
+            },
+            "1": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash",
+                    "starkware.cairo.common.hash.hash2"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash.hash2.hash_ptr": 2,
+                        "starkware.cairo.common.hash.hash2.x": 0,
+                        "starkware.cairo.common.hash.hash2.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 19,
+                    "end_line": 15,
+                    "input_file": {
+                        "filename": "/Users/lambda/Library/Python/3.8/lib/python/site-packages/starkware/cairo/common/hash.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 15
+                }
+            },
+            "2": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash",
+                    "starkware.cairo.common.hash.hash2"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash.hash2.hash_ptr": 4,
+                        "starkware.cairo.common.hash.hash2.result": 3,
+                        "starkware.cairo.common.hash.hash2.x": 0,
+                        "starkware.cairo.common.hash.hash2.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 47,
+                    "end_line": 17,
+                    "input_file": {
+                        "filename": "/Users/lambda/Library/Python/3.8/lib/python/site-packages/starkware/cairo/common/hash.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 35,
+                            "end_line": 13,
+                            "input_file": {
+                                "filename": "/Users/lambda/Library/Python/3.8/lib/python/site-packages/starkware/cairo/common/hash.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 27,
+                                    "end_line": 18,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/Library/Python/3.8/lib/python/site-packages/starkware/cairo/common/hash.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 18
+                                },
+                                "While trying to retrieve the implicit argument 'hash_ptr' in:"
+                            ],
+                            "start_col": 12,
+                            "start_line": 13
+                        },
+                        "While expanding the reference 'hash_ptr' in:"
+                    ],
+                    "start_col": 20,
+                    "start_line": 17
+                }
+            },
+            "4": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash",
+                    "starkware.cairo.common.hash.hash2"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash.hash2.hash_ptr": 4,
+                        "starkware.cairo.common.hash.hash2.result": 3,
+                        "starkware.cairo.common.hash.hash2.x": 0,
+                        "starkware.cairo.common.hash.hash2.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 33,
+                    "end_line": 16,
+                    "input_file": {
+                        "filename": "/Users/lambda/Library/Python/3.8/lib/python/site-packages/starkware/cairo/common/hash.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 26,
+                            "end_line": 18,
+                            "input_file": {
+                                "filename": "/Users/lambda/Library/Python/3.8/lib/python/site-packages/starkware/cairo/common/hash.cairo"
+                            },
+                            "start_col": 20,
+                            "start_line": 18
+                        },
+                        "While expanding the reference 'result' in:"
+                    ],
+                    "start_col": 18,
+                    "start_line": 16
+                }
+            },
+            "5": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash",
+                    "starkware.cairo.common.hash.hash2"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash.hash2.hash_ptr": 4,
+                        "starkware.cairo.common.hash.hash2.result": 3,
+                        "starkware.cairo.common.hash.hash2.x": 0,
+                        "starkware.cairo.common.hash.hash2.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 27,
+                    "end_line": 18,
+                    "input_file": {
+                        "filename": "/Users/lambda/Library/Python/3.8/lib/python/site-packages/starkware/cairo/common/hash.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 18
+                }
+            },
+            "6": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.main.output_ptr": 5,
+                        "__main__.main.pedersen_ptr": 6,
+                        "__main__.main.range_check_ptr": 7
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 58,
+                    "end_line": 6,
+                    "input_file": {
+                        "filename": "pedersen_test.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 45,
+                            "end_line": 7,
+                            "input_file": {
+                                "filename": "pedersen_test.cairo"
+                            },
+                            "start_col": 33,
+                            "start_line": 7
+                        },
+                        "While expanding the reference 'pedersen_ptr' in:"
+                    ],
+                    "start_col": 31,
+                    "start_line": 6
+                }
+            },
+            "7": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.main.output_ptr": 5,
+                        "__main__.main.pedersen_ptr": 6,
+                        "__main__.main.range_check_ptr": 7
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 48,
+                    "end_line": 7,
+                    "input_file": {
+                        "filename": "pedersen_test.cairo"
+                    },
+                    "start_col": 47,
+                    "start_line": 7
+                }
+            },
+            "9": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.main.output_ptr": 5,
+                        "__main__.main.pedersen_ptr": 6,
+                        "__main__.main.range_check_ptr": 7
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 50,
+                    "end_line": 7,
+                    "input_file": {
+                        "filename": "pedersen_test.cairo"
+                    },
+                    "start_col": 49,
+                    "start_line": 7
+                }
+            },
+            "11": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "__main__.main.output_ptr": 5,
+                        "__main__.main.pedersen_ptr": 6,
+                        "__main__.main.range_check_ptr": 7
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 51,
+                    "end_line": 7,
+                    "input_file": {
+                        "filename": "pedersen_test.cairo"
+                    },
+                    "start_col": 18,
+                    "start_line": 7
+                }
+            },
+            "13": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 7
+                    },
+                    "reference_ids": {
+                        "__main__.main.output_ptr": 5,
+                        "__main__.main.pedersen_ptr": 8,
+                        "__main__.main.range_check_ptr": 7,
+                        "__main__.main.seed": 9
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 31,
+                    "end_line": 8,
+                    "input_file": {
+                        "filename": "pedersen_test.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 8
+                }
+            },
+            "14": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 7
+                    },
+                    "reference_ids": {
+                        "__main__.main.output_ptr": 10,
+                        "__main__.main.pedersen_ptr": 8,
+                        "__main__.main.range_check_ptr": 7,
+                        "__main__.main.seed": 9
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 34,
+                    "end_line": 9,
+                    "input_file": {
+                        "filename": "pedersen_test.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 29,
+                            "end_line": 6,
+                            "input_file": {
+                                "filename": "pedersen_test.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 13,
+                                    "end_line": 10,
+                                    "input_file": {
+                                        "filename": "pedersen_test.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 10
+                                },
+                                "While trying to retrieve the implicit argument 'output_ptr' in:"
+                            ],
+                            "start_col": 11,
+                            "start_line": 6
+                        },
+                        "While expanding the reference 'output_ptr' in:"
+                    ],
+                    "start_col": 22,
+                    "start_line": 9
+                }
+            },
+            "16": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 8
+                    },
+                    "reference_ids": {
+                        "__main__.main.output_ptr": 10,
+                        "__main__.main.pedersen_ptr": 8,
+                        "__main__.main.range_check_ptr": 7,
+                        "__main__.main.seed": 9
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 45,
+                    "end_line": 7,
+                    "input_file": {
+                        "filename": "pedersen_test.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 58,
+                            "end_line": 6,
+                            "input_file": {
+                                "filename": "pedersen_test.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 13,
+                                    "end_line": 10,
+                                    "input_file": {
+                                        "filename": "pedersen_test.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 10
+                                },
+                                "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                            ],
+                            "start_col": 31,
+                            "start_line": 6
+                        },
+                        "While expanding the reference 'pedersen_ptr' in:"
+                    ],
+                    "start_col": 33,
+                    "start_line": 7
+                }
+            },
+            "17": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 9
+                    },
+                    "reference_ids": {
+                        "__main__.main.output_ptr": 10,
+                        "__main__.main.pedersen_ptr": 8,
+                        "__main__.main.range_check_ptr": 7,
+                        "__main__.main.seed": 9
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 74,
+                    "end_line": 6,
+                    "input_file": {
+                        "filename": "pedersen_test.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 74,
+                            "end_line": 6,
+                            "input_file": {
+                                "filename": "pedersen_test.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 13,
+                                    "end_line": 10,
+                                    "input_file": {
+                                        "filename": "pedersen_test.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 10
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 59,
+                            "start_line": 6
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 59,
+                    "start_line": 6
+                }
+            },
+            "18": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 10
+                    },
+                    "reference_ids": {
+                        "__main__.main.output_ptr": 10,
+                        "__main__.main.pedersen_ptr": 8,
+                        "__main__.main.range_check_ptr": 7,
+                        "__main__.main.seed": 9
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 13,
+                    "end_line": 10,
+                    "input_file": {
+                        "filename": "pedersen_test.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 10
+                }
+            }
+        }
+    },
+    "hints": {},
+    "identifiers": {
+        "__main__.HashBuiltin": {
+            "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+            "type": "alias"
+        },
+        "__main__.hash2": {
+            "destination": "starkware.cairo.common.hash.hash2",
+            "type": "alias"
+        },
+        "__main__.main": {
+            "decorators": [],
+            "pc": 6,
+            "type": "function"
+        },
+        "__main__.main.Args": {
+            "full_name": "__main__.main.Args",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.ImplicitArgs": {
+            "full_name": "__main__.main.ImplicitArgs",
+            "members": {
+                "output_ptr": {
+                    "cairo_type": "felt*",
+                    "offset": 0
+                },
+                "pedersen_ptr": {
+                    "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                    "offset": 1
+                },
+                "range_check_ptr": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                }
+            },
+            "size": 3,
+            "type": "struct"
+        },
+        "__main__.main.Return": {
+            "full_name": "__main__.main.Return",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.main.output_ptr": {
+            "cairo_type": "felt*",
+            "full_name": "__main__.main.output_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 6,
+                    "value": "[cast(fp + (-5), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 7
+                    },
+                    "pc": 14,
+                    "value": "cast([fp + (-5)] + 1, felt*)"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "full_name": "__main__.main.pedersen_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 6,
+                    "value": "[cast(fp + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 7
+                    },
+                    "pc": 13,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.range_check_ptr": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.range_check_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 6,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.seed": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.seed",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 7
+                    },
+                    "pc": 13,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.cairo_builtins.BitwiseBuiltin": {
+            "full_name": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+            "members": {
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "x_and_y": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                },
+                "x_or_y": {
+                    "cairo_type": "felt",
+                    "offset": 4
+                },
+                "x_xor_y": {
+                    "cairo_type": "felt",
+                    "offset": 3
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 5,
+            "type": "struct"
+        },
+        "starkware.cairo.common.cairo_builtins.EcOpBuiltin": {
+            "full_name": "starkware.cairo.common.cairo_builtins.EcOpBuiltin",
+            "members": {
+                "m": {
+                    "cairo_type": "felt",
+                    "offset": 4
+                },
+                "p": {
+                    "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+                    "offset": 0
+                },
+                "q": {
+                    "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+                    "offset": 2
+                },
+                "r": {
+                    "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+                    "offset": 5
+                }
+            },
+            "size": 7,
+            "type": "struct"
+        },
+        "starkware.cairo.common.cairo_builtins.EcPoint": {
+            "destination": "starkware.cairo.common.ec_point.EcPoint",
+            "type": "alias"
+        },
+        "starkware.cairo.common.cairo_builtins.HashBuiltin": {
+            "full_name": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+            "members": {
+                "result": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                },
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 3,
+            "type": "struct"
+        },
+        "starkware.cairo.common.cairo_builtins.SignatureBuiltin": {
+            "full_name": "starkware.cairo.common.cairo_builtins.SignatureBuiltin",
+            "members": {
+                "message": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                },
+                "pub_key": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.ec_point.EcPoint": {
+            "full_name": "starkware.cairo.common.ec_point.EcPoint",
+            "members": {
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.hash.HashBuiltin": {
+            "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+            "type": "alias"
+        },
+        "starkware.cairo.common.hash.hash2": {
+            "decorators": [],
+            "pc": 0,
+            "type": "function"
+        },
+        "starkware.cairo.common.hash.hash2.Args": {
+            "full_name": "starkware.cairo.common.hash.hash2.Args",
+            "members": {
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.hash.hash2.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.hash.hash2.ImplicitArgs",
+            "members": {
+                "hash_ptr": {
+                    "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.hash.hash2.Return": {
+            "full_name": "starkware.cairo.common.hash.hash2.Return",
+            "members": {
+                "result": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.hash.hash2.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.hash.hash2.hash_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "full_name": "starkware.cairo.common.hash.hash2.hash_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 2,
+                    "value": "cast([fp + (-5)] + 3, starkware.cairo.common.cairo_builtins.HashBuiltin*)"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash.hash2.result": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.hash.hash2.result",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 2,
+                    "value": "[cast([fp + (-5)] + 2, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash.hash2.x": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.hash.hash2.x",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "[cast(fp + (-4), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash.hash2.y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.hash.hash2.y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        }
+    },
+    "main_scope": "__main__",
+    "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+    "reference_manager": {
+        "references": [
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 0,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 0,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 0,
+                "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 2,
+                "value": "[cast([fp + (-5)] + 2, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 2,
+                "value": "cast([fp + (-5)] + 3, starkware.cairo.common.cairo_builtins.HashBuiltin*)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 6,
+                "value": "[cast(fp + (-5), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 6,
+                "value": "[cast(fp + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 6,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 7
+                },
+                "pc": 13,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 7
+                },
+                "pc": 13,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 7
+                },
+                "pc": 14,
+                "value": "cast([fp + (-5)] + 1, felt*)"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
# Pedersen builtin integration test

## Description

Add an integration test of the Pedersen builtin.
This test executes a Cairo program and compares the relocated trace of Cleopatra VM vs Python VM

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [x] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
