### PR TITLE
Remove panic! in relocatable.rs

### DIFF
--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -37,12 +37,16 @@ impl From<BigInt> for MaybeRelocatable {
 
 impl MaybeRelocatable {
     ///Adds a bigint to self, then performs mod prime
-    pub fn add_int_mod(&self, other: BigInt, prime: BigInt) -> MaybeRelocatable {
+    pub fn add_int_mod(
+        &self,
+        other: BigInt,
+        prime: BigInt,
+    ) -> Result<MaybeRelocatable, VirtualMachineError> {
         match *self {
             MaybeRelocatable::Int(ref value) => {
                 let mut num = Clone::clone(value);
                 num = (other + num) % prime;
-                MaybeRelocatable::Int(num)
+                Ok(MaybeRelocatable::Int(num))
             }
             MaybeRelocatable::RelocatableValue(ref rel) => {
                 let mut big_offset = rel.offset + other;
@@ -50,12 +54,12 @@ impl MaybeRelocatable {
                 big_offset %= prime;
                 let new_offset = match big_offset.to_usize() {
                     Some(usize) => usize,
-                    None => panic!("Offset exeeds maximum offset value"),
+                    None => return Err(VirtualMachineError::OffsetExeeded(big_offset)),
                 };
-                MaybeRelocatable::RelocatableValue(Relocatable {
+                Ok(MaybeRelocatable::RelocatableValue(Relocatable {
                     segment_index: rel.segment_index,
                     offset: new_offset,
-                })
+                }))
             }
         }
     }
@@ -176,7 +180,7 @@ mod tests {
     fn add_bigint_to_int() {
         let addr = MaybeRelocatable::from(bigint!(7));
         let added_addr = addr.add_int_mod(bigint!(2), bigint!(17));
-        assert_eq!(MaybeRelocatable::Int(bigint!(9)), added_addr);
+        assert_eq!(Ok(MaybeRelocatable::Int(bigint!(9))), added_addr);
     }
 
     #[test]
@@ -190,14 +194,14 @@ mod tests {
     fn add_bigint_to_relocatable() {
         let addr = MaybeRelocatable::RelocatableValue(relocatable!(7, 65));
         let added_addr = addr.add_int_mod(bigint!(2), bigint!(121));
-        assert_eq!(MaybeRelocatable::from((7, 67)), added_addr);
+        assert_eq!(Ok(MaybeRelocatable::from((7, 67))), added_addr);
     }
 
     #[test]
     fn add_usize_to_relocatable() {
         let addr = MaybeRelocatable::RelocatableValue(relocatable!(7, 65));
         let added_addr = addr.add_int_mod(bigint!(2), bigint!(121));
-        assert_eq!(MaybeRelocatable::from((7, 67)), added_addr);
+        assert_eq!(Ok(MaybeRelocatable::from((7, 67))), added_addr);
     }
 
     #[test]
@@ -219,7 +223,7 @@ mod tests {
                 ],
             ),
         );
-        assert_eq!(MaybeRelocatable::Int(bigint!(4)), added_addr);
+        assert_eq!(Ok(MaybeRelocatable::Int(bigint!(4))), added_addr);
     }
 
     #[test]
@@ -230,7 +234,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
         );
         assert_eq!(
-            MaybeRelocatable::RelocatableValue(relocatable!(1, 9)),
+            Ok(MaybeRelocatable::RelocatableValue(relocatable!(1, 9))),
             added_addr
         );
     }

--- a/src/vm/context/run_context.rs
+++ b/src/vm/context/run_context.rs
@@ -14,7 +14,10 @@ pub struct RunContext {
 
 impl RunContext {
     #[allow(dead_code)]
-    pub fn compute_dst_addr(&self, instruction: &Instruction) -> MaybeRelocatable {
+    pub fn compute_dst_addr(
+        &self,
+        instruction: &Instruction,
+    ) -> Result<MaybeRelocatable, VirtualMachineError> {
         let base_addr = match instruction.dst_register {
             Register::AP => &self.ap,
             Register::FP => &self.fp,
@@ -22,7 +25,10 @@ impl RunContext {
         base_addr.add_int_mod(instruction.off0.clone(), self.prime.clone())
     }
 
-    pub fn compute_op0_addr(&self, instruction: &Instruction) -> MaybeRelocatable {
+    pub fn compute_op0_addr(
+        &self,
+        instruction: &Instruction,
+    ) -> Result<MaybeRelocatable, VirtualMachineError> {
         let base_addr = match instruction.op0_register {
             Register::AP => &self.ap,
             Register::FP => &self.fp,
@@ -44,12 +50,12 @@ impl RunContext {
             },
             Op1Addr::Op0 => match op0 {
                 Some(addr) => {
-                    return Ok(addr.add_int_mod(instruction.off2.clone(), self.prime.clone()))
+                    return addr.add_int_mod(instruction.off2.clone(), self.prime.clone())
                 }
                 None => return Err(VirtualMachineError::UnknownOp0),
             },
         };
-        Ok(base_addr.add_int_mod(instruction.off2.clone(), self.prime.clone()))
+        base_addr.add_int_mod(instruction.off2.clone(), self.prime.clone())
     }
 }
 
@@ -83,7 +89,7 @@ mod tests {
             prime: bigint!(39),
         };
         assert_eq!(
-            MaybeRelocatable::Int(bigint!(6)),
+            Ok(MaybeRelocatable::Int(bigint!(6))),
             run_context.compute_dst_addr(&instruction)
         );
     }
@@ -112,7 +118,7 @@ mod tests {
             prime: bigint!(39),
         };
         assert_eq!(
-            MaybeRelocatable::Int(bigint!(7)),
+            Ok(MaybeRelocatable::Int(bigint!(7))),
             run_context.compute_dst_addr(&instruction)
         );
     }
@@ -141,7 +147,7 @@ mod tests {
             prime: bigint!(39),
         };
         assert_eq!(
-            MaybeRelocatable::Int(bigint!(7)),
+            Ok(MaybeRelocatable::Int(bigint!(7))),
             run_context.compute_op0_addr(&instruction)
         );
     }
@@ -170,7 +176,7 @@ mod tests {
             prime: bigint!(39),
         };
         assert_eq!(
-            MaybeRelocatable::Int(bigint!(8)),
+            Ok(MaybeRelocatable::Int(bigint!(8))),
             run_context.compute_op0_addr(&instruction)
         );
     }

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -128,9 +128,10 @@ impl VirtualMachine {
             },
             PcUpdate::JumpRel => match operands.res.clone() {
                 Some(res) => match res {
-                    MaybeRelocatable::Int(num_res) => {
-                        self.run_context.pc.add_int_mod(num_res, self.prime.clone())
-                    }
+                    MaybeRelocatable::Int(num_res) => self
+                        .run_context
+                        .pc
+                        .add_int_mod(num_res, self.prime.clone())?,
 
                     _ => return Err(VirtualMachineError::PureValue),
                 },
@@ -418,9 +419,9 @@ impl VirtualMachine {
         &mut self,
         instruction: &Instruction,
     ) -> Result<(Operands, Vec<MaybeRelocatable>), VirtualMachineError> {
-        let dst_addr: MaybeRelocatable = self.run_context.compute_dst_addr(instruction);
+        let dst_addr: MaybeRelocatable = self.run_context.compute_dst_addr(instruction)?;
         let mut dst: Option<MaybeRelocatable> = self.memory.get(&dst_addr).unwrap().cloned();
-        let op0_addr: MaybeRelocatable = self.run_context.compute_op0_addr(instruction);
+        let op0_addr: MaybeRelocatable = self.run_context.compute_op0_addr(instruction)?;
         let mut op0: Option<MaybeRelocatable> = self.memory.get(&op0_addr).unwrap().cloned();
         let op1_addr: MaybeRelocatable = self
             .run_context


### PR DESCRIPTION
# Remove panic! in relocatable.rs

## Description

Remove the `panic!("Offset exeeds maximum offset value")` in relocatable.rs and handle the error

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
