### PR TITLE
Add Integration test + benchmark for a program with all supported builtins + Fixes

### DIFF
--- a/bench/criterion/criterion_benchmark.rs
+++ b/bench/criterion/criterion_benchmark.rs
@@ -1,11 +1,21 @@
 use cleopatra_cairo::cairo_run;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-pub fn criterion_benchmark(c: &mut Criterion) {
+pub fn criterion_benchmark_fibonacci(c: &mut Criterion) {
     c.bench_function("cairo_run(bench/criterion/fibonacci_1000.json", |b| {
         b.iter(|| cairo_run::cairo_run(black_box("bench/criterion/fibonacci_1000.json")))
     });
 }
 
-criterion_group!(benches, criterion_benchmark);
+pub fn criterion_benchmark_integration(c: &mut Criterion) {
+    c.bench_function("cairo_run(bench/criterion/integration.json", |b| {
+        b.iter(|| cairo_run::cairo_run(black_box("bench/criterion/fibonacci_1000.json")))
+    });
+}
+
+criterion_group!(
+    benches,
+    criterion_benchmark_fibonacci,
+    criterion_benchmark_integration
+);
 criterion_main!(benches);

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -9,7 +9,7 @@ use crate::vm::trace::trace_entry::TraceEntry;
 use crate::vm::vm_memory::memory::Memory;
 use num_bigint::BigInt;
 use num_traits::{FromPrimitive, ToPrimitive};
-use std::collections::{BTreeMap, HashSet};
+use std::collections::HashSet;
 
 #[derive(PartialEq, Debug)]
 pub struct Operands {
@@ -22,7 +22,7 @@ pub struct Operands {
 pub struct VirtualMachine {
     pub run_context: RunContext,
     pub prime: BigInt,
-    pub builtin_runners: BTreeMap<String, Box<dyn BuiltinRunner>>,
+    pub builtin_runners: Vec<(String, Box<dyn BuiltinRunner>)>,
     //exec_scopes: Vec<HashMap<..., ...>>,
     //enter_scope:
     //hints: HashMap<MaybeRelocatable, Vec<CompiledHint>>,
@@ -46,7 +46,7 @@ pub struct VirtualMachine {
 impl VirtualMachine {
     pub fn new(
         prime: BigInt,
-        builtin_runners: BTreeMap<String, Box<dyn BuiltinRunner>>,
+        builtin_runners: Vec<(String, Box<dyn BuiltinRunner>)>,
     ) -> VirtualMachine {
         let run_context = RunContext {
             pc: MaybeRelocatable::from((0, 0)),
@@ -521,16 +521,18 @@ impl VirtualMachine {
 mod tests {
     use super::*;
     use crate::types::instruction::{ApUpdate, FpUpdate, Op1Addr, Opcode, PcUpdate, Register, Res};
+
     use crate::vm::runners::builtin_runner::{
         BitwiseBuiltinRunner, EcOpBuiltinRunner, HashBuiltinRunner,
     };
+
     use crate::{bigint64, bigint_str};
     use crate::{relocatable, types::relocatable::Relocatable};
     use num_bigint::Sign;
 
     #[test]
     fn get_instruction_encoding_successful_without_imm() {
-        let mut vm = VirtualMachine::new(bigint!(39), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(39), Vec::new());
         vm.memory.data.push(Vec::new());
         vm.run_context.pc = MaybeRelocatable::RelocatableValue(relocatable!(0, 0));
         vm.memory
@@ -544,7 +546,7 @@ mod tests {
 
     #[test]
     fn get_instruction_encoding_successful_with_imm() {
-        let mut vm = VirtualMachine::new(bigint!(39), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(39), Vec::new());
         vm.memory.data.push(Vec::new());
         vm.run_context.pc = MaybeRelocatable::from((0, 0));
 
@@ -570,7 +572,7 @@ mod tests {
 
     #[test]
     fn get_instruction_encoding_unsuccesful() {
-        let mut vm = VirtualMachine::new(bigint!(39), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(39), Vec::new());
         vm.run_context.pc = MaybeRelocatable::from((0, 0));
         assert_eq!(
             Err(VirtualMachineError::InvalidInstructionEncoding),
@@ -602,7 +604,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(39), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(39), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -635,7 +637,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(39), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(39), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -668,7 +670,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(39), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(39), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -701,7 +703,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(39), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(39), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -734,7 +736,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(39), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(39), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -769,7 +771,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(39), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(39), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -802,7 +804,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(39), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(39), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -835,7 +837,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(39), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(39), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -868,7 +870,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(39), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(39), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -901,7 +903,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(39), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(39), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -934,7 +936,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(39), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(39), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -967,7 +969,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(39), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(39), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1002,7 +1004,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(39), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(39), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1035,7 +1037,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(39), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(39), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1070,7 +1072,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(39), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(39), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1105,7 +1107,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(39), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(39), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1138,7 +1140,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(39), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(39), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1171,7 +1173,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(39), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(39), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1206,7 +1208,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(39), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(39), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1258,7 +1260,7 @@ mod tests {
             opcode: Opcode::Call,
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1286,7 +1288,7 @@ mod tests {
             opcode: Opcode::AssertEq,
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1319,7 +1321,7 @@ mod tests {
             opcode: Opcode::AssertEq,
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1344,7 +1346,7 @@ mod tests {
             opcode: Opcode::AssertEq,
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1377,7 +1379,7 @@ mod tests {
             opcode: Opcode::AssertEq,
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1407,7 +1409,7 @@ mod tests {
             opcode: Opcode::AssertEq,
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1437,7 +1439,7 @@ mod tests {
             opcode: Opcode::Ret,
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1467,7 +1469,7 @@ mod tests {
             opcode: Opcode::Call,
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1492,7 +1494,7 @@ mod tests {
             opcode: Opcode::AssertEq,
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1525,7 +1527,7 @@ mod tests {
             opcode: Opcode::AssertEq,
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1550,7 +1552,7 @@ mod tests {
             opcode: Opcode::AssertEq,
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1583,7 +1585,7 @@ mod tests {
             opcode: Opcode::AssertEq,
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1613,7 +1615,7 @@ mod tests {
             opcode: Opcode::AssertEq,
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1642,7 +1644,7 @@ mod tests {
             opcode: Opcode::AssertEq,
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1674,7 +1676,7 @@ mod tests {
             opcode: Opcode::AssertEq,
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1704,7 +1706,7 @@ mod tests {
             opcode: Opcode::AssertEq,
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1734,7 +1736,7 @@ mod tests {
             opcode: Opcode::AssertEq,
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1764,7 +1766,7 @@ mod tests {
             opcode: Opcode::AssertEq,
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1794,7 +1796,7 @@ mod tests {
             opcode: Opcode::AssertEq,
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1821,7 +1823,7 @@ mod tests {
             opcode: Opcode::AssertEq,
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1850,7 +1852,7 @@ mod tests {
             opcode: Opcode::AssertEq,
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1875,7 +1877,7 @@ mod tests {
             opcode: Opcode::Call,
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1903,7 +1905,7 @@ mod tests {
             opcode: Opcode::Ret,
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -1928,7 +1930,7 @@ mod tests {
             opcode: Opcode::NOp,
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.memory.data.push(Vec::new());
         let dst_addr = MaybeRelocatable::from((0, 0));
         let dst_addr_value = MaybeRelocatable::Int(bigint!(5));
@@ -1970,7 +1972,7 @@ mod tests {
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
         };
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.memory.data.push(Vec::new());
         let dst_addr = MaybeRelocatable::from((0, 0));
         let dst_addr_value = MaybeRelocatable::from(bigint!(6));
@@ -2024,7 +2026,7 @@ mod tests {
             ),
         ];
 
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.memory = Memory::from(mem_arr.clone(), 2).unwrap();
 
         let expected_operands = Operands {
@@ -2068,7 +2070,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -2103,7 +2105,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -2141,7 +2143,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.run_context.pc = MaybeRelocatable::Int(bigint!(4));
         vm.run_context.ap = MaybeRelocatable::Int(bigint!(5));
         vm.run_context.fp = MaybeRelocatable::Int(bigint!(6));
@@ -2190,7 +2192,7 @@ mod tests {
             run_context: run_context,
             prime: bigint!(127),
             _program_base: None,
-            builtin_runners: BTreeMap::<String, Box<dyn BuiltinRunner>>::new(),
+            builtin_runners: Vec::new(),
             memory: Memory::new(),
             accessed_addresses: HashSet::<MaybeRelocatable>::new(),
             trace: Vec::<TraceEntry>::new(),
@@ -2227,7 +2229,7 @@ mod tests {
     fn test_step_for_preset_memory() {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-            BTreeMap::new(),
+            Vec::new(),
         );
         for _ in 0..4 {
             vm.memory.data.push(Vec::new());
@@ -2310,7 +2312,7 @@ mod tests {
     fn test_step_for_preset_memory_function_call() {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-            BTreeMap::new(),
+            Vec::new(),
         );
         for _ in 0..4 {
             vm.memory.data.push(Vec::new());
@@ -2568,7 +2570,7 @@ mod tests {
         ];
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-            BTreeMap::new(),
+            Vec::new(),
         );
         vm.run_context.pc = MaybeRelocatable::from((0, 0));
         vm.run_context.ap = MaybeRelocatable::from((1, 2));
@@ -2606,17 +2608,17 @@ mod tests {
 
     #[test]
     fn deduce_memory_cell_no_pedersen_builtin() {
-        let mut vm = VirtualMachine::new(bigint!(17), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(17), Vec::new());
         assert_eq!(vm.deduce_memory_cell(&MaybeRelocatable::from((0, 0))), None);
     }
 
     #[test]
     fn deduce_memory_cell_pedersen_builtin_valid() {
-        let mut vm = VirtualMachine::new(bigint!(17), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(17), Vec::new());
         let mut builtin = HashBuiltinRunner::new(true, 8);
         builtin.base = Some(relocatable!(0, 0));
         vm.builtin_runners
-            .insert(String::from("pedersen"), Box::new(builtin));
+            .push((String::from("pedersen"), Box::new(builtin)));
         vm.memory.data.push(Vec::new());
         vm.memory
             .insert(
@@ -2685,9 +2687,9 @@ mod tests {
         };
         let mut builtin = HashBuiltinRunner::new(true, 8);
         builtin.base = Some(relocatable!(3, 0));
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.builtin_runners
-            .insert(String::from("pedersen"), Box::new(builtin));
+            .push((String::from("pedersen"), Box::new(builtin)));
         vm.run_context.ap = MaybeRelocatable::from((1, 13));
         vm.run_context.fp = MaybeRelocatable::from((1, 12));
         vm.memory.data.push(Vec::new());
@@ -2821,11 +2823,11 @@ mod tests {
 
     #[test]
     fn deduce_memory_cell_bitwise_builtin_valid_and() {
-        let mut vm = VirtualMachine::new(bigint!(17), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(17), Vec::new());
         let mut builtin = BitwiseBuiltinRunner::new(true, 8);
         builtin.base = Some(relocatable!(0, 0));
         vm.builtin_runners
-            .insert(String::from("bitwise"), Box::new(builtin));
+            .push((String::from("bitwise"), Box::new(builtin)));
         vm.memory.data.push(Vec::new());
         vm.memory
             .insert(
@@ -2881,9 +2883,9 @@ mod tests {
         };
         let mut builtin = BitwiseBuiltinRunner::new(true, 256);
         builtin.base = Some(relocatable!(2, 0));
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.builtin_runners
-            .insert(String::from("bitwise"), Box::new(builtin));
+            .push((String::from("bitwise"), Box::new(builtin)));
         vm.run_context.ap = MaybeRelocatable::from((1, 9));
         vm.run_context.fp = MaybeRelocatable::from((1, 8));
         for _ in 0..3 {
@@ -2977,11 +2979,11 @@ mod tests {
 
     #[test]
     fn deduce_memory_cell_ec_op_builtin_valid() {
-        let mut vm = VirtualMachine::new(bigint!(17), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(17), Vec::new());
         let mut builtin = EcOpBuiltinRunner::new(true, 256);
         builtin.base = Some(relocatable!(0, 0));
         vm.builtin_runners
-            .insert(String::from("ec_op"), Box::new(builtin));
+            .push((String::from("ec_op"), Box::new(builtin)));
         vm.memory.data.push(Vec::new());
         vm.memory
             .insert(
@@ -3059,9 +3061,9 @@ mod tests {
     fn verify_auto_deductions_for_ec_op_builtin_valid() {
         let mut builtin = EcOpBuiltinRunner::new(true, 256);
         builtin.base = Some(relocatable!(3, 0));
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.builtin_runners
-            .insert(String::from("ec_op"), Box::new(builtin));
+            .push((String::from("ec_op"), Box::new(builtin)));
         for _ in 0..4 {
             vm.memory.data.push(Vec::new());
         }
@@ -3119,9 +3121,9 @@ mod tests {
     fn verify_auto_deductions_for_ec_op_builtin_valid_points_invalid_result() {
         let mut builtin = EcOpBuiltinRunner::new(true, 256);
         builtin.base = Some(relocatable!(3, 0));
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.builtin_runners
-            .insert(String::from("ec_op"), Box::new(builtin));
+            .push((String::from("ec_op"), Box::new(builtin)));
         for _ in 0..4 {
             vm.memory.data.push(Vec::new());
         }
@@ -3190,9 +3192,9 @@ mod tests {
     fn verify_auto_deductions_bitwise() {
         let mut builtin = BitwiseBuiltinRunner::new(true, 256);
         builtin.base = Some(relocatable!(2, 0));
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.builtin_runners
-            .insert(String::from("bitwise"), Box::new(builtin));
+            .push((String::from("bitwise"), Box::new(builtin)));
         for _ in 0..3 {
             vm.memory.data.push(Vec::new());
         }
@@ -3238,9 +3240,9 @@ mod tests {
     fn verify_auto_deductions_pedersen() {
         let mut builtin = HashBuiltinRunner::new(true, 8);
         builtin.base = Some(relocatable!(3, 0));
-        let mut vm = VirtualMachine::new(bigint!(127), BTreeMap::new());
+        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         vm.builtin_runners
-            .insert(String::from("pedersen"), Box::new(builtin));
+            .push((String::from("pedersen"), Box::new(builtin)));
         for _ in 0..4 {
             vm.memory.data.push(Vec::new());
         }

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -502,7 +502,7 @@ impl VirtualMachine {
                         let deduced_value = builtin
                             .deduce_memory_cell(&MaybeRelocatable::from((i, j)), &self.memory)
                             .unwrap();
-                        if deduced_value != None && &deduced_value != value {
+                        if deduced_value != None && value != &None && &deduced_value != value {
                             return Err(VirtualMachineError::InconsistentAutoDeduction(
                                 name.to_owned(),
                                 deduced_value.unwrap(),

--- a/tests/cairo_run_test.rs
+++ b/tests/cairo_run_test.rs
@@ -9,3 +9,8 @@ fn cairo_run_test() {
 fn cairo_run_bitwise_output() {
     cairo_run::cairo_run("tests/support/bitwise_output.json");
 }
+
+#[test]
+fn cairo_run_bitwise_recursion() {
+    cairo_run::cairo_run("tests/support/bitwise_recursion.json");
+}

--- a/tests/cairo_run_test.rs
+++ b/tests/cairo_run_test.rs
@@ -14,3 +14,8 @@ fn cairo_run_bitwise_output() {
 fn cairo_run_bitwise_recursion() {
     cairo_run::cairo_run("tests/support/bitwise_recursion.json");
 }
+
+#[test]
+fn cairo_run_integration() {
+    cairo_run::cairo_run("tests/support/integration.json");
+}

--- a/tests/cairo_run_test.rs
+++ b/tests/cairo_run_test.rs
@@ -4,3 +4,8 @@ use cleopatra_cairo::cairo_run;
 fn cairo_run_test() {
     cairo_run::cairo_run("tests/support/fibonacci_compiled.json");
 }
+
+#[test]
+fn cairo_run_bitwise_output() {
+    cairo_run::cairo_run("tests/support/bitwise_output.json");
+}

--- a/tests/support/bitwise_output.cairo
+++ b/tests/support/bitwise_output.cairo
@@ -1,0 +1,11 @@
+%builtins output bitwise
+from starkware.cairo.common.bitwise import bitwise_and
+from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
+from starkware.cairo.common.serialize import serialize_word
+
+
+func main{output_ptr : felt*, bitwise_ptr: BitwiseBuiltin*}():
+    let (result) = bitwise_and(1, 2)
+    serialize_word(result)
+    return()
+end

--- a/tests/support/bitwise_output.json
+++ b/tests/support/bitwise_output.json
@@ -1,0 +1,1211 @@
+{
+    "attributes": [],
+    "builtins": [
+        "output",
+        "bitwise"
+    ],
+    "data": [
+        "0x400380007ffb7ffc",
+        "0x400380017ffb7ffd",
+        "0x482680017ffb8000",
+        "0x5",
+        "0x480280027ffb8000",
+        "0x208b7fff7fff7ffe",
+        "0x400380007ffc7ffd",
+        "0x482680017ffc8000",
+        "0x1",
+        "0x208b7fff7fff7ffe",
+        "0x480a7ffd7fff8000",
+        "0x480680017fff8000",
+        "0x1",
+        "0x480680017fff8000",
+        "0x2",
+        "0x1104800180018000",
+        "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff2",
+        "0x480a7ffc7fff8000",
+        "0x48127ffe7fff8000",
+        "0x1104800180018000",
+        "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff4",
+        "0x48127ff97fff8000",
+        "0x208b7fff7fff7ffe"
+    ],
+    "debug_info": {
+        "file_contents": {},
+        "instruction_locations": {
+            "0": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_and"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_and.bitwise_ptr": 2,
+                        "starkware.cairo.common.bitwise.bitwise_and.x": 0,
+                        "starkware.cairo.common.bitwise.bitwise_and.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 22,
+                    "end_line": 38,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 38
+                }
+            },
+            "1": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_and"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_and.bitwise_ptr": 2,
+                        "starkware.cairo.common.bitwise.bitwise_and.x": 0,
+                        "starkware.cairo.common.bitwise.bitwise_and.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 22,
+                    "end_line": 39,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 39
+                }
+            },
+            "2": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_and"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_and.bitwise_ptr": 6,
+                        "starkware.cairo.common.bitwise.bitwise_and.x": 0,
+                        "starkware.cairo.common.bitwise.bitwise_and.x_and_y": 3,
+                        "starkware.cairo.common.bitwise.bitwise_and.x_or_y": 5,
+                        "starkware.cairo.common.bitwise.bitwise_and.x_xor_y": 4,
+                        "starkware.cairo.common.bitwise.bitwise_and.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 56,
+                    "end_line": 43,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 47,
+                            "end_line": 37,
+                            "input_file": {
+                                "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 29,
+                                    "end_line": 44,
+                                    "input_file": {
+                                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 44
+                                },
+                                "While trying to retrieve the implicit argument 'bitwise_ptr' in:"
+                            ],
+                            "start_col": 18,
+                            "start_line": 37
+                        },
+                        "While expanding the reference 'bitwise_ptr' in:"
+                    ],
+                    "start_col": 23,
+                    "start_line": 43
+                }
+            },
+            "4": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_and"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_and.bitwise_ptr": 6,
+                        "starkware.cairo.common.bitwise.bitwise_and.x": 0,
+                        "starkware.cairo.common.bitwise.bitwise_and.x_and_y": 3,
+                        "starkware.cairo.common.bitwise.bitwise_and.x_or_y": 5,
+                        "starkware.cairo.common.bitwise.bitwise_and.x_xor_y": 4,
+                        "starkware.cairo.common.bitwise.bitwise_and.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 38,
+                    "end_line": 40,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 28,
+                            "end_line": 44,
+                            "input_file": {
+                                "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                            },
+                            "start_col": 21,
+                            "start_line": 44
+                        },
+                        "While expanding the reference 'x_and_y' in:"
+                    ],
+                    "start_col": 19,
+                    "start_line": 40
+                }
+            },
+            "5": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_and"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_and.bitwise_ptr": 6,
+                        "starkware.cairo.common.bitwise.bitwise_and.x": 0,
+                        "starkware.cairo.common.bitwise.bitwise_and.x_and_y": 3,
+                        "starkware.cairo.common.bitwise.bitwise_and.x_or_y": 5,
+                        "starkware.cairo.common.bitwise.bitwise_and.x_xor_y": 4,
+                        "starkware.cairo.common.bitwise.bitwise_and.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 29,
+                    "end_line": 44,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 44
+                }
+            },
+            "6": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.serialize",
+                    "starkware.cairo.common.serialize.serialize_word"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.serialize.serialize_word.output_ptr": 8,
+                        "starkware.cairo.common.serialize.serialize_word.word": 7
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 31,
+                    "end_line": 3,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 3
+                }
+            },
+            "7": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.serialize",
+                    "starkware.cairo.common.serialize.serialize_word"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.serialize.serialize_word.output_ptr": 9,
+                        "starkware.cairo.common.serialize.serialize_word.word": 7
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 36,
+                    "end_line": 4,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 39,
+                            "end_line": 2,
+                            "input_file": {
+                                "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 14,
+                                    "end_line": 5,
+                                    "input_file": {
+                                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 5
+                                },
+                                "While trying to retrieve the implicit argument 'output_ptr' in:"
+                            ],
+                            "start_col": 21,
+                            "start_line": 2
+                        },
+                        "While expanding the reference 'output_ptr' in:"
+                    ],
+                    "start_col": 22,
+                    "start_line": 4
+                }
+            },
+            "9": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.serialize",
+                    "starkware.cairo.common.serialize.serialize_word"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.serialize.serialize_word.output_ptr": 9,
+                        "starkware.cairo.common.serialize.serialize_word.word": 7
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 14,
+                    "end_line": 5,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 5
+                }
+            },
+            "10": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 11,
+                        "__main__.main.output_ptr": 10
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 59,
+                    "end_line": 7,
+                    "input_file": {
+                        "filename": "bitwise_output.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 47,
+                            "end_line": 37,
+                            "input_file": {
+                                "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 37,
+                                    "end_line": 8,
+                                    "input_file": {
+                                        "filename": "bitwise_output.cairo"
+                                    },
+                                    "start_col": 20,
+                                    "start_line": 8
+                                },
+                                "While trying to retrieve the implicit argument 'bitwise_ptr' in:"
+                            ],
+                            "start_col": 18,
+                            "start_line": 37
+                        },
+                        "While expanding the reference 'bitwise_ptr' in:"
+                    ],
+                    "start_col": 31,
+                    "start_line": 7
+                }
+            },
+            "11": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 11,
+                        "__main__.main.output_ptr": 10
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 33,
+                    "end_line": 8,
+                    "input_file": {
+                        "filename": "bitwise_output.cairo"
+                    },
+                    "start_col": 32,
+                    "start_line": 8
+                }
+            },
+            "13": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 11,
+                        "__main__.main.output_ptr": 10
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 36,
+                    "end_line": 8,
+                    "input_file": {
+                        "filename": "bitwise_output.cairo"
+                    },
+                    "start_col": 35,
+                    "start_line": 8
+                }
+            },
+            "15": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 11,
+                        "__main__.main.output_ptr": 10
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 37,
+                    "end_line": 8,
+                    "input_file": {
+                        "filename": "bitwise_output.cairo"
+                    },
+                    "start_col": 20,
+                    "start_line": 8
+                }
+            },
+            "17": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 7
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 12,
+                        "__main__.main.output_ptr": 10,
+                        "__main__.main.result": 13
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 29,
+                    "end_line": 7,
+                    "input_file": {
+                        "filename": "bitwise_output.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 39,
+                            "end_line": 2,
+                            "input_file": {
+                                "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 27,
+                                    "end_line": 9,
+                                    "input_file": {
+                                        "filename": "bitwise_output.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 9
+                                },
+                                "While trying to retrieve the implicit argument 'output_ptr' in:"
+                            ],
+                            "start_col": 21,
+                            "start_line": 2
+                        },
+                        "While expanding the reference 'output_ptr' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 7
+                }
+            },
+            "18": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 8
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 12,
+                        "__main__.main.output_ptr": 10,
+                        "__main__.main.result": 13
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 16,
+                    "end_line": 8,
+                    "input_file": {
+                        "filename": "bitwise_output.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 26,
+                            "end_line": 9,
+                            "input_file": {
+                                "filename": "bitwise_output.cairo"
+                            },
+                            "start_col": 20,
+                            "start_line": 9
+                        },
+                        "While expanding the reference 'result' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 8
+                }
+            },
+            "19": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 9
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 12,
+                        "__main__.main.output_ptr": 10,
+                        "__main__.main.result": 13
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 27,
+                    "end_line": 9,
+                    "input_file": {
+                        "filename": "bitwise_output.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 9
+                }
+            },
+            "21": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 12
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 12,
+                        "__main__.main.output_ptr": 14,
+                        "__main__.main.result": 13
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 47,
+                    "end_line": 37,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 37,
+                            "end_line": 8,
+                            "input_file": {
+                                "filename": "bitwise_output.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 59,
+                                    "end_line": 7,
+                                    "input_file": {
+                                        "filename": "bitwise_output.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 13,
+                                            "end_line": 10,
+                                            "input_file": {
+                                                "filename": "bitwise_output.cairo"
+                                            },
+                                            "start_col": 5,
+                                            "start_line": 10
+                                        },
+                                        "While trying to retrieve the implicit argument 'bitwise_ptr' in:"
+                                    ],
+                                    "start_col": 31,
+                                    "start_line": 7
+                                },
+                                "While expanding the reference 'bitwise_ptr' in:"
+                            ],
+                            "start_col": 20,
+                            "start_line": 8
+                        },
+                        "While trying to update the implicit return value 'bitwise_ptr' in:"
+                    ],
+                    "start_col": 18,
+                    "start_line": 37
+                }
+            },
+            "22": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 13
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 12,
+                        "__main__.main.output_ptr": 14,
+                        "__main__.main.result": 13
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 13,
+                    "end_line": 10,
+                    "input_file": {
+                        "filename": "bitwise_output.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 10
+                }
+            }
+        }
+    },
+    "hints": {},
+    "identifiers": {
+        "__main__.BitwiseBuiltin": {
+            "destination": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+            "type": "alias"
+        },
+        "__main__.bitwise_and": {
+            "destination": "starkware.cairo.common.bitwise.bitwise_and",
+            "type": "alias"
+        },
+        "__main__.main": {
+            "decorators": [],
+            "pc": 10,
+            "type": "function"
+        },
+        "__main__.main.Args": {
+            "full_name": "__main__.main.Args",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.ImplicitArgs": {
+            "full_name": "__main__.main.ImplicitArgs",
+            "members": {
+                "bitwise_ptr": {
+                    "cairo_type": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin*",
+                    "offset": 1
+                },
+                "output_ptr": {
+                    "cairo_type": "felt*",
+                    "offset": 0
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "__main__.main.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "__main__.main.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.main.bitwise_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin*",
+            "full_name": "__main__.main.bitwise_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 10,
+                    "value": "[cast(fp + (-3), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 7
+                    },
+                    "pc": 17,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.output_ptr": {
+            "cairo_type": "felt*",
+            "full_name": "__main__.main.output_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 10,
+                    "value": "[cast(fp + (-4), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 12
+                    },
+                    "pc": 21,
+                    "value": "[cast(ap + (-1), felt**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.result": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.result",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 7
+                    },
+                    "pc": 17,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.serialize_word": {
+            "destination": "starkware.cairo.common.serialize.serialize_word",
+            "type": "alias"
+        },
+        "starkware.cairo.common.bitwise.ALL_ONES": {
+            "type": "const",
+            "value": -106710729501573572985208420194530329073740042555888586719234
+        },
+        "starkware.cairo.common.bitwise.BitwiseBuiltin": {
+            "destination": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+            "type": "alias"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and": {
+            "decorators": [],
+            "pc": 0,
+            "type": "function"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.Args": {
+            "full_name": "starkware.cairo.common.bitwise.bitwise_and.Args",
+            "members": {
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.bitwise.bitwise_and.ImplicitArgs",
+            "members": {
+                "bitwise_ptr": {
+                    "cairo_type": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.Return": {
+            "cairo_type": "(x_and_y : felt)",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.bitwise_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin*",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_and.bitwise_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 2,
+                    "value": "cast([fp + (-5)] + 5, starkware.cairo.common.cairo_builtins.BitwiseBuiltin*)"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.x": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_and.x",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "[cast(fp + (-4), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.x_and_y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_and.x_and_y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 2,
+                    "value": "[cast([fp + (-5)] + 2, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.x_or_y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_and.x_or_y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 2,
+                    "value": "[cast([fp + (-5)] + 4, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.x_xor_y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_and.x_xor_y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 2,
+                    "value": "[cast([fp + (-5)] + 3, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_and.y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.cairo_builtins.BitwiseBuiltin": {
+            "full_name": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+            "members": {
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "x_and_y": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                },
+                "x_or_y": {
+                    "cairo_type": "felt",
+                    "offset": 4
+                },
+                "x_xor_y": {
+                    "cairo_type": "felt",
+                    "offset": 3
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 5,
+            "type": "struct"
+        },
+        "starkware.cairo.common.cairo_builtins.EcOpBuiltin": {
+            "full_name": "starkware.cairo.common.cairo_builtins.EcOpBuiltin",
+            "members": {
+                "m": {
+                    "cairo_type": "felt",
+                    "offset": 4
+                },
+                "p": {
+                    "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+                    "offset": 0
+                },
+                "q": {
+                    "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+                    "offset": 2
+                },
+                "r": {
+                    "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+                    "offset": 5
+                }
+            },
+            "size": 7,
+            "type": "struct"
+        },
+        "starkware.cairo.common.cairo_builtins.EcPoint": {
+            "destination": "starkware.cairo.common.ec_point.EcPoint",
+            "type": "alias"
+        },
+        "starkware.cairo.common.cairo_builtins.HashBuiltin": {
+            "full_name": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+            "members": {
+                "result": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                },
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 3,
+            "type": "struct"
+        },
+        "starkware.cairo.common.cairo_builtins.SignatureBuiltin": {
+            "full_name": "starkware.cairo.common.cairo_builtins.SignatureBuiltin",
+            "members": {
+                "message": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                },
+                "pub_key": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.ec_point.EcPoint": {
+            "full_name": "starkware.cairo.common.ec_point.EcPoint",
+            "members": {
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.serialize.serialize_word": {
+            "decorators": [],
+            "pc": 6,
+            "type": "function"
+        },
+        "starkware.cairo.common.serialize.serialize_word.Args": {
+            "full_name": "starkware.cairo.common.serialize.serialize_word.Args",
+            "members": {
+                "word": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.serialize.serialize_word.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.serialize.serialize_word.ImplicitArgs",
+            "members": {
+                "output_ptr": {
+                    "cairo_type": "felt*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.serialize.serialize_word.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.serialize.serialize_word.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.serialize.serialize_word.output_ptr": {
+            "cairo_type": "felt*",
+            "full_name": "starkware.cairo.common.serialize.serialize_word.output_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 6,
+                    "value": "[cast(fp + (-4), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 7,
+                    "value": "cast([fp + (-4)] + 1, felt*)"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.serialize.serialize_word.word": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.serialize.serialize_word.word",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 6,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        }
+    },
+    "main_scope": "__main__",
+    "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+    "reference_manager": {
+        "references": [
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 0,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 0,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 0,
+                "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 2,
+                "value": "[cast([fp + (-5)] + 2, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 2,
+                "value": "[cast([fp + (-5)] + 3, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 2,
+                "value": "[cast([fp + (-5)] + 4, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 2,
+                "value": "cast([fp + (-5)] + 5, starkware.cairo.common.cairo_builtins.BitwiseBuiltin*)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 6,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 6,
+                "value": "[cast(fp + (-4), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 7,
+                "value": "cast([fp + (-4)] + 1, felt*)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 0
+                },
+                "pc": 10,
+                "value": "[cast(fp + (-4), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 0
+                },
+                "pc": 10,
+                "value": "[cast(fp + (-3), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 7
+                },
+                "pc": 17,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 7
+                },
+                "pc": 17,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 12
+                },
+                "pc": 21,
+                "value": "[cast(ap + (-1), felt**)]"
+            }
+        ]
+    }
+}

--- a/tests/support/bitwise_recursion.cairo
+++ b/tests/support/bitwise_recursion.cairo
@@ -1,0 +1,30 @@
+%builtins output range_check bitwise
+
+from starkware.cairo.common.bitwise import bitwise_and, bitwise_or, bitwise_xor
+from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
+from starkware.cairo.common.serialize import serialize_word
+
+
+func distort_value{range_check_ptr: felt, bitwise_ptr: BitwiseBuiltin*}(value: felt, secondary_value: felt, loop_num: felt) -> (r: felt):
+    if loop_num == 0:
+        return (value)
+    end
+
+    # Check that 0 <= secondary_value < 2**64.
+    [range_check_ptr] = secondary_value
+    assert [range_check_ptr + 1] = 2 ** 64 - 1 - secondary_value
+    let range_check_ptr = range_check_ptr + 2
+
+    let (distorted_value_a) = bitwise_xor(value, secondary_value)
+    let (distorted_value_b) = bitwise_or(value, secondary_value/2)
+    let (distorted_value) = bitwise_and(distorted_value_a, distorted_value_b)
+
+    return distort_value(distorted_value, secondary_value*3, loop_num - 1)
+end
+
+func main{output_ptr: felt*, range_check_ptr: felt, bitwise_ptr: BitwiseBuiltin*}():
+    let (result) = distort_value(45678783924002957984, 12546479, 20)
+    assert result = 45673807582400916561
+    serialize_word(result)
+    return()
+end

--- a/tests/support/bitwise_recursion.json
+++ b/tests/support/bitwise_recursion.json
@@ -1,0 +1,3791 @@
+{
+    "attributes": [],
+    "builtins": [
+        "output",
+        "range_check",
+        "bitwise"
+    ],
+    "data": [
+        "0x400380007ffb7ffc",
+        "0x400380017ffb7ffd",
+        "0x482680017ffb8000",
+        "0x5",
+        "0x480280027ffb8000",
+        "0x208b7fff7fff7ffe",
+        "0x400380007ffb7ffc",
+        "0x400380017ffb7ffd",
+        "0x482680017ffb8000",
+        "0x5",
+        "0x480280037ffb8000",
+        "0x208b7fff7fff7ffe",
+        "0x400380007ffb7ffc",
+        "0x400380017ffb7ffd",
+        "0x482680017ffb8000",
+        "0x5",
+        "0x480280047ffb8000",
+        "0x208b7fff7fff7ffe",
+        "0x400380007ffc7ffd",
+        "0x482680017ffc8000",
+        "0x1",
+        "0x208b7fff7fff7ffe",
+        "0x20780017fff7ffd",
+        "0x6",
+        "0x480a7ff97fff8000",
+        "0x480a7ffa7fff8000",
+        "0x480a7ffb7fff8000",
+        "0x208b7fff7fff7ffe",
+        "0x400380007ff97ffc",
+        "0x480680017fff8000",
+        "0xffffffffffffffff",
+        "0x48287ffc80007fff",
+        "0x400280017ff97fff",
+        "0x480a7ffa7fff8000",
+        "0x480a7ffb7fff8000",
+        "0x480a7ffc7fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe3",
+        "0x48127ffe7fff8000",
+        "0x480a7ffb7fff8000",
+        "0x484680017ffc8000",
+        "0x400000000000008800000000000000000000000000000000000000000000001",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe3",
+        "0x48127ffe7fff8000",
+        "0x48127ff77fff8000",
+        "0x48127ffd7fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd2",
+        "0x482680017ff98000",
+        "0x2",
+        "0x48127ffd7fff8000",
+        "0x48127ffd7fff8000",
+        "0x484680017ffc8000",
+        "0x3",
+        "0x482680017ffd8000",
+        "0x800000000000011000000000000000000000000000000000000000000000000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffde",
+        "0x208b7fff7fff7ffe",
+        "0x480a7ffc7fff8000",
+        "0x480a7ffd7fff8000",
+        "0x480680017fff8000",
+        "0x279eba3f65a052aa0",
+        "0x480680017fff8000",
+        "0xbf71af",
+        "0x480680017fff8000",
+        "0x14",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd3",
+        "0x400680017fff7fff",
+        "0x279d9f601888cac51",
+        "0x480a7ffb7fff8000",
+        "0x48127ffe7fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffc9",
+        "0x48127ff87fff8000",
+        "0x48127ff87fff8000",
+        "0x208b7fff7fff7ffe"
+    ],
+    "debug_info": {
+        "file_contents": {},
+        "instruction_locations": {
+            "0": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_and"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_and.bitwise_ptr": 2,
+                        "starkware.cairo.common.bitwise.bitwise_and.x": 0,
+                        "starkware.cairo.common.bitwise.bitwise_and.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 22,
+                    "end_line": 38,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 38
+                }
+            },
+            "1": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_and"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_and.bitwise_ptr": 2,
+                        "starkware.cairo.common.bitwise.bitwise_and.x": 0,
+                        "starkware.cairo.common.bitwise.bitwise_and.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 22,
+                    "end_line": 39,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 39
+                }
+            },
+            "2": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_and"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_and.bitwise_ptr": 6,
+                        "starkware.cairo.common.bitwise.bitwise_and.x": 0,
+                        "starkware.cairo.common.bitwise.bitwise_and.x_and_y": 3,
+                        "starkware.cairo.common.bitwise.bitwise_and.x_or_y": 5,
+                        "starkware.cairo.common.bitwise.bitwise_and.x_xor_y": 4,
+                        "starkware.cairo.common.bitwise.bitwise_and.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 56,
+                    "end_line": 43,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 47,
+                            "end_line": 37,
+                            "input_file": {
+                                "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 29,
+                                    "end_line": 44,
+                                    "input_file": {
+                                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 44
+                                },
+                                "While trying to retrieve the implicit argument 'bitwise_ptr' in:"
+                            ],
+                            "start_col": 18,
+                            "start_line": 37
+                        },
+                        "While expanding the reference 'bitwise_ptr' in:"
+                    ],
+                    "start_col": 23,
+                    "start_line": 43
+                }
+            },
+            "4": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_and"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_and.bitwise_ptr": 6,
+                        "starkware.cairo.common.bitwise.bitwise_and.x": 0,
+                        "starkware.cairo.common.bitwise.bitwise_and.x_and_y": 3,
+                        "starkware.cairo.common.bitwise.bitwise_and.x_or_y": 5,
+                        "starkware.cairo.common.bitwise.bitwise_and.x_xor_y": 4,
+                        "starkware.cairo.common.bitwise.bitwise_and.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 38,
+                    "end_line": 40,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 28,
+                            "end_line": 44,
+                            "input_file": {
+                                "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                            },
+                            "start_col": 21,
+                            "start_line": 44
+                        },
+                        "While expanding the reference 'x_and_y' in:"
+                    ],
+                    "start_col": 19,
+                    "start_line": 40
+                }
+            },
+            "5": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_and"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_and.bitwise_ptr": 6,
+                        "starkware.cairo.common.bitwise.bitwise_and.x": 0,
+                        "starkware.cairo.common.bitwise.bitwise_and.x_and_y": 3,
+                        "starkware.cairo.common.bitwise.bitwise_and.x_or_y": 5,
+                        "starkware.cairo.common.bitwise.bitwise_and.x_xor_y": 4,
+                        "starkware.cairo.common.bitwise.bitwise_and.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 29,
+                    "end_line": 44,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 44
+                }
+            },
+            "6": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_xor"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_xor.bitwise_ptr": 9,
+                        "starkware.cairo.common.bitwise.bitwise_xor.x": 7,
+                        "starkware.cairo.common.bitwise.bitwise_xor.y": 8
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 22,
+                    "end_line": 57,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 57
+                }
+            },
+            "7": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_xor"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_xor.bitwise_ptr": 9,
+                        "starkware.cairo.common.bitwise.bitwise_xor.x": 7,
+                        "starkware.cairo.common.bitwise.bitwise_xor.y": 8
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 22,
+                    "end_line": 58,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 58
+                }
+            },
+            "8": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_xor"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_xor.bitwise_ptr": 13,
+                        "starkware.cairo.common.bitwise.bitwise_xor.x": 7,
+                        "starkware.cairo.common.bitwise.bitwise_xor.x_and_y": 10,
+                        "starkware.cairo.common.bitwise.bitwise_xor.x_or_y": 12,
+                        "starkware.cairo.common.bitwise.bitwise_xor.x_xor_y": 11,
+                        "starkware.cairo.common.bitwise.bitwise_xor.y": 8
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 56,
+                    "end_line": 62,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 47,
+                            "end_line": 56,
+                            "input_file": {
+                                "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 29,
+                                    "end_line": 63,
+                                    "input_file": {
+                                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 63
+                                },
+                                "While trying to retrieve the implicit argument 'bitwise_ptr' in:"
+                            ],
+                            "start_col": 18,
+                            "start_line": 56
+                        },
+                        "While expanding the reference 'bitwise_ptr' in:"
+                    ],
+                    "start_col": 23,
+                    "start_line": 62
+                }
+            },
+            "10": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_xor"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_xor.bitwise_ptr": 13,
+                        "starkware.cairo.common.bitwise.bitwise_xor.x": 7,
+                        "starkware.cairo.common.bitwise.bitwise_xor.x_and_y": 10,
+                        "starkware.cairo.common.bitwise.bitwise_xor.x_or_y": 12,
+                        "starkware.cairo.common.bitwise.bitwise_xor.x_xor_y": 11,
+                        "starkware.cairo.common.bitwise.bitwise_xor.y": 8
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 38,
+                    "end_line": 60,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 28,
+                            "end_line": 63,
+                            "input_file": {
+                                "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                            },
+                            "start_col": 21,
+                            "start_line": 63
+                        },
+                        "While expanding the reference 'x_xor_y' in:"
+                    ],
+                    "start_col": 19,
+                    "start_line": 60
+                }
+            },
+            "11": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_xor"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_xor.bitwise_ptr": 13,
+                        "starkware.cairo.common.bitwise.bitwise_xor.x": 7,
+                        "starkware.cairo.common.bitwise.bitwise_xor.x_and_y": 10,
+                        "starkware.cairo.common.bitwise.bitwise_xor.x_or_y": 12,
+                        "starkware.cairo.common.bitwise.bitwise_xor.x_xor_y": 11,
+                        "starkware.cairo.common.bitwise.bitwise_xor.y": 8
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 29,
+                    "end_line": 63,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 63
+                }
+            },
+            "12": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_or"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_or.bitwise_ptr": 16,
+                        "starkware.cairo.common.bitwise.bitwise_or.x": 14,
+                        "starkware.cairo.common.bitwise.bitwise_or.y": 15
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 22,
+                    "end_line": 76,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 76
+                }
+            },
+            "13": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_or"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_or.bitwise_ptr": 16,
+                        "starkware.cairo.common.bitwise.bitwise_or.x": 14,
+                        "starkware.cairo.common.bitwise.bitwise_or.y": 15
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 22,
+                    "end_line": 77,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 77
+                }
+            },
+            "14": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_or"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_or.bitwise_ptr": 20,
+                        "starkware.cairo.common.bitwise.bitwise_or.x": 14,
+                        "starkware.cairo.common.bitwise.bitwise_or.x_and_y": 17,
+                        "starkware.cairo.common.bitwise.bitwise_or.x_or_y": 19,
+                        "starkware.cairo.common.bitwise.bitwise_or.x_xor_y": 18,
+                        "starkware.cairo.common.bitwise.bitwise_or.y": 15
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 56,
+                    "end_line": 81,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 46,
+                            "end_line": 75,
+                            "input_file": {
+                                "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 27,
+                                    "end_line": 82,
+                                    "input_file": {
+                                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 82
+                                },
+                                "While trying to retrieve the implicit argument 'bitwise_ptr' in:"
+                            ],
+                            "start_col": 17,
+                            "start_line": 75
+                        },
+                        "While expanding the reference 'bitwise_ptr' in:"
+                    ],
+                    "start_col": 23,
+                    "start_line": 81
+                }
+            },
+            "16": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_or"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_or.bitwise_ptr": 20,
+                        "starkware.cairo.common.bitwise.bitwise_or.x": 14,
+                        "starkware.cairo.common.bitwise.bitwise_or.x_and_y": 17,
+                        "starkware.cairo.common.bitwise.bitwise_or.x_or_y": 19,
+                        "starkware.cairo.common.bitwise.bitwise_or.x_xor_y": 18,
+                        "starkware.cairo.common.bitwise.bitwise_or.y": 15
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 36,
+                    "end_line": 80,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 26,
+                            "end_line": 82,
+                            "input_file": {
+                                "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                            },
+                            "start_col": 20,
+                            "start_line": 82
+                        },
+                        "While expanding the reference 'x_or_y' in:"
+                    ],
+                    "start_col": 18,
+                    "start_line": 80
+                }
+            },
+            "17": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_or"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_or.bitwise_ptr": 20,
+                        "starkware.cairo.common.bitwise.bitwise_or.x": 14,
+                        "starkware.cairo.common.bitwise.bitwise_or.x_and_y": 17,
+                        "starkware.cairo.common.bitwise.bitwise_or.x_or_y": 19,
+                        "starkware.cairo.common.bitwise.bitwise_or.x_xor_y": 18,
+                        "starkware.cairo.common.bitwise.bitwise_or.y": 15
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 27,
+                    "end_line": 82,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 82
+                }
+            },
+            "18": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.serialize",
+                    "starkware.cairo.common.serialize.serialize_word"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.serialize.serialize_word.output_ptr": 22,
+                        "starkware.cairo.common.serialize.serialize_word.word": 21
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 31,
+                    "end_line": 3,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 3
+                }
+            },
+            "19": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.serialize",
+                    "starkware.cairo.common.serialize.serialize_word"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.serialize.serialize_word.output_ptr": 23,
+                        "starkware.cairo.common.serialize.serialize_word.word": 21
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 36,
+                    "end_line": 4,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 39,
+                            "end_line": 2,
+                            "input_file": {
+                                "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 14,
+                                    "end_line": 5,
+                                    "input_file": {
+                                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 5
+                                },
+                                "While trying to retrieve the implicit argument 'output_ptr' in:"
+                            ],
+                            "start_col": 21,
+                            "start_line": 2
+                        },
+                        "While expanding the reference 'output_ptr' in:"
+                    ],
+                    "start_col": 22,
+                    "start_line": 4
+                }
+            },
+            "21": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.serialize",
+                    "starkware.cairo.common.serialize.serialize_word"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.serialize.serialize_word.output_ptr": 23,
+                        "starkware.cairo.common.serialize.serialize_word.word": 21
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 14,
+                    "end_line": 5,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 5
+                }
+            },
+            "22": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.bitwise_ptr": 28,
+                        "__main__.distort_value.loop_num": 26,
+                        "__main__.distort_value.range_check_ptr": 27,
+                        "__main__.distort_value.secondary_value": 25,
+                        "__main__.distort_value.value": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 7,
+                    "end_line": 9,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 9
+                }
+            },
+            "24": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.bitwise_ptr": 28,
+                        "__main__.distort_value.loop_num": 26,
+                        "__main__.distort_value.range_check_ptr": 27,
+                        "__main__.distort_value.secondary_value": 25,
+                        "__main__.distort_value.value": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 41,
+                    "end_line": 8,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 41,
+                            "end_line": 8,
+                            "input_file": {
+                                "filename": "bitwise_recursion.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 23,
+                                    "end_line": 10,
+                                    "input_file": {
+                                        "filename": "bitwise_recursion.cairo"
+                                    },
+                                    "start_col": 9,
+                                    "start_line": 10
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 20,
+                            "start_line": 8
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 20,
+                    "start_line": 8
+                }
+            },
+            "25": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.bitwise_ptr": 28,
+                        "__main__.distort_value.loop_num": 26,
+                        "__main__.distort_value.range_check_ptr": 27,
+                        "__main__.distort_value.secondary_value": 25,
+                        "__main__.distort_value.value": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 71,
+                    "end_line": 8,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 71,
+                            "end_line": 8,
+                            "input_file": {
+                                "filename": "bitwise_recursion.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 23,
+                                    "end_line": 10,
+                                    "input_file": {
+                                        "filename": "bitwise_recursion.cairo"
+                                    },
+                                    "start_col": 9,
+                                    "start_line": 10
+                                },
+                                "While trying to retrieve the implicit argument 'bitwise_ptr' in:"
+                            ],
+                            "start_col": 43,
+                            "start_line": 8
+                        },
+                        "While expanding the reference 'bitwise_ptr' in:"
+                    ],
+                    "start_col": 43,
+                    "start_line": 8
+                }
+            },
+            "26": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.bitwise_ptr": 28,
+                        "__main__.distort_value.loop_num": 26,
+                        "__main__.distort_value.range_check_ptr": 27,
+                        "__main__.distort_value.secondary_value": 25,
+                        "__main__.distort_value.value": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 84,
+                    "end_line": 8,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 22,
+                            "end_line": 10,
+                            "input_file": {
+                                "filename": "bitwise_recursion.cairo"
+                            },
+                            "start_col": 17,
+                            "start_line": 10
+                        },
+                        "While expanding the reference 'value' in:"
+                    ],
+                    "start_col": 73,
+                    "start_line": 8
+                }
+            },
+            "27": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.bitwise_ptr": 28,
+                        "__main__.distort_value.loop_num": 26,
+                        "__main__.distort_value.range_check_ptr": 27,
+                        "__main__.distort_value.secondary_value": 25,
+                        "__main__.distort_value.value": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 23,
+                    "end_line": 10,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "start_col": 9,
+                    "start_line": 10
+                }
+            },
+            "28": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.bitwise_ptr": 28,
+                        "__main__.distort_value.loop_num": 26,
+                        "__main__.distort_value.range_check_ptr": 27,
+                        "__main__.distort_value.secondary_value": 25,
+                        "__main__.distort_value.value": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 40,
+                    "end_line": 14,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 14
+                }
+            },
+            "29": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.bitwise_ptr": 28,
+                        "__main__.distort_value.loop_num": 26,
+                        "__main__.distort_value.range_check_ptr": 27,
+                        "__main__.distort_value.secondary_value": 25,
+                        "__main__.distort_value.value": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 47,
+                    "end_line": 15,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "start_col": 36,
+                    "start_line": 15
+                }
+            },
+            "31": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 29,
+                        "__main__.distort_value.bitwise_ptr": 28,
+                        "__main__.distort_value.loop_num": 26,
+                        "__main__.distort_value.range_check_ptr": 27,
+                        "__main__.distort_value.secondary_value": 25,
+                        "__main__.distort_value.value": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 65,
+                    "end_line": 15,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "start_col": 36,
+                    "start_line": 15
+                }
+            },
+            "32": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 29,
+                        "__main__.distort_value.__temp1": 30,
+                        "__main__.distort_value.bitwise_ptr": 28,
+                        "__main__.distort_value.loop_num": 26,
+                        "__main__.distort_value.range_check_ptr": 27,
+                        "__main__.distort_value.secondary_value": 25,
+                        "__main__.distort_value.value": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 65,
+                    "end_line": 15,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 15
+                }
+            },
+            "33": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 29,
+                        "__main__.distort_value.__temp1": 30,
+                        "__main__.distort_value.bitwise_ptr": 28,
+                        "__main__.distort_value.loop_num": 26,
+                        "__main__.distort_value.range_check_ptr": 31,
+                        "__main__.distort_value.secondary_value": 25,
+                        "__main__.distort_value.value": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 71,
+                    "end_line": 8,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 47,
+                            "end_line": 56,
+                            "input_file": {
+                                "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 66,
+                                    "end_line": 18,
+                                    "input_file": {
+                                        "filename": "bitwise_recursion.cairo"
+                                    },
+                                    "start_col": 31,
+                                    "start_line": 18
+                                },
+                                "While trying to retrieve the implicit argument 'bitwise_ptr' in:"
+                            ],
+                            "start_col": 18,
+                            "start_line": 56
+                        },
+                        "While expanding the reference 'bitwise_ptr' in:"
+                    ],
+                    "start_col": 43,
+                    "start_line": 8
+                }
+            },
+            "34": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 29,
+                        "__main__.distort_value.__temp1": 30,
+                        "__main__.distort_value.bitwise_ptr": 28,
+                        "__main__.distort_value.loop_num": 26,
+                        "__main__.distort_value.range_check_ptr": 31,
+                        "__main__.distort_value.secondary_value": 25,
+                        "__main__.distort_value.value": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 84,
+                    "end_line": 8,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 48,
+                            "end_line": 18,
+                            "input_file": {
+                                "filename": "bitwise_recursion.cairo"
+                            },
+                            "start_col": 43,
+                            "start_line": 18
+                        },
+                        "While expanding the reference 'value' in:"
+                    ],
+                    "start_col": 73,
+                    "start_line": 8
+                }
+            },
+            "35": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 29,
+                        "__main__.distort_value.__temp1": 30,
+                        "__main__.distort_value.bitwise_ptr": 28,
+                        "__main__.distort_value.loop_num": 26,
+                        "__main__.distort_value.range_check_ptr": 31,
+                        "__main__.distort_value.secondary_value": 25,
+                        "__main__.distort_value.value": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 107,
+                    "end_line": 8,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 65,
+                            "end_line": 18,
+                            "input_file": {
+                                "filename": "bitwise_recursion.cairo"
+                            },
+                            "start_col": 50,
+                            "start_line": 18
+                        },
+                        "While expanding the reference 'secondary_value' in:"
+                    ],
+                    "start_col": 86,
+                    "start_line": 8
+                }
+            },
+            "36": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 29,
+                        "__main__.distort_value.__temp1": 30,
+                        "__main__.distort_value.bitwise_ptr": 28,
+                        "__main__.distort_value.loop_num": 26,
+                        "__main__.distort_value.range_check_ptr": 31,
+                        "__main__.distort_value.secondary_value": 25,
+                        "__main__.distort_value.value": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 66,
+                    "end_line": 18,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "start_col": 31,
+                    "start_line": 18
+                }
+            },
+            "38": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 9
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 29,
+                        "__main__.distort_value.__temp1": 30,
+                        "__main__.distort_value.bitwise_ptr": 32,
+                        "__main__.distort_value.distorted_value_a": 33,
+                        "__main__.distort_value.loop_num": 26,
+                        "__main__.distort_value.range_check_ptr": 31,
+                        "__main__.distort_value.secondary_value": 25,
+                        "__main__.distort_value.value": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 47,
+                    "end_line": 56,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 66,
+                            "end_line": 18,
+                            "input_file": {
+                                "filename": "bitwise_recursion.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 46,
+                                    "end_line": 75,
+                                    "input_file": {
+                                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 67,
+                                            "end_line": 19,
+                                            "input_file": {
+                                                "filename": "bitwise_recursion.cairo"
+                                            },
+                                            "start_col": 31,
+                                            "start_line": 19
+                                        },
+                                        "While trying to retrieve the implicit argument 'bitwise_ptr' in:"
+                                    ],
+                                    "start_col": 17,
+                                    "start_line": 75
+                                },
+                                "While expanding the reference 'bitwise_ptr' in:"
+                            ],
+                            "start_col": 31,
+                            "start_line": 18
+                        },
+                        "While trying to update the implicit return value 'bitwise_ptr' in:"
+                    ],
+                    "start_col": 18,
+                    "start_line": 56
+                }
+            },
+            "39": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 10
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 29,
+                        "__main__.distort_value.__temp1": 30,
+                        "__main__.distort_value.bitwise_ptr": 32,
+                        "__main__.distort_value.distorted_value_a": 33,
+                        "__main__.distort_value.loop_num": 26,
+                        "__main__.distort_value.range_check_ptr": 31,
+                        "__main__.distort_value.secondary_value": 25,
+                        "__main__.distort_value.value": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 84,
+                    "end_line": 8,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 47,
+                            "end_line": 19,
+                            "input_file": {
+                                "filename": "bitwise_recursion.cairo"
+                            },
+                            "start_col": 42,
+                            "start_line": 19
+                        },
+                        "While expanding the reference 'value' in:"
+                    ],
+                    "start_col": 73,
+                    "start_line": 8
+                }
+            },
+            "40": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 11
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 29,
+                        "__main__.distort_value.__temp1": 30,
+                        "__main__.distort_value.bitwise_ptr": 32,
+                        "__main__.distort_value.distorted_value_a": 33,
+                        "__main__.distort_value.loop_num": 26,
+                        "__main__.distort_value.range_check_ptr": 31,
+                        "__main__.distort_value.secondary_value": 25,
+                        "__main__.distort_value.value": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 66,
+                    "end_line": 19,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "start_col": 49,
+                    "start_line": 19
+                }
+            },
+            "42": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 12
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 29,
+                        "__main__.distort_value.__temp1": 30,
+                        "__main__.distort_value.bitwise_ptr": 32,
+                        "__main__.distort_value.distorted_value_a": 33,
+                        "__main__.distort_value.loop_num": 26,
+                        "__main__.distort_value.range_check_ptr": 31,
+                        "__main__.distort_value.secondary_value": 25,
+                        "__main__.distort_value.value": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 67,
+                    "end_line": 19,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "start_col": 31,
+                    "start_line": 19
+                }
+            },
+            "44": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 16
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 29,
+                        "__main__.distort_value.__temp1": 30,
+                        "__main__.distort_value.bitwise_ptr": 34,
+                        "__main__.distort_value.distorted_value_a": 33,
+                        "__main__.distort_value.distorted_value_b": 35,
+                        "__main__.distort_value.loop_num": 26,
+                        "__main__.distort_value.range_check_ptr": 31,
+                        "__main__.distort_value.secondary_value": 25,
+                        "__main__.distort_value.value": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 46,
+                    "end_line": 75,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 67,
+                            "end_line": 19,
+                            "input_file": {
+                                "filename": "bitwise_recursion.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 47,
+                                    "end_line": 37,
+                                    "input_file": {
+                                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 78,
+                                            "end_line": 20,
+                                            "input_file": {
+                                                "filename": "bitwise_recursion.cairo"
+                                            },
+                                            "start_col": 29,
+                                            "start_line": 20
+                                        },
+                                        "While trying to retrieve the implicit argument 'bitwise_ptr' in:"
+                                    ],
+                                    "start_col": 18,
+                                    "start_line": 37
+                                },
+                                "While expanding the reference 'bitwise_ptr' in:"
+                            ],
+                            "start_col": 31,
+                            "start_line": 19
+                        },
+                        "While trying to update the implicit return value 'bitwise_ptr' in:"
+                    ],
+                    "start_col": 17,
+                    "start_line": 75
+                }
+            },
+            "45": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 17
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 29,
+                        "__main__.distort_value.__temp1": 30,
+                        "__main__.distort_value.bitwise_ptr": 34,
+                        "__main__.distort_value.distorted_value_a": 33,
+                        "__main__.distort_value.distorted_value_b": 35,
+                        "__main__.distort_value.loop_num": 26,
+                        "__main__.distort_value.range_check_ptr": 31,
+                        "__main__.distort_value.secondary_value": 25,
+                        "__main__.distort_value.value": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 27,
+                    "end_line": 18,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 58,
+                            "end_line": 20,
+                            "input_file": {
+                                "filename": "bitwise_recursion.cairo"
+                            },
+                            "start_col": 41,
+                            "start_line": 20
+                        },
+                        "While expanding the reference 'distorted_value_a' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 18
+                }
+            },
+            "46": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 18
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 29,
+                        "__main__.distort_value.__temp1": 30,
+                        "__main__.distort_value.bitwise_ptr": 34,
+                        "__main__.distort_value.distorted_value_a": 33,
+                        "__main__.distort_value.distorted_value_b": 35,
+                        "__main__.distort_value.loop_num": 26,
+                        "__main__.distort_value.range_check_ptr": 31,
+                        "__main__.distort_value.secondary_value": 25,
+                        "__main__.distort_value.value": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 27,
+                    "end_line": 19,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 77,
+                            "end_line": 20,
+                            "input_file": {
+                                "filename": "bitwise_recursion.cairo"
+                            },
+                            "start_col": 60,
+                            "start_line": 20
+                        },
+                        "While expanding the reference 'distorted_value_b' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 19
+                }
+            },
+            "47": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 19
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 29,
+                        "__main__.distort_value.__temp1": 30,
+                        "__main__.distort_value.bitwise_ptr": 34,
+                        "__main__.distort_value.distorted_value_a": 33,
+                        "__main__.distort_value.distorted_value_b": 35,
+                        "__main__.distort_value.loop_num": 26,
+                        "__main__.distort_value.range_check_ptr": 31,
+                        "__main__.distort_value.secondary_value": 25,
+                        "__main__.distort_value.value": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 78,
+                    "end_line": 20,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "start_col": 29,
+                    "start_line": 20
+                }
+            },
+            "49": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 23
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 29,
+                        "__main__.distort_value.__temp1": 30,
+                        "__main__.distort_value.bitwise_ptr": 36,
+                        "__main__.distort_value.distorted_value": 37,
+                        "__main__.distort_value.distorted_value_a": 33,
+                        "__main__.distort_value.distorted_value_b": 35,
+                        "__main__.distort_value.loop_num": 26,
+                        "__main__.distort_value.range_check_ptr": 31,
+                        "__main__.distort_value.secondary_value": 25,
+                        "__main__.distort_value.value": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 46,
+                    "end_line": 16,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 41,
+                            "end_line": 8,
+                            "input_file": {
+                                "filename": "bitwise_recursion.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 75,
+                                    "end_line": 22,
+                                    "input_file": {
+                                        "filename": "bitwise_recursion.cairo"
+                                    },
+                                    "start_col": 12,
+                                    "start_line": 22
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 20,
+                            "start_line": 8
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 27,
+                    "start_line": 16
+                }
+            },
+            "51": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 24
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 29,
+                        "__main__.distort_value.__temp1": 30,
+                        "__main__.distort_value.bitwise_ptr": 36,
+                        "__main__.distort_value.distorted_value": 37,
+                        "__main__.distort_value.distorted_value_a": 33,
+                        "__main__.distort_value.distorted_value_b": 35,
+                        "__main__.distort_value.loop_num": 26,
+                        "__main__.distort_value.range_check_ptr": 31,
+                        "__main__.distort_value.secondary_value": 25,
+                        "__main__.distort_value.value": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 47,
+                    "end_line": 37,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 78,
+                            "end_line": 20,
+                            "input_file": {
+                                "filename": "bitwise_recursion.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 71,
+                                    "end_line": 8,
+                                    "input_file": {
+                                        "filename": "bitwise_recursion.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 75,
+                                            "end_line": 22,
+                                            "input_file": {
+                                                "filename": "bitwise_recursion.cairo"
+                                            },
+                                            "start_col": 12,
+                                            "start_line": 22
+                                        },
+                                        "While trying to retrieve the implicit argument 'bitwise_ptr' in:"
+                                    ],
+                                    "start_col": 43,
+                                    "start_line": 8
+                                },
+                                "While expanding the reference 'bitwise_ptr' in:"
+                            ],
+                            "start_col": 29,
+                            "start_line": 20
+                        },
+                        "While trying to update the implicit return value 'bitwise_ptr' in:"
+                    ],
+                    "start_col": 18,
+                    "start_line": 37
+                }
+            },
+            "52": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 25
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 29,
+                        "__main__.distort_value.__temp1": 30,
+                        "__main__.distort_value.bitwise_ptr": 36,
+                        "__main__.distort_value.distorted_value": 37,
+                        "__main__.distort_value.distorted_value_a": 33,
+                        "__main__.distort_value.distorted_value_b": 35,
+                        "__main__.distort_value.loop_num": 26,
+                        "__main__.distort_value.range_check_ptr": 31,
+                        "__main__.distort_value.secondary_value": 25,
+                        "__main__.distort_value.value": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 25,
+                    "end_line": 20,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 41,
+                            "end_line": 22,
+                            "input_file": {
+                                "filename": "bitwise_recursion.cairo"
+                            },
+                            "start_col": 26,
+                            "start_line": 22
+                        },
+                        "While expanding the reference 'distorted_value' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 20
+                }
+            },
+            "53": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 26
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 29,
+                        "__main__.distort_value.__temp1": 30,
+                        "__main__.distort_value.bitwise_ptr": 36,
+                        "__main__.distort_value.distorted_value": 37,
+                        "__main__.distort_value.distorted_value_a": 33,
+                        "__main__.distort_value.distorted_value_b": 35,
+                        "__main__.distort_value.loop_num": 26,
+                        "__main__.distort_value.range_check_ptr": 31,
+                        "__main__.distort_value.secondary_value": 25,
+                        "__main__.distort_value.value": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 60,
+                    "end_line": 22,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "start_col": 43,
+                    "start_line": 22
+                }
+            },
+            "55": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 27
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 29,
+                        "__main__.distort_value.__temp1": 30,
+                        "__main__.distort_value.bitwise_ptr": 36,
+                        "__main__.distort_value.distorted_value": 37,
+                        "__main__.distort_value.distorted_value_a": 33,
+                        "__main__.distort_value.distorted_value_b": 35,
+                        "__main__.distort_value.loop_num": 26,
+                        "__main__.distort_value.range_check_ptr": 31,
+                        "__main__.distort_value.secondary_value": 25,
+                        "__main__.distort_value.value": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 74,
+                    "end_line": 22,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "start_col": 62,
+                    "start_line": 22
+                }
+            },
+            "57": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 28
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 29,
+                        "__main__.distort_value.__temp1": 30,
+                        "__main__.distort_value.bitwise_ptr": 36,
+                        "__main__.distort_value.distorted_value": 37,
+                        "__main__.distort_value.distorted_value_a": 33,
+                        "__main__.distort_value.distorted_value_b": 35,
+                        "__main__.distort_value.loop_num": 26,
+                        "__main__.distort_value.range_check_ptr": 31,
+                        "__main__.distort_value.secondary_value": 25,
+                        "__main__.distort_value.value": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 75,
+                    "end_line": 22,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "start_col": 12,
+                    "start_line": 22
+                }
+            },
+            "59": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 29,
+                        "__main__.distort_value.__temp1": 30,
+                        "__main__.distort_value.bitwise_ptr": 39,
+                        "__main__.distort_value.distorted_value": 37,
+                        "__main__.distort_value.distorted_value_a": 33,
+                        "__main__.distort_value.distorted_value_b": 35,
+                        "__main__.distort_value.loop_num": 26,
+                        "__main__.distort_value.range_check_ptr": 38,
+                        "__main__.distort_value.secondary_value": 25,
+                        "__main__.distort_value.value": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 75,
+                    "end_line": 22,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 22
+                }
+            },
+            "60": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 42,
+                        "__main__.main.output_ptr": 40,
+                        "__main__.main.range_check_ptr": 41
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 51,
+                    "end_line": 25,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 41,
+                            "end_line": 8,
+                            "input_file": {
+                                "filename": "bitwise_recursion.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 69,
+                                    "end_line": 26,
+                                    "input_file": {
+                                        "filename": "bitwise_recursion.cairo"
+                                    },
+                                    "start_col": 20,
+                                    "start_line": 26
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 20,
+                            "start_line": 8
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 30,
+                    "start_line": 25
+                }
+            },
+            "61": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 42,
+                        "__main__.main.output_ptr": 40,
+                        "__main__.main.range_check_ptr": 41
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 81,
+                    "end_line": 25,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 71,
+                            "end_line": 8,
+                            "input_file": {
+                                "filename": "bitwise_recursion.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 69,
+                                    "end_line": 26,
+                                    "input_file": {
+                                        "filename": "bitwise_recursion.cairo"
+                                    },
+                                    "start_col": 20,
+                                    "start_line": 26
+                                },
+                                "While trying to retrieve the implicit argument 'bitwise_ptr' in:"
+                            ],
+                            "start_col": 43,
+                            "start_line": 8
+                        },
+                        "While expanding the reference 'bitwise_ptr' in:"
+                    ],
+                    "start_col": 53,
+                    "start_line": 25
+                }
+            },
+            "62": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 42,
+                        "__main__.main.output_ptr": 40,
+                        "__main__.main.range_check_ptr": 41
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 54,
+                    "end_line": 26,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 26
+                }
+            },
+            "64": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 42,
+                        "__main__.main.output_ptr": 40,
+                        "__main__.main.range_check_ptr": 41
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 64,
+                    "end_line": 26,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "start_col": 56,
+                    "start_line": 26
+                }
+            },
+            "66": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 42,
+                        "__main__.main.output_ptr": 40,
+                        "__main__.main.range_check_ptr": 41
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 68,
+                    "end_line": 26,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "start_col": 66,
+                    "start_line": 26
+                }
+            },
+            "68": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 42,
+                        "__main__.main.output_ptr": 40,
+                        "__main__.main.range_check_ptr": 41
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 69,
+                    "end_line": 26,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "start_col": 20,
+                    "start_line": 26
+                }
+            },
+            "70": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 7,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 44,
+                        "__main__.main.output_ptr": 40,
+                        "__main__.main.range_check_ptr": 43,
+                        "__main__.main.result": 45
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 41,
+                    "end_line": 27,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 27
+                }
+            },
+            "72": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 7,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 44,
+                        "__main__.main.output_ptr": 40,
+                        "__main__.main.range_check_ptr": 43,
+                        "__main__.main.result": 45
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 28,
+                    "end_line": 25,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 39,
+                            "end_line": 2,
+                            "input_file": {
+                                "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 27,
+                                    "end_line": 28,
+                                    "input_file": {
+                                        "filename": "bitwise_recursion.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 28
+                                },
+                                "While trying to retrieve the implicit argument 'output_ptr' in:"
+                            ],
+                            "start_col": 21,
+                            "start_line": 2
+                        },
+                        "While expanding the reference 'output_ptr' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 25
+                }
+            },
+            "73": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 7,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 44,
+                        "__main__.main.output_ptr": 40,
+                        "__main__.main.range_check_ptr": 43,
+                        "__main__.main.result": 45
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 16,
+                    "end_line": 26,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 26,
+                            "end_line": 28,
+                            "input_file": {
+                                "filename": "bitwise_recursion.cairo"
+                            },
+                            "start_col": 20,
+                            "start_line": 28
+                        },
+                        "While expanding the reference 'result' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 26
+                }
+            },
+            "74": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 7,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 44,
+                        "__main__.main.output_ptr": 40,
+                        "__main__.main.range_check_ptr": 43,
+                        "__main__.main.result": 45
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 27,
+                    "end_line": 28,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 28
+                }
+            },
+            "76": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 7,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 44,
+                        "__main__.main.output_ptr": 46,
+                        "__main__.main.range_check_ptr": 43,
+                        "__main__.main.result": 45
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 41,
+                    "end_line": 8,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 69,
+                            "end_line": 26,
+                            "input_file": {
+                                "filename": "bitwise_recursion.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 51,
+                                    "end_line": 25,
+                                    "input_file": {
+                                        "filename": "bitwise_recursion.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 13,
+                                            "end_line": 29,
+                                            "input_file": {
+                                                "filename": "bitwise_recursion.cairo"
+                                            },
+                                            "start_col": 5,
+                                            "start_line": 29
+                                        },
+                                        "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                    ],
+                                    "start_col": 30,
+                                    "start_line": 25
+                                },
+                                "While expanding the reference 'range_check_ptr' in:"
+                            ],
+                            "start_col": 20,
+                            "start_line": 26
+                        },
+                        "While trying to update the implicit return value 'range_check_ptr' in:"
+                    ],
+                    "start_col": 20,
+                    "start_line": 8
+                }
+            },
+            "77": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 7,
+                        "offset": 6
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 44,
+                        "__main__.main.output_ptr": 46,
+                        "__main__.main.range_check_ptr": 43,
+                        "__main__.main.result": 45
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 71,
+                    "end_line": 8,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 69,
+                            "end_line": 26,
+                            "input_file": {
+                                "filename": "bitwise_recursion.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 81,
+                                    "end_line": 25,
+                                    "input_file": {
+                                        "filename": "bitwise_recursion.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 13,
+                                            "end_line": 29,
+                                            "input_file": {
+                                                "filename": "bitwise_recursion.cairo"
+                                            },
+                                            "start_col": 5,
+                                            "start_line": 29
+                                        },
+                                        "While trying to retrieve the implicit argument 'bitwise_ptr' in:"
+                                    ],
+                                    "start_col": 53,
+                                    "start_line": 25
+                                },
+                                "While expanding the reference 'bitwise_ptr' in:"
+                            ],
+                            "start_col": 20,
+                            "start_line": 26
+                        },
+                        "While trying to update the implicit return value 'bitwise_ptr' in:"
+                    ],
+                    "start_col": 43,
+                    "start_line": 8
+                }
+            },
+            "78": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 7,
+                        "offset": 7
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 44,
+                        "__main__.main.output_ptr": 46,
+                        "__main__.main.range_check_ptr": 43,
+                        "__main__.main.result": 45
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 13,
+                    "end_line": 29,
+                    "input_file": {
+                        "filename": "bitwise_recursion.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 29
+                }
+            }
+        }
+    },
+    "hints": {},
+    "identifiers": {
+        "__main__.BitwiseBuiltin": {
+            "destination": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+            "type": "alias"
+        },
+        "__main__.bitwise_and": {
+            "destination": "starkware.cairo.common.bitwise.bitwise_and",
+            "type": "alias"
+        },
+        "__main__.bitwise_or": {
+            "destination": "starkware.cairo.common.bitwise.bitwise_or",
+            "type": "alias"
+        },
+        "__main__.bitwise_xor": {
+            "destination": "starkware.cairo.common.bitwise.bitwise_xor",
+            "type": "alias"
+        },
+        "__main__.distort_value": {
+            "decorators": [],
+            "pc": 22,
+            "type": "function"
+        },
+        "__main__.distort_value.Args": {
+            "full_name": "__main__.distort_value.Args",
+            "members": {
+                "loop_num": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                },
+                "secondary_value": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                },
+                "value": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 3,
+            "type": "struct"
+        },
+        "__main__.distort_value.ImplicitArgs": {
+            "full_name": "__main__.distort_value.ImplicitArgs",
+            "members": {
+                "bitwise_ptr": {
+                    "cairo_type": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin*",
+                    "offset": 1
+                },
+                "range_check_ptr": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "__main__.distort_value.Return": {
+            "cairo_type": "(r : felt)",
+            "type": "type_definition"
+        },
+        "__main__.distort_value.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.distort_value.__temp0": {
+            "cairo_type": "felt",
+            "full_name": "__main__.distort_value.__temp0",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 1
+                    },
+                    "pc": 31,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.distort_value.__temp1": {
+            "cairo_type": "felt",
+            "full_name": "__main__.distort_value.__temp1",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 2
+                    },
+                    "pc": 32,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.distort_value.bitwise_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin*",
+            "full_name": "__main__.distort_value.bitwise_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 22,
+                    "value": "[cast(fp + (-6), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 9
+                    },
+                    "pc": 38,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 16
+                    },
+                    "pc": 44,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 23
+                    },
+                    "pc": 49,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 0
+                    },
+                    "pc": 59,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.distort_value.distorted_value": {
+            "cairo_type": "felt",
+            "full_name": "__main__.distort_value.distorted_value",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 23
+                    },
+                    "pc": 49,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.distort_value.distorted_value_a": {
+            "cairo_type": "felt",
+            "full_name": "__main__.distort_value.distorted_value_a",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 9
+                    },
+                    "pc": 38,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.distort_value.distorted_value_b": {
+            "cairo_type": "felt",
+            "full_name": "__main__.distort_value.distorted_value_b",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 16
+                    },
+                    "pc": 44,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.distort_value.loop_num": {
+            "cairo_type": "felt",
+            "full_name": "__main__.distort_value.loop_num",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 22,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.distort_value.range_check_ptr": {
+            "cairo_type": "felt",
+            "full_name": "__main__.distort_value.range_check_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 22,
+                    "value": "[cast(fp + (-7), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 2
+                    },
+                    "pc": 33,
+                    "value": "cast([fp + (-7)] + 2, felt)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 0
+                    },
+                    "pc": 59,
+                    "value": "[cast(ap + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.distort_value.secondary_value": {
+            "cairo_type": "felt",
+            "full_name": "__main__.distort_value.secondary_value",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 22,
+                    "value": "[cast(fp + (-4), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.distort_value.value": {
+            "cairo_type": "felt",
+            "full_name": "__main__.distort_value.value",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 22,
+                    "value": "[cast(fp + (-5), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main": {
+            "decorators": [],
+            "pc": 60,
+            "type": "function"
+        },
+        "__main__.main.Args": {
+            "full_name": "__main__.main.Args",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.ImplicitArgs": {
+            "full_name": "__main__.main.ImplicitArgs",
+            "members": {
+                "bitwise_ptr": {
+                    "cairo_type": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin*",
+                    "offset": 2
+                },
+                "output_ptr": {
+                    "cairo_type": "felt*",
+                    "offset": 0
+                },
+                "range_check_ptr": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 3,
+            "type": "struct"
+        },
+        "__main__.main.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "__main__.main.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.main.bitwise_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin*",
+            "full_name": "__main__.main.bitwise_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 0
+                    },
+                    "pc": 60,
+                    "value": "[cast(fp + (-3), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 7,
+                        "offset": 0
+                    },
+                    "pc": 70,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.output_ptr": {
+            "cairo_type": "felt*",
+            "full_name": "__main__.main.output_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 0
+                    },
+                    "pc": 60,
+                    "value": "[cast(fp + (-5), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 7,
+                        "offset": 5
+                    },
+                    "pc": 76,
+                    "value": "[cast(ap + (-1), felt**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.range_check_ptr": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.range_check_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 0
+                    },
+                    "pc": 60,
+                    "value": "[cast(fp + (-4), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 7,
+                        "offset": 0
+                    },
+                    "pc": 70,
+                    "value": "[cast(ap + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.result": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.result",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 7,
+                        "offset": 0
+                    },
+                    "pc": 70,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.serialize_word": {
+            "destination": "starkware.cairo.common.serialize.serialize_word",
+            "type": "alias"
+        },
+        "starkware.cairo.common.bitwise.ALL_ONES": {
+            "type": "const",
+            "value": -106710729501573572985208420194530329073740042555888586719234
+        },
+        "starkware.cairo.common.bitwise.BitwiseBuiltin": {
+            "destination": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+            "type": "alias"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and": {
+            "decorators": [],
+            "pc": 0,
+            "type": "function"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.Args": {
+            "full_name": "starkware.cairo.common.bitwise.bitwise_and.Args",
+            "members": {
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.bitwise.bitwise_and.ImplicitArgs",
+            "members": {
+                "bitwise_ptr": {
+                    "cairo_type": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.Return": {
+            "cairo_type": "(x_and_y : felt)",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.bitwise_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin*",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_and.bitwise_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 2,
+                    "value": "cast([fp + (-5)] + 5, starkware.cairo.common.cairo_builtins.BitwiseBuiltin*)"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.x": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_and.x",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "[cast(fp + (-4), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.x_and_y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_and.x_and_y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 2,
+                    "value": "[cast([fp + (-5)] + 2, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.x_or_y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_and.x_or_y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 2,
+                    "value": "[cast([fp + (-5)] + 4, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.x_xor_y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_and.x_xor_y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 2,
+                    "value": "[cast([fp + (-5)] + 3, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_and.y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_or": {
+            "decorators": [],
+            "pc": 12,
+            "type": "function"
+        },
+        "starkware.cairo.common.bitwise.bitwise_or.Args": {
+            "full_name": "starkware.cairo.common.bitwise.bitwise_or.Args",
+            "members": {
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.bitwise.bitwise_or.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.bitwise.bitwise_or.ImplicitArgs",
+            "members": {
+                "bitwise_ptr": {
+                    "cairo_type": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.bitwise.bitwise_or.Return": {
+            "cairo_type": "(x_or_y : felt)",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.bitwise.bitwise_or.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.bitwise.bitwise_or.bitwise_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin*",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_or.bitwise_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 12,
+                    "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 14,
+                    "value": "cast([fp + (-5)] + 5, starkware.cairo.common.cairo_builtins.BitwiseBuiltin*)"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_or.x": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_or.x",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 12,
+                    "value": "[cast(fp + (-4), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_or.x_and_y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_or.x_and_y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 14,
+                    "value": "[cast([fp + (-5)] + 2, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_or.x_or_y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_or.x_or_y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 14,
+                    "value": "[cast([fp + (-5)] + 4, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_or.x_xor_y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_or.x_xor_y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 14,
+                    "value": "[cast([fp + (-5)] + 3, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_or.y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_or.y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 12,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_xor": {
+            "decorators": [],
+            "pc": 6,
+            "type": "function"
+        },
+        "starkware.cairo.common.bitwise.bitwise_xor.Args": {
+            "full_name": "starkware.cairo.common.bitwise.bitwise_xor.Args",
+            "members": {
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.bitwise.bitwise_xor.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.bitwise.bitwise_xor.ImplicitArgs",
+            "members": {
+                "bitwise_ptr": {
+                    "cairo_type": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.bitwise.bitwise_xor.Return": {
+            "cairo_type": "(x_xor_y : felt)",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.bitwise.bitwise_xor.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.bitwise.bitwise_xor.bitwise_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin*",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_xor.bitwise_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 6,
+                    "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 8,
+                    "value": "cast([fp + (-5)] + 5, starkware.cairo.common.cairo_builtins.BitwiseBuiltin*)"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_xor.x": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_xor.x",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 6,
+                    "value": "[cast(fp + (-4), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_xor.x_and_y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_xor.x_and_y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 8,
+                    "value": "[cast([fp + (-5)] + 2, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_xor.x_or_y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_xor.x_or_y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 8,
+                    "value": "[cast([fp + (-5)] + 4, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_xor.x_xor_y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_xor.x_xor_y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 8,
+                    "value": "[cast([fp + (-5)] + 3, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_xor.y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_xor.y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 6,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.cairo_builtins.BitwiseBuiltin": {
+            "full_name": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+            "members": {
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "x_and_y": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                },
+                "x_or_y": {
+                    "cairo_type": "felt",
+                    "offset": 4
+                },
+                "x_xor_y": {
+                    "cairo_type": "felt",
+                    "offset": 3
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 5,
+            "type": "struct"
+        },
+        "starkware.cairo.common.cairo_builtins.EcOpBuiltin": {
+            "full_name": "starkware.cairo.common.cairo_builtins.EcOpBuiltin",
+            "members": {
+                "m": {
+                    "cairo_type": "felt",
+                    "offset": 4
+                },
+                "p": {
+                    "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+                    "offset": 0
+                },
+                "q": {
+                    "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+                    "offset": 2
+                },
+                "r": {
+                    "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+                    "offset": 5
+                }
+            },
+            "size": 7,
+            "type": "struct"
+        },
+        "starkware.cairo.common.cairo_builtins.EcPoint": {
+            "destination": "starkware.cairo.common.ec_point.EcPoint",
+            "type": "alias"
+        },
+        "starkware.cairo.common.cairo_builtins.HashBuiltin": {
+            "full_name": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+            "members": {
+                "result": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                },
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 3,
+            "type": "struct"
+        },
+        "starkware.cairo.common.cairo_builtins.SignatureBuiltin": {
+            "full_name": "starkware.cairo.common.cairo_builtins.SignatureBuiltin",
+            "members": {
+                "message": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                },
+                "pub_key": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.ec_point.EcPoint": {
+            "full_name": "starkware.cairo.common.ec_point.EcPoint",
+            "members": {
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.serialize.serialize_word": {
+            "decorators": [],
+            "pc": 18,
+            "type": "function"
+        },
+        "starkware.cairo.common.serialize.serialize_word.Args": {
+            "full_name": "starkware.cairo.common.serialize.serialize_word.Args",
+            "members": {
+                "word": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.serialize.serialize_word.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.serialize.serialize_word.ImplicitArgs",
+            "members": {
+                "output_ptr": {
+                    "cairo_type": "felt*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.serialize.serialize_word.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.serialize.serialize_word.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.serialize.serialize_word.output_ptr": {
+            "cairo_type": "felt*",
+            "full_name": "starkware.cairo.common.serialize.serialize_word.output_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "pc": 18,
+                    "value": "[cast(fp + (-4), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "pc": 19,
+                    "value": "cast([fp + (-4)] + 1, felt*)"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.serialize.serialize_word.word": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.serialize.serialize_word.word",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "pc": 18,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        }
+    },
+    "main_scope": "__main__",
+    "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+    "reference_manager": {
+        "references": [
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 0,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 0,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 0,
+                "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 2,
+                "value": "[cast([fp + (-5)] + 2, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 2,
+                "value": "[cast([fp + (-5)] + 3, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 2,
+                "value": "[cast([fp + (-5)] + 4, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 2,
+                "value": "cast([fp + (-5)] + 5, starkware.cairo.common.cairo_builtins.BitwiseBuiltin*)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 6,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 6,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 6,
+                "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 8,
+                "value": "[cast([fp + (-5)] + 2, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 8,
+                "value": "[cast([fp + (-5)] + 3, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 8,
+                "value": "[cast([fp + (-5)] + 4, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 8,
+                "value": "cast([fp + (-5)] + 5, starkware.cairo.common.cairo_builtins.BitwiseBuiltin*)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 0
+                },
+                "pc": 12,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 0
+                },
+                "pc": 12,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 0
+                },
+                "pc": 12,
+                "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 0
+                },
+                "pc": 14,
+                "value": "[cast([fp + (-5)] + 2, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 0
+                },
+                "pc": 14,
+                "value": "[cast([fp + (-5)] + 3, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 0
+                },
+                "pc": 14,
+                "value": "[cast([fp + (-5)] + 4, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 0
+                },
+                "pc": 14,
+                "value": "cast([fp + (-5)] + 5, starkware.cairo.common.cairo_builtins.BitwiseBuiltin*)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 3,
+                    "offset": 0
+                },
+                "pc": 18,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 3,
+                    "offset": 0
+                },
+                "pc": 18,
+                "value": "[cast(fp + (-4), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 3,
+                    "offset": 0
+                },
+                "pc": 19,
+                "value": "cast([fp + (-4)] + 1, felt*)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 0
+                },
+                "pc": 22,
+                "value": "[cast(fp + (-5), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 0
+                },
+                "pc": 22,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 0
+                },
+                "pc": 22,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 0
+                },
+                "pc": 22,
+                "value": "[cast(fp + (-7), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 0
+                },
+                "pc": 22,
+                "value": "[cast(fp + (-6), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 1
+                },
+                "pc": 31,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 2
+                },
+                "pc": 32,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 2
+                },
+                "pc": 33,
+                "value": "cast([fp + (-7)] + 2, felt)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 9
+                },
+                "pc": 38,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 9
+                },
+                "pc": 38,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 16
+                },
+                "pc": 44,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 16
+                },
+                "pc": 44,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 23
+                },
+                "pc": 49,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 23
+                },
+                "pc": 49,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 5,
+                    "offset": 0
+                },
+                "pc": 59,
+                "value": "[cast(ap + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 5,
+                    "offset": 0
+                },
+                "pc": 59,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 0
+                },
+                "pc": 60,
+                "value": "[cast(fp + (-5), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 0
+                },
+                "pc": 60,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 0
+                },
+                "pc": 60,
+                "value": "[cast(fp + (-3), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 7,
+                    "offset": 0
+                },
+                "pc": 70,
+                "value": "[cast(ap + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 7,
+                    "offset": 0
+                },
+                "pc": 70,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 7,
+                    "offset": 0
+                },
+                "pc": 70,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 7,
+                    "offset": 5
+                },
+                "pc": 76,
+                "value": "[cast(ap + (-1), felt**)]"
+            }
+        ]
+    }
+}

--- a/tests/support/integration.cairo
+++ b/tests/support/integration.cairo
@@ -1,0 +1,41 @@
+%builtins output pedersen range_check bitwise
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.hash import hash2
+from starkware.cairo.common.bitwise import bitwise_and, bitwise_or, bitwise_xor
+from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
+from starkware.cairo.common.serialize import serialize_word
+
+func get_hash(hash_ptr : HashBuiltin*, num_a: felt, num_b: felt) -> (hash_ptr : HashBuiltin*, r):
+    with hash_ptr:
+        let (result) = hash2(num_a, num_b)
+    end
+    return (hash_ptr=hash_ptr, r=result)
+end
+
+func distort_value{range_check_ptr: felt, bitwise_ptr: BitwiseBuiltin*}(value: felt, secondary_value: felt, loop_num: felt) -> (r: felt):
+    if loop_num == 0:
+        return (value)
+    end
+
+    # Check that 0 <= secondary_value < 2**64.
+    [range_check_ptr] = secondary_value
+    assert [range_check_ptr + 1] = 2 ** 64 - 1 - secondary_value
+    let range_check_ptr = range_check_ptr + 2
+
+    let (distorted_value_a) = bitwise_xor(value, secondary_value)
+    let (distorted_value_b) = bitwise_or(value, secondary_value/2)
+    let (distorted_value) = bitwise_and(distorted_value_a, distorted_value_b)
+
+    return distort_value(distorted_value, secondary_value*3, loop_num - 1)
+end
+
+func main{output_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr: felt, bitwise_ptr: BitwiseBuiltin*}():
+    let num_a = 123568
+    let num_b = 5673940
+    let (distorted_num_b) = distort_value(num_b, 6783043740, 20)
+    let (pedersen_ptr, result: felt) = get_hash(pedersen_ptr, num_a, distorted_num_b)
+    assert result = 1705936988874506830037172232662562674195194978736118624789869153703579404549
+    serialize_word(result)
+    return()
+end

--- a/tests/support/integration.json
+++ b/tests/support/integration.json
@@ -1,0 +1,4860 @@
+{
+    "attributes": [],
+    "builtins": [
+        "output",
+        "pedersen",
+        "range_check",
+        "bitwise"
+    ],
+    "data": [
+        "0x400380007ffb7ffc",
+        "0x400380017ffb7ffd",
+        "0x482680017ffb8000",
+        "0x3",
+        "0x480280027ffb8000",
+        "0x208b7fff7fff7ffe",
+        "0x400380007ffb7ffc",
+        "0x400380017ffb7ffd",
+        "0x482680017ffb8000",
+        "0x5",
+        "0x480280027ffb8000",
+        "0x208b7fff7fff7ffe",
+        "0x400380007ffb7ffc",
+        "0x400380017ffb7ffd",
+        "0x482680017ffb8000",
+        "0x5",
+        "0x480280037ffb8000",
+        "0x208b7fff7fff7ffe",
+        "0x400380007ffb7ffc",
+        "0x400380017ffb7ffd",
+        "0x482680017ffb8000",
+        "0x5",
+        "0x480280047ffb8000",
+        "0x208b7fff7fff7ffe",
+        "0x400380007ffc7ffd",
+        "0x482680017ffc8000",
+        "0x1",
+        "0x208b7fff7fff7ffe",
+        "0x480a7ffb7fff8000",
+        "0x480a7ffc7fff8000",
+        "0x480a7ffd7fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe2",
+        "0x208b7fff7fff7ffe",
+        "0x20780017fff7ffd",
+        "0x6",
+        "0x480a7ff97fff8000",
+        "0x480a7ffa7fff8000",
+        "0x480a7ffb7fff8000",
+        "0x208b7fff7fff7ffe",
+        "0x400380007ff97ffc",
+        "0x480680017fff8000",
+        "0xffffffffffffffff",
+        "0x48287ffc80007fff",
+        "0x400280017ff97fff",
+        "0x480a7ffa7fff8000",
+        "0x480a7ffb7fff8000",
+        "0x480a7ffc7fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffdd",
+        "0x48127ffe7fff8000",
+        "0x480a7ffb7fff8000",
+        "0x484680017ffc8000",
+        "0x400000000000008800000000000000000000000000000000000000000000001",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffdd",
+        "0x48127ffe7fff8000",
+        "0x48127ff77fff8000",
+        "0x48127ffd7fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffcc",
+        "0x482680017ff98000",
+        "0x2",
+        "0x48127ffd7fff8000",
+        "0x48127ffd7fff8000",
+        "0x484680017ffc8000",
+        "0x3",
+        "0x482680017ffd8000",
+        "0x800000000000011000000000000000000000000000000000000000000000000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffde",
+        "0x208b7fff7fff7ffe",
+        "0x480a7ffc7fff8000",
+        "0x480a7ffd7fff8000",
+        "0x480680017fff8000",
+        "0x5693d4",
+        "0x480680017fff8000",
+        "0x1944d089c",
+        "0x480680017fff8000",
+        "0x14",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd3",
+        "0x480a7ffb7fff8000",
+        "0x480680017fff8000",
+        "0x1e2b0",
+        "0x48127ffd7fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffc7",
+        "0x400680017fff7fff",
+        "0x3c586afb7daf8da5e7b504266a2101cb60fbbda3f960ec85889be018044c905",
+        "0x480a7ffa7fff8000",
+        "0x48127ffe7fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffbd",
+        "0x48127ff97fff8000",
+        "0x48127feb7fff8000",
+        "0x48127feb7fff8000",
+        "0x208b7fff7fff7ffe"
+    ],
+    "debug_info": {
+        "file_contents": {},
+        "instruction_locations": {
+            "0": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash",
+                    "starkware.cairo.common.hash.hash2"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash.hash2.hash_ptr": 2,
+                        "starkware.cairo.common.hash.hash2.x": 0,
+                        "starkware.cairo.common.hash.hash2.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 19,
+                    "end_line": 14,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/hash.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 14
+                }
+            },
+            "1": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash",
+                    "starkware.cairo.common.hash.hash2"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash.hash2.hash_ptr": 2,
+                        "starkware.cairo.common.hash.hash2.x": 0,
+                        "starkware.cairo.common.hash.hash2.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 19,
+                    "end_line": 15,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/hash.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 15
+                }
+            },
+            "2": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash",
+                    "starkware.cairo.common.hash.hash2"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash.hash2.hash_ptr": 4,
+                        "starkware.cairo.common.hash.hash2.result": 3,
+                        "starkware.cairo.common.hash.hash2.x": 0,
+                        "starkware.cairo.common.hash.hash2.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 47,
+                    "end_line": 17,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/hash.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 35,
+                            "end_line": 13,
+                            "input_file": {
+                                "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/hash.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 27,
+                                    "end_line": 18,
+                                    "input_file": {
+                                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/hash.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 18
+                                },
+                                "While trying to retrieve the implicit argument 'hash_ptr' in:"
+                            ],
+                            "start_col": 12,
+                            "start_line": 13
+                        },
+                        "While expanding the reference 'hash_ptr' in:"
+                    ],
+                    "start_col": 20,
+                    "start_line": 17
+                }
+            },
+            "4": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash",
+                    "starkware.cairo.common.hash.hash2"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash.hash2.hash_ptr": 4,
+                        "starkware.cairo.common.hash.hash2.result": 3,
+                        "starkware.cairo.common.hash.hash2.x": 0,
+                        "starkware.cairo.common.hash.hash2.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 33,
+                    "end_line": 16,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/hash.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 26,
+                            "end_line": 18,
+                            "input_file": {
+                                "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/hash.cairo"
+                            },
+                            "start_col": 20,
+                            "start_line": 18
+                        },
+                        "While expanding the reference 'result' in:"
+                    ],
+                    "start_col": 18,
+                    "start_line": 16
+                }
+            },
+            "5": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash",
+                    "starkware.cairo.common.hash.hash2"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash.hash2.hash_ptr": 4,
+                        "starkware.cairo.common.hash.hash2.result": 3,
+                        "starkware.cairo.common.hash.hash2.x": 0,
+                        "starkware.cairo.common.hash.hash2.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 27,
+                    "end_line": 18,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/hash.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 18
+                }
+            },
+            "6": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_and"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_and.bitwise_ptr": 7,
+                        "starkware.cairo.common.bitwise.bitwise_and.x": 5,
+                        "starkware.cairo.common.bitwise.bitwise_and.y": 6
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 22,
+                    "end_line": 38,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 38
+                }
+            },
+            "7": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_and"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_and.bitwise_ptr": 7,
+                        "starkware.cairo.common.bitwise.bitwise_and.x": 5,
+                        "starkware.cairo.common.bitwise.bitwise_and.y": 6
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 22,
+                    "end_line": 39,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 39
+                }
+            },
+            "8": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_and"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_and.bitwise_ptr": 11,
+                        "starkware.cairo.common.bitwise.bitwise_and.x": 5,
+                        "starkware.cairo.common.bitwise.bitwise_and.x_and_y": 8,
+                        "starkware.cairo.common.bitwise.bitwise_and.x_or_y": 10,
+                        "starkware.cairo.common.bitwise.bitwise_and.x_xor_y": 9,
+                        "starkware.cairo.common.bitwise.bitwise_and.y": 6
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 56,
+                    "end_line": 43,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 47,
+                            "end_line": 37,
+                            "input_file": {
+                                "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 29,
+                                    "end_line": 44,
+                                    "input_file": {
+                                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 44
+                                },
+                                "While trying to retrieve the implicit argument 'bitwise_ptr' in:"
+                            ],
+                            "start_col": 18,
+                            "start_line": 37
+                        },
+                        "While expanding the reference 'bitwise_ptr' in:"
+                    ],
+                    "start_col": 23,
+                    "start_line": 43
+                }
+            },
+            "10": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_and"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_and.bitwise_ptr": 11,
+                        "starkware.cairo.common.bitwise.bitwise_and.x": 5,
+                        "starkware.cairo.common.bitwise.bitwise_and.x_and_y": 8,
+                        "starkware.cairo.common.bitwise.bitwise_and.x_or_y": 10,
+                        "starkware.cairo.common.bitwise.bitwise_and.x_xor_y": 9,
+                        "starkware.cairo.common.bitwise.bitwise_and.y": 6
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 38,
+                    "end_line": 40,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 28,
+                            "end_line": 44,
+                            "input_file": {
+                                "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                            },
+                            "start_col": 21,
+                            "start_line": 44
+                        },
+                        "While expanding the reference 'x_and_y' in:"
+                    ],
+                    "start_col": 19,
+                    "start_line": 40
+                }
+            },
+            "11": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_and"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_and.bitwise_ptr": 11,
+                        "starkware.cairo.common.bitwise.bitwise_and.x": 5,
+                        "starkware.cairo.common.bitwise.bitwise_and.x_and_y": 8,
+                        "starkware.cairo.common.bitwise.bitwise_and.x_or_y": 10,
+                        "starkware.cairo.common.bitwise.bitwise_and.x_xor_y": 9,
+                        "starkware.cairo.common.bitwise.bitwise_and.y": 6
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 29,
+                    "end_line": 44,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 44
+                }
+            },
+            "12": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_xor"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_xor.bitwise_ptr": 14,
+                        "starkware.cairo.common.bitwise.bitwise_xor.x": 12,
+                        "starkware.cairo.common.bitwise.bitwise_xor.y": 13
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 22,
+                    "end_line": 57,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 57
+                }
+            },
+            "13": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_xor"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_xor.bitwise_ptr": 14,
+                        "starkware.cairo.common.bitwise.bitwise_xor.x": 12,
+                        "starkware.cairo.common.bitwise.bitwise_xor.y": 13
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 22,
+                    "end_line": 58,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 58
+                }
+            },
+            "14": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_xor"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_xor.bitwise_ptr": 18,
+                        "starkware.cairo.common.bitwise.bitwise_xor.x": 12,
+                        "starkware.cairo.common.bitwise.bitwise_xor.x_and_y": 15,
+                        "starkware.cairo.common.bitwise.bitwise_xor.x_or_y": 17,
+                        "starkware.cairo.common.bitwise.bitwise_xor.x_xor_y": 16,
+                        "starkware.cairo.common.bitwise.bitwise_xor.y": 13
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 56,
+                    "end_line": 62,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 47,
+                            "end_line": 56,
+                            "input_file": {
+                                "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 29,
+                                    "end_line": 63,
+                                    "input_file": {
+                                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 63
+                                },
+                                "While trying to retrieve the implicit argument 'bitwise_ptr' in:"
+                            ],
+                            "start_col": 18,
+                            "start_line": 56
+                        },
+                        "While expanding the reference 'bitwise_ptr' in:"
+                    ],
+                    "start_col": 23,
+                    "start_line": 62
+                }
+            },
+            "16": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_xor"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_xor.bitwise_ptr": 18,
+                        "starkware.cairo.common.bitwise.bitwise_xor.x": 12,
+                        "starkware.cairo.common.bitwise.bitwise_xor.x_and_y": 15,
+                        "starkware.cairo.common.bitwise.bitwise_xor.x_or_y": 17,
+                        "starkware.cairo.common.bitwise.bitwise_xor.x_xor_y": 16,
+                        "starkware.cairo.common.bitwise.bitwise_xor.y": 13
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 38,
+                    "end_line": 60,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 28,
+                            "end_line": 63,
+                            "input_file": {
+                                "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                            },
+                            "start_col": 21,
+                            "start_line": 63
+                        },
+                        "While expanding the reference 'x_xor_y' in:"
+                    ],
+                    "start_col": 19,
+                    "start_line": 60
+                }
+            },
+            "17": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_xor"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_xor.bitwise_ptr": 18,
+                        "starkware.cairo.common.bitwise.bitwise_xor.x": 12,
+                        "starkware.cairo.common.bitwise.bitwise_xor.x_and_y": 15,
+                        "starkware.cairo.common.bitwise.bitwise_xor.x_or_y": 17,
+                        "starkware.cairo.common.bitwise.bitwise_xor.x_xor_y": 16,
+                        "starkware.cairo.common.bitwise.bitwise_xor.y": 13
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 29,
+                    "end_line": 63,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 63
+                }
+            },
+            "18": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_or"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_or.bitwise_ptr": 21,
+                        "starkware.cairo.common.bitwise.bitwise_or.x": 19,
+                        "starkware.cairo.common.bitwise.bitwise_or.y": 20
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 22,
+                    "end_line": 76,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 76
+                }
+            },
+            "19": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_or"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_or.bitwise_ptr": 21,
+                        "starkware.cairo.common.bitwise.bitwise_or.x": 19,
+                        "starkware.cairo.common.bitwise.bitwise_or.y": 20
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 22,
+                    "end_line": 77,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 77
+                }
+            },
+            "20": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_or"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_or.bitwise_ptr": 25,
+                        "starkware.cairo.common.bitwise.bitwise_or.x": 19,
+                        "starkware.cairo.common.bitwise.bitwise_or.x_and_y": 22,
+                        "starkware.cairo.common.bitwise.bitwise_or.x_or_y": 24,
+                        "starkware.cairo.common.bitwise.bitwise_or.x_xor_y": 23,
+                        "starkware.cairo.common.bitwise.bitwise_or.y": 20
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 56,
+                    "end_line": 81,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 46,
+                            "end_line": 75,
+                            "input_file": {
+                                "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 27,
+                                    "end_line": 82,
+                                    "input_file": {
+                                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 82
+                                },
+                                "While trying to retrieve the implicit argument 'bitwise_ptr' in:"
+                            ],
+                            "start_col": 17,
+                            "start_line": 75
+                        },
+                        "While expanding the reference 'bitwise_ptr' in:"
+                    ],
+                    "start_col": 23,
+                    "start_line": 81
+                }
+            },
+            "22": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_or"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_or.bitwise_ptr": 25,
+                        "starkware.cairo.common.bitwise.bitwise_or.x": 19,
+                        "starkware.cairo.common.bitwise.bitwise_or.x_and_y": 22,
+                        "starkware.cairo.common.bitwise.bitwise_or.x_or_y": 24,
+                        "starkware.cairo.common.bitwise.bitwise_or.x_xor_y": 23,
+                        "starkware.cairo.common.bitwise.bitwise_or.y": 20
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 36,
+                    "end_line": 80,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 26,
+                            "end_line": 82,
+                            "input_file": {
+                                "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                            },
+                            "start_col": 20,
+                            "start_line": 82
+                        },
+                        "While expanding the reference 'x_or_y' in:"
+                    ],
+                    "start_col": 18,
+                    "start_line": 80
+                }
+            },
+            "23": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.bitwise",
+                    "starkware.cairo.common.bitwise.bitwise_or"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.bitwise.bitwise_or.bitwise_ptr": 25,
+                        "starkware.cairo.common.bitwise.bitwise_or.x": 19,
+                        "starkware.cairo.common.bitwise.bitwise_or.x_and_y": 22,
+                        "starkware.cairo.common.bitwise.bitwise_or.x_or_y": 24,
+                        "starkware.cairo.common.bitwise.bitwise_or.x_xor_y": 23,
+                        "starkware.cairo.common.bitwise.bitwise_or.y": 20
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 27,
+                    "end_line": 82,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 82
+                }
+            },
+            "24": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.serialize",
+                    "starkware.cairo.common.serialize.serialize_word"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.serialize.serialize_word.output_ptr": 27,
+                        "starkware.cairo.common.serialize.serialize_word.word": 26
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 31,
+                    "end_line": 3,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 3
+                }
+            },
+            "25": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.serialize",
+                    "starkware.cairo.common.serialize.serialize_word"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.serialize.serialize_word.output_ptr": 28,
+                        "starkware.cairo.common.serialize.serialize_word.word": 26
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 36,
+                    "end_line": 4,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 39,
+                            "end_line": 2,
+                            "input_file": {
+                                "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 14,
+                                    "end_line": 5,
+                                    "input_file": {
+                                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 5
+                                },
+                                "While trying to retrieve the implicit argument 'output_ptr' in:"
+                            ],
+                            "start_col": 21,
+                            "start_line": 2
+                        },
+                        "While expanding the reference 'output_ptr' in:"
+                    ],
+                    "start_col": 22,
+                    "start_line": 4
+                }
+            },
+            "27": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.serialize",
+                    "starkware.cairo.common.serialize.serialize_word"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.serialize.serialize_word.output_ptr": 28,
+                        "starkware.cairo.common.serialize.serialize_word.word": 26
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 14,
+                    "end_line": 5,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 5
+                }
+            },
+            "28": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.get_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.get_hash.hash_ptr": 29,
+                        "__main__.get_hash.num_a": 30,
+                        "__main__.get_hash.num_b": 31
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 38,
+                    "end_line": 9,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 35,
+                            "end_line": 13,
+                            "input_file": {
+                                "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/hash.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 43,
+                                    "end_line": 11,
+                                    "input_file": {
+                                        "filename": "integration.cairo"
+                                    },
+                                    "start_col": 24,
+                                    "start_line": 11
+                                },
+                                "While trying to retrieve the implicit argument 'hash_ptr' in:"
+                            ],
+                            "start_col": 12,
+                            "start_line": 13
+                        },
+                        "While expanding the reference 'hash_ptr' in:"
+                    ],
+                    "start_col": 15,
+                    "start_line": 9
+                }
+            },
+            "29": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.get_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.get_hash.hash_ptr": 29,
+                        "__main__.get_hash.num_a": 30,
+                        "__main__.get_hash.num_b": 31
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 51,
+                    "end_line": 9,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 35,
+                            "end_line": 11,
+                            "input_file": {
+                                "filename": "integration.cairo"
+                            },
+                            "start_col": 30,
+                            "start_line": 11
+                        },
+                        "While expanding the reference 'num_a' in:"
+                    ],
+                    "start_col": 40,
+                    "start_line": 9
+                }
+            },
+            "30": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.get_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.get_hash.hash_ptr": 29,
+                        "__main__.get_hash.num_a": 30,
+                        "__main__.get_hash.num_b": 31
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 64,
+                    "end_line": 9,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 42,
+                            "end_line": 11,
+                            "input_file": {
+                                "filename": "integration.cairo"
+                            },
+                            "start_col": 37,
+                            "start_line": 11
+                        },
+                        "While expanding the reference 'num_b' in:"
+                    ],
+                    "start_col": 53,
+                    "start_line": 9
+                }
+            },
+            "31": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.get_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "__main__.get_hash.hash_ptr": 29,
+                        "__main__.get_hash.num_a": 30,
+                        "__main__.get_hash.num_b": 31
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 43,
+                    "end_line": 11,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "start_col": 24,
+                    "start_line": 11
+                }
+            },
+            "33": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.get_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 7
+                    },
+                    "reference_ids": {
+                        "__main__.get_hash.hash_ptr": 32,
+                        "__main__.get_hash.num_a": 30,
+                        "__main__.get_hash.num_b": 31,
+                        "__main__.get_hash.result": 33
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 41,
+                    "end_line": 13,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 13
+                }
+            },
+            "34": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.bitwise_ptr": 38,
+                        "__main__.distort_value.loop_num": 36,
+                        "__main__.distort_value.range_check_ptr": 37,
+                        "__main__.distort_value.secondary_value": 35,
+                        "__main__.distort_value.value": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 7,
+                    "end_line": 17,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 17
+                }
+            },
+            "36": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.bitwise_ptr": 38,
+                        "__main__.distort_value.loop_num": 36,
+                        "__main__.distort_value.range_check_ptr": 37,
+                        "__main__.distort_value.secondary_value": 35,
+                        "__main__.distort_value.value": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 41,
+                    "end_line": 16,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 41,
+                            "end_line": 16,
+                            "input_file": {
+                                "filename": "integration.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 23,
+                                    "end_line": 18,
+                                    "input_file": {
+                                        "filename": "integration.cairo"
+                                    },
+                                    "start_col": 9,
+                                    "start_line": 18
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 20,
+                            "start_line": 16
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 20,
+                    "start_line": 16
+                }
+            },
+            "37": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.bitwise_ptr": 38,
+                        "__main__.distort_value.loop_num": 36,
+                        "__main__.distort_value.range_check_ptr": 37,
+                        "__main__.distort_value.secondary_value": 35,
+                        "__main__.distort_value.value": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 71,
+                    "end_line": 16,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 71,
+                            "end_line": 16,
+                            "input_file": {
+                                "filename": "integration.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 23,
+                                    "end_line": 18,
+                                    "input_file": {
+                                        "filename": "integration.cairo"
+                                    },
+                                    "start_col": 9,
+                                    "start_line": 18
+                                },
+                                "While trying to retrieve the implicit argument 'bitwise_ptr' in:"
+                            ],
+                            "start_col": 43,
+                            "start_line": 16
+                        },
+                        "While expanding the reference 'bitwise_ptr' in:"
+                    ],
+                    "start_col": 43,
+                    "start_line": 16
+                }
+            },
+            "38": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.bitwise_ptr": 38,
+                        "__main__.distort_value.loop_num": 36,
+                        "__main__.distort_value.range_check_ptr": 37,
+                        "__main__.distort_value.secondary_value": 35,
+                        "__main__.distort_value.value": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 84,
+                    "end_line": 16,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 22,
+                            "end_line": 18,
+                            "input_file": {
+                                "filename": "integration.cairo"
+                            },
+                            "start_col": 17,
+                            "start_line": 18
+                        },
+                        "While expanding the reference 'value' in:"
+                    ],
+                    "start_col": 73,
+                    "start_line": 16
+                }
+            },
+            "39": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.bitwise_ptr": 38,
+                        "__main__.distort_value.loop_num": 36,
+                        "__main__.distort_value.range_check_ptr": 37,
+                        "__main__.distort_value.secondary_value": 35,
+                        "__main__.distort_value.value": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 23,
+                    "end_line": 18,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "start_col": 9,
+                    "start_line": 18
+                }
+            },
+            "40": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.bitwise_ptr": 38,
+                        "__main__.distort_value.loop_num": 36,
+                        "__main__.distort_value.range_check_ptr": 37,
+                        "__main__.distort_value.secondary_value": 35,
+                        "__main__.distort_value.value": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 40,
+                    "end_line": 22,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 22
+                }
+            },
+            "41": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.bitwise_ptr": 38,
+                        "__main__.distort_value.loop_num": 36,
+                        "__main__.distort_value.range_check_ptr": 37,
+                        "__main__.distort_value.secondary_value": 35,
+                        "__main__.distort_value.value": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 47,
+                    "end_line": 23,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "start_col": 36,
+                    "start_line": 23
+                }
+            },
+            "43": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 39,
+                        "__main__.distort_value.bitwise_ptr": 38,
+                        "__main__.distort_value.loop_num": 36,
+                        "__main__.distort_value.range_check_ptr": 37,
+                        "__main__.distort_value.secondary_value": 35,
+                        "__main__.distort_value.value": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 65,
+                    "end_line": 23,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "start_col": 36,
+                    "start_line": 23
+                }
+            },
+            "44": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 39,
+                        "__main__.distort_value.__temp1": 40,
+                        "__main__.distort_value.bitwise_ptr": 38,
+                        "__main__.distort_value.loop_num": 36,
+                        "__main__.distort_value.range_check_ptr": 37,
+                        "__main__.distort_value.secondary_value": 35,
+                        "__main__.distort_value.value": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 65,
+                    "end_line": 23,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 23
+                }
+            },
+            "45": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 39,
+                        "__main__.distort_value.__temp1": 40,
+                        "__main__.distort_value.bitwise_ptr": 38,
+                        "__main__.distort_value.loop_num": 36,
+                        "__main__.distort_value.range_check_ptr": 41,
+                        "__main__.distort_value.secondary_value": 35,
+                        "__main__.distort_value.value": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 71,
+                    "end_line": 16,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 47,
+                            "end_line": 56,
+                            "input_file": {
+                                "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 66,
+                                    "end_line": 26,
+                                    "input_file": {
+                                        "filename": "integration.cairo"
+                                    },
+                                    "start_col": 31,
+                                    "start_line": 26
+                                },
+                                "While trying to retrieve the implicit argument 'bitwise_ptr' in:"
+                            ],
+                            "start_col": 18,
+                            "start_line": 56
+                        },
+                        "While expanding the reference 'bitwise_ptr' in:"
+                    ],
+                    "start_col": 43,
+                    "start_line": 16
+                }
+            },
+            "46": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 39,
+                        "__main__.distort_value.__temp1": 40,
+                        "__main__.distort_value.bitwise_ptr": 38,
+                        "__main__.distort_value.loop_num": 36,
+                        "__main__.distort_value.range_check_ptr": 41,
+                        "__main__.distort_value.secondary_value": 35,
+                        "__main__.distort_value.value": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 84,
+                    "end_line": 16,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 48,
+                            "end_line": 26,
+                            "input_file": {
+                                "filename": "integration.cairo"
+                            },
+                            "start_col": 43,
+                            "start_line": 26
+                        },
+                        "While expanding the reference 'value' in:"
+                    ],
+                    "start_col": 73,
+                    "start_line": 16
+                }
+            },
+            "47": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 39,
+                        "__main__.distort_value.__temp1": 40,
+                        "__main__.distort_value.bitwise_ptr": 38,
+                        "__main__.distort_value.loop_num": 36,
+                        "__main__.distort_value.range_check_ptr": 41,
+                        "__main__.distort_value.secondary_value": 35,
+                        "__main__.distort_value.value": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 107,
+                    "end_line": 16,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 65,
+                            "end_line": 26,
+                            "input_file": {
+                                "filename": "integration.cairo"
+                            },
+                            "start_col": 50,
+                            "start_line": 26
+                        },
+                        "While expanding the reference 'secondary_value' in:"
+                    ],
+                    "start_col": 86,
+                    "start_line": 16
+                }
+            },
+            "48": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 39,
+                        "__main__.distort_value.__temp1": 40,
+                        "__main__.distort_value.bitwise_ptr": 38,
+                        "__main__.distort_value.loop_num": 36,
+                        "__main__.distort_value.range_check_ptr": 41,
+                        "__main__.distort_value.secondary_value": 35,
+                        "__main__.distort_value.value": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 66,
+                    "end_line": 26,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "start_col": 31,
+                    "start_line": 26
+                }
+            },
+            "50": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 9
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 39,
+                        "__main__.distort_value.__temp1": 40,
+                        "__main__.distort_value.bitwise_ptr": 42,
+                        "__main__.distort_value.distorted_value_a": 43,
+                        "__main__.distort_value.loop_num": 36,
+                        "__main__.distort_value.range_check_ptr": 41,
+                        "__main__.distort_value.secondary_value": 35,
+                        "__main__.distort_value.value": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 47,
+                    "end_line": 56,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 66,
+                            "end_line": 26,
+                            "input_file": {
+                                "filename": "integration.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 46,
+                                    "end_line": 75,
+                                    "input_file": {
+                                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 67,
+                                            "end_line": 27,
+                                            "input_file": {
+                                                "filename": "integration.cairo"
+                                            },
+                                            "start_col": 31,
+                                            "start_line": 27
+                                        },
+                                        "While trying to retrieve the implicit argument 'bitwise_ptr' in:"
+                                    ],
+                                    "start_col": 17,
+                                    "start_line": 75
+                                },
+                                "While expanding the reference 'bitwise_ptr' in:"
+                            ],
+                            "start_col": 31,
+                            "start_line": 26
+                        },
+                        "While trying to update the implicit return value 'bitwise_ptr' in:"
+                    ],
+                    "start_col": 18,
+                    "start_line": 56
+                }
+            },
+            "51": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 10
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 39,
+                        "__main__.distort_value.__temp1": 40,
+                        "__main__.distort_value.bitwise_ptr": 42,
+                        "__main__.distort_value.distorted_value_a": 43,
+                        "__main__.distort_value.loop_num": 36,
+                        "__main__.distort_value.range_check_ptr": 41,
+                        "__main__.distort_value.secondary_value": 35,
+                        "__main__.distort_value.value": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 84,
+                    "end_line": 16,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 47,
+                            "end_line": 27,
+                            "input_file": {
+                                "filename": "integration.cairo"
+                            },
+                            "start_col": 42,
+                            "start_line": 27
+                        },
+                        "While expanding the reference 'value' in:"
+                    ],
+                    "start_col": 73,
+                    "start_line": 16
+                }
+            },
+            "52": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 11
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 39,
+                        "__main__.distort_value.__temp1": 40,
+                        "__main__.distort_value.bitwise_ptr": 42,
+                        "__main__.distort_value.distorted_value_a": 43,
+                        "__main__.distort_value.loop_num": 36,
+                        "__main__.distort_value.range_check_ptr": 41,
+                        "__main__.distort_value.secondary_value": 35,
+                        "__main__.distort_value.value": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 66,
+                    "end_line": 27,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "start_col": 49,
+                    "start_line": 27
+                }
+            },
+            "54": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 12
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 39,
+                        "__main__.distort_value.__temp1": 40,
+                        "__main__.distort_value.bitwise_ptr": 42,
+                        "__main__.distort_value.distorted_value_a": 43,
+                        "__main__.distort_value.loop_num": 36,
+                        "__main__.distort_value.range_check_ptr": 41,
+                        "__main__.distort_value.secondary_value": 35,
+                        "__main__.distort_value.value": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 67,
+                    "end_line": 27,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "start_col": 31,
+                    "start_line": 27
+                }
+            },
+            "56": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 16
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 39,
+                        "__main__.distort_value.__temp1": 40,
+                        "__main__.distort_value.bitwise_ptr": 44,
+                        "__main__.distort_value.distorted_value_a": 43,
+                        "__main__.distort_value.distorted_value_b": 45,
+                        "__main__.distort_value.loop_num": 36,
+                        "__main__.distort_value.range_check_ptr": 41,
+                        "__main__.distort_value.secondary_value": 35,
+                        "__main__.distort_value.value": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 46,
+                    "end_line": 75,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 67,
+                            "end_line": 27,
+                            "input_file": {
+                                "filename": "integration.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 47,
+                                    "end_line": 37,
+                                    "input_file": {
+                                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 78,
+                                            "end_line": 28,
+                                            "input_file": {
+                                                "filename": "integration.cairo"
+                                            },
+                                            "start_col": 29,
+                                            "start_line": 28
+                                        },
+                                        "While trying to retrieve the implicit argument 'bitwise_ptr' in:"
+                                    ],
+                                    "start_col": 18,
+                                    "start_line": 37
+                                },
+                                "While expanding the reference 'bitwise_ptr' in:"
+                            ],
+                            "start_col": 31,
+                            "start_line": 27
+                        },
+                        "While trying to update the implicit return value 'bitwise_ptr' in:"
+                    ],
+                    "start_col": 17,
+                    "start_line": 75
+                }
+            },
+            "57": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 17
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 39,
+                        "__main__.distort_value.__temp1": 40,
+                        "__main__.distort_value.bitwise_ptr": 44,
+                        "__main__.distort_value.distorted_value_a": 43,
+                        "__main__.distort_value.distorted_value_b": 45,
+                        "__main__.distort_value.loop_num": 36,
+                        "__main__.distort_value.range_check_ptr": 41,
+                        "__main__.distort_value.secondary_value": 35,
+                        "__main__.distort_value.value": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 27,
+                    "end_line": 26,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 58,
+                            "end_line": 28,
+                            "input_file": {
+                                "filename": "integration.cairo"
+                            },
+                            "start_col": 41,
+                            "start_line": 28
+                        },
+                        "While expanding the reference 'distorted_value_a' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 26
+                }
+            },
+            "58": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 18
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 39,
+                        "__main__.distort_value.__temp1": 40,
+                        "__main__.distort_value.bitwise_ptr": 44,
+                        "__main__.distort_value.distorted_value_a": 43,
+                        "__main__.distort_value.distorted_value_b": 45,
+                        "__main__.distort_value.loop_num": 36,
+                        "__main__.distort_value.range_check_ptr": 41,
+                        "__main__.distort_value.secondary_value": 35,
+                        "__main__.distort_value.value": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 27,
+                    "end_line": 27,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 77,
+                            "end_line": 28,
+                            "input_file": {
+                                "filename": "integration.cairo"
+                            },
+                            "start_col": 60,
+                            "start_line": 28
+                        },
+                        "While expanding the reference 'distorted_value_b' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 27
+                }
+            },
+            "59": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 19
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 39,
+                        "__main__.distort_value.__temp1": 40,
+                        "__main__.distort_value.bitwise_ptr": 44,
+                        "__main__.distort_value.distorted_value_a": 43,
+                        "__main__.distort_value.distorted_value_b": 45,
+                        "__main__.distort_value.loop_num": 36,
+                        "__main__.distort_value.range_check_ptr": 41,
+                        "__main__.distort_value.secondary_value": 35,
+                        "__main__.distort_value.value": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 78,
+                    "end_line": 28,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "start_col": 29,
+                    "start_line": 28
+                }
+            },
+            "61": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 23
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 39,
+                        "__main__.distort_value.__temp1": 40,
+                        "__main__.distort_value.bitwise_ptr": 46,
+                        "__main__.distort_value.distorted_value": 47,
+                        "__main__.distort_value.distorted_value_a": 43,
+                        "__main__.distort_value.distorted_value_b": 45,
+                        "__main__.distort_value.loop_num": 36,
+                        "__main__.distort_value.range_check_ptr": 41,
+                        "__main__.distort_value.secondary_value": 35,
+                        "__main__.distort_value.value": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 46,
+                    "end_line": 24,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 41,
+                            "end_line": 16,
+                            "input_file": {
+                                "filename": "integration.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 75,
+                                    "end_line": 30,
+                                    "input_file": {
+                                        "filename": "integration.cairo"
+                                    },
+                                    "start_col": 12,
+                                    "start_line": 30
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 20,
+                            "start_line": 16
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 27,
+                    "start_line": 24
+                }
+            },
+            "63": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 24
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 39,
+                        "__main__.distort_value.__temp1": 40,
+                        "__main__.distort_value.bitwise_ptr": 46,
+                        "__main__.distort_value.distorted_value": 47,
+                        "__main__.distort_value.distorted_value_a": 43,
+                        "__main__.distort_value.distorted_value_b": 45,
+                        "__main__.distort_value.loop_num": 36,
+                        "__main__.distort_value.range_check_ptr": 41,
+                        "__main__.distort_value.secondary_value": 35,
+                        "__main__.distort_value.value": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 47,
+                    "end_line": 37,
+                    "input_file": {
+                        "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/bitwise.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 78,
+                            "end_line": 28,
+                            "input_file": {
+                                "filename": "integration.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 71,
+                                    "end_line": 16,
+                                    "input_file": {
+                                        "filename": "integration.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 75,
+                                            "end_line": 30,
+                                            "input_file": {
+                                                "filename": "integration.cairo"
+                                            },
+                                            "start_col": 12,
+                                            "start_line": 30
+                                        },
+                                        "While trying to retrieve the implicit argument 'bitwise_ptr' in:"
+                                    ],
+                                    "start_col": 43,
+                                    "start_line": 16
+                                },
+                                "While expanding the reference 'bitwise_ptr' in:"
+                            ],
+                            "start_col": 29,
+                            "start_line": 28
+                        },
+                        "While trying to update the implicit return value 'bitwise_ptr' in:"
+                    ],
+                    "start_col": 18,
+                    "start_line": 37
+                }
+            },
+            "64": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 25
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 39,
+                        "__main__.distort_value.__temp1": 40,
+                        "__main__.distort_value.bitwise_ptr": 46,
+                        "__main__.distort_value.distorted_value": 47,
+                        "__main__.distort_value.distorted_value_a": 43,
+                        "__main__.distort_value.distorted_value_b": 45,
+                        "__main__.distort_value.loop_num": 36,
+                        "__main__.distort_value.range_check_ptr": 41,
+                        "__main__.distort_value.secondary_value": 35,
+                        "__main__.distort_value.value": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 25,
+                    "end_line": 28,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 41,
+                            "end_line": 30,
+                            "input_file": {
+                                "filename": "integration.cairo"
+                            },
+                            "start_col": 26,
+                            "start_line": 30
+                        },
+                        "While expanding the reference 'distorted_value' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 28
+                }
+            },
+            "65": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 26
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 39,
+                        "__main__.distort_value.__temp1": 40,
+                        "__main__.distort_value.bitwise_ptr": 46,
+                        "__main__.distort_value.distorted_value": 47,
+                        "__main__.distort_value.distorted_value_a": 43,
+                        "__main__.distort_value.distorted_value_b": 45,
+                        "__main__.distort_value.loop_num": 36,
+                        "__main__.distort_value.range_check_ptr": 41,
+                        "__main__.distort_value.secondary_value": 35,
+                        "__main__.distort_value.value": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 60,
+                    "end_line": 30,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "start_col": 43,
+                    "start_line": 30
+                }
+            },
+            "67": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 27
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 39,
+                        "__main__.distort_value.__temp1": 40,
+                        "__main__.distort_value.bitwise_ptr": 46,
+                        "__main__.distort_value.distorted_value": 47,
+                        "__main__.distort_value.distorted_value_a": 43,
+                        "__main__.distort_value.distorted_value_b": 45,
+                        "__main__.distort_value.loop_num": 36,
+                        "__main__.distort_value.range_check_ptr": 41,
+                        "__main__.distort_value.secondary_value": 35,
+                        "__main__.distort_value.value": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 74,
+                    "end_line": 30,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "start_col": 62,
+                    "start_line": 30
+                }
+            },
+            "69": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 28
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 39,
+                        "__main__.distort_value.__temp1": 40,
+                        "__main__.distort_value.bitwise_ptr": 46,
+                        "__main__.distort_value.distorted_value": 47,
+                        "__main__.distort_value.distorted_value_a": 43,
+                        "__main__.distort_value.distorted_value_b": 45,
+                        "__main__.distort_value.loop_num": 36,
+                        "__main__.distort_value.range_check_ptr": 41,
+                        "__main__.distort_value.secondary_value": 35,
+                        "__main__.distort_value.value": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 75,
+                    "end_line": 30,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "start_col": 12,
+                    "start_line": 30
+                }
+            },
+            "71": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.distort_value"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 7,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.distort_value.__temp0": 39,
+                        "__main__.distort_value.__temp1": 40,
+                        "__main__.distort_value.bitwise_ptr": 49,
+                        "__main__.distort_value.distorted_value": 47,
+                        "__main__.distort_value.distorted_value_a": 43,
+                        "__main__.distort_value.distorted_value_b": 45,
+                        "__main__.distort_value.loop_num": 36,
+                        "__main__.distort_value.range_check_ptr": 48,
+                        "__main__.distort_value.secondary_value": 35,
+                        "__main__.distort_value.value": 34
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 75,
+                    "end_line": 30,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 30
+                }
+            },
+            "72": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 53,
+                        "__main__.main.num_a": 54,
+                        "__main__.main.num_b": 55,
+                        "__main__.main.output_ptr": 50,
+                        "__main__.main.pedersen_ptr": 51,
+                        "__main__.main.range_check_ptr": 52
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 79,
+                    "end_line": 33,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 41,
+                            "end_line": 16,
+                            "input_file": {
+                                "filename": "integration.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 65,
+                                    "end_line": 36,
+                                    "input_file": {
+                                        "filename": "integration.cairo"
+                                    },
+                                    "start_col": 29,
+                                    "start_line": 36
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 20,
+                            "start_line": 16
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 58,
+                    "start_line": 33
+                }
+            },
+            "73": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 53,
+                        "__main__.main.num_a": 54,
+                        "__main__.main.num_b": 55,
+                        "__main__.main.output_ptr": 50,
+                        "__main__.main.pedersen_ptr": 51,
+                        "__main__.main.range_check_ptr": 52
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 109,
+                    "end_line": 33,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 71,
+                            "end_line": 16,
+                            "input_file": {
+                                "filename": "integration.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 65,
+                                    "end_line": 36,
+                                    "input_file": {
+                                        "filename": "integration.cairo"
+                                    },
+                                    "start_col": 29,
+                                    "start_line": 36
+                                },
+                                "While trying to retrieve the implicit argument 'bitwise_ptr' in:"
+                            ],
+                            "start_col": 43,
+                            "start_line": 16
+                        },
+                        "While expanding the reference 'bitwise_ptr' in:"
+                    ],
+                    "start_col": 81,
+                    "start_line": 33
+                }
+            },
+            "74": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 53,
+                        "__main__.main.num_a": 54,
+                        "__main__.main.num_b": 55,
+                        "__main__.main.output_ptr": 50,
+                        "__main__.main.pedersen_ptr": 51,
+                        "__main__.main.range_check_ptr": 52
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 24,
+                    "end_line": 35,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 48,
+                            "end_line": 36,
+                            "input_file": {
+                                "filename": "integration.cairo"
+                            },
+                            "start_col": 43,
+                            "start_line": 36
+                        },
+                        "While expanding the reference 'num_b' in:"
+                    ],
+                    "start_col": 17,
+                    "start_line": 35
+                }
+            },
+            "76": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 53,
+                        "__main__.main.num_a": 54,
+                        "__main__.main.num_b": 55,
+                        "__main__.main.output_ptr": 50,
+                        "__main__.main.pedersen_ptr": 51,
+                        "__main__.main.range_check_ptr": 52
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 60,
+                    "end_line": 36,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "start_col": 50,
+                    "start_line": 36
+                }
+            },
+            "78": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 53,
+                        "__main__.main.num_a": 54,
+                        "__main__.main.num_b": 55,
+                        "__main__.main.output_ptr": 50,
+                        "__main__.main.pedersen_ptr": 51,
+                        "__main__.main.range_check_ptr": 52
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 64,
+                    "end_line": 36,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "start_col": 62,
+                    "start_line": 36
+                }
+            },
+            "80": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 53,
+                        "__main__.main.num_a": 54,
+                        "__main__.main.num_b": 55,
+                        "__main__.main.output_ptr": 50,
+                        "__main__.main.pedersen_ptr": 51,
+                        "__main__.main.range_check_ptr": 52
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 65,
+                    "end_line": 36,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "start_col": 29,
+                    "start_line": 36
+                }
+            },
+            "82": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 57,
+                        "__main__.main.distorted_num_b": 58,
+                        "__main__.main.num_a": 54,
+                        "__main__.main.num_b": 55,
+                        "__main__.main.output_ptr": 50,
+                        "__main__.main.pedersen_ptr": 51,
+                        "__main__.main.range_check_ptr": 56
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 56,
+                    "end_line": 33,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 61,
+                            "end_line": 37,
+                            "input_file": {
+                                "filename": "integration.cairo"
+                            },
+                            "start_col": 49,
+                            "start_line": 37
+                        },
+                        "While expanding the reference 'pedersen_ptr' in:"
+                    ],
+                    "start_col": 30,
+                    "start_line": 33
+                }
+            },
+            "83": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 57,
+                        "__main__.main.distorted_num_b": 58,
+                        "__main__.main.num_a": 54,
+                        "__main__.main.num_b": 55,
+                        "__main__.main.output_ptr": 50,
+                        "__main__.main.pedersen_ptr": 51,
+                        "__main__.main.range_check_ptr": 56
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 23,
+                    "end_line": 34,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 68,
+                            "end_line": 37,
+                            "input_file": {
+                                "filename": "integration.cairo"
+                            },
+                            "start_col": 63,
+                            "start_line": 37
+                        },
+                        "While expanding the reference 'num_a' in:"
+                    ],
+                    "start_col": 17,
+                    "start_line": 34
+                }
+            },
+            "85": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 57,
+                        "__main__.main.distorted_num_b": 58,
+                        "__main__.main.num_a": 54,
+                        "__main__.main.num_b": 55,
+                        "__main__.main.output_ptr": 50,
+                        "__main__.main.pedersen_ptr": 51,
+                        "__main__.main.range_check_ptr": 56
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 25,
+                    "end_line": 36,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 85,
+                            "end_line": 37,
+                            "input_file": {
+                                "filename": "integration.cairo"
+                            },
+                            "start_col": 70,
+                            "start_line": 37
+                        },
+                        "While expanding the reference 'distorted_num_b' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 36
+                }
+            },
+            "86": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 57,
+                        "__main__.main.distorted_num_b": 58,
+                        "__main__.main.num_a": 54,
+                        "__main__.main.num_b": 55,
+                        "__main__.main.output_ptr": 50,
+                        "__main__.main.pedersen_ptr": 51,
+                        "__main__.main.range_check_ptr": 56
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 86,
+                    "end_line": 37,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "start_col": 40,
+                    "start_line": 37
+                }
+            },
+            "88": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 12
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 57,
+                        "__main__.main.distorted_num_b": 58,
+                        "__main__.main.num_a": 54,
+                        "__main__.main.num_b": 55,
+                        "__main__.main.output_ptr": 50,
+                        "__main__.main.pedersen_ptr": 59,
+                        "__main__.main.range_check_ptr": 56,
+                        "__main__.main.result": 60
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 97,
+                    "end_line": 38,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 38
+                }
+            },
+            "90": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 12
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 57,
+                        "__main__.main.distorted_num_b": 58,
+                        "__main__.main.num_a": 54,
+                        "__main__.main.num_b": 55,
+                        "__main__.main.output_ptr": 50,
+                        "__main__.main.pedersen_ptr": 59,
+                        "__main__.main.range_check_ptr": 56,
+                        "__main__.main.result": 60
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 28,
+                    "end_line": 33,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 39,
+                            "end_line": 2,
+                            "input_file": {
+                                "filename": "/opt/homebrew/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 27,
+                                    "end_line": 39,
+                                    "input_file": {
+                                        "filename": "integration.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 39
+                                },
+                                "While trying to retrieve the implicit argument 'output_ptr' in:"
+                            ],
+                            "start_col": 21,
+                            "start_line": 2
+                        },
+                        "While expanding the reference 'output_ptr' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 33
+                }
+            },
+            "91": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 13
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 57,
+                        "__main__.main.distorted_num_b": 58,
+                        "__main__.main.num_a": 54,
+                        "__main__.main.num_b": 55,
+                        "__main__.main.output_ptr": 50,
+                        "__main__.main.pedersen_ptr": 59,
+                        "__main__.main.range_check_ptr": 56,
+                        "__main__.main.result": 60
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 36,
+                    "end_line": 37,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 26,
+                            "end_line": 39,
+                            "input_file": {
+                                "filename": "integration.cairo"
+                            },
+                            "start_col": 20,
+                            "start_line": 39
+                        },
+                        "While expanding the reference 'result' in:"
+                    ],
+                    "start_col": 24,
+                    "start_line": 37
+                }
+            },
+            "92": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 14
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 57,
+                        "__main__.main.distorted_num_b": 58,
+                        "__main__.main.num_a": 54,
+                        "__main__.main.num_b": 55,
+                        "__main__.main.output_ptr": 50,
+                        "__main__.main.pedersen_ptr": 59,
+                        "__main__.main.range_check_ptr": 56,
+                        "__main__.main.result": 60
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 27,
+                    "end_line": 39,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 39
+                }
+            },
+            "94": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 17
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 57,
+                        "__main__.main.distorted_num_b": 58,
+                        "__main__.main.num_a": 54,
+                        "__main__.main.num_b": 55,
+                        "__main__.main.output_ptr": 61,
+                        "__main__.main.pedersen_ptr": 59,
+                        "__main__.main.range_check_ptr": 56,
+                        "__main__.main.result": 60
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 22,
+                    "end_line": 37,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 56,
+                            "end_line": 33,
+                            "input_file": {
+                                "filename": "integration.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 13,
+                                    "end_line": 40,
+                                    "input_file": {
+                                        "filename": "integration.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 40
+                                },
+                                "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                            ],
+                            "start_col": 30,
+                            "start_line": 33
+                        },
+                        "While expanding the reference 'pedersen_ptr' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 37
+                }
+            },
+            "95": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 18
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 57,
+                        "__main__.main.distorted_num_b": 58,
+                        "__main__.main.num_a": 54,
+                        "__main__.main.num_b": 55,
+                        "__main__.main.output_ptr": 61,
+                        "__main__.main.pedersen_ptr": 59,
+                        "__main__.main.range_check_ptr": 56,
+                        "__main__.main.result": 60
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 41,
+                    "end_line": 16,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 65,
+                            "end_line": 36,
+                            "input_file": {
+                                "filename": "integration.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 79,
+                                    "end_line": 33,
+                                    "input_file": {
+                                        "filename": "integration.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 13,
+                                            "end_line": 40,
+                                            "input_file": {
+                                                "filename": "integration.cairo"
+                                            },
+                                            "start_col": 5,
+                                            "start_line": 40
+                                        },
+                                        "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                    ],
+                                    "start_col": 58,
+                                    "start_line": 33
+                                },
+                                "While expanding the reference 'range_check_ptr' in:"
+                            ],
+                            "start_col": 29,
+                            "start_line": 36
+                        },
+                        "While trying to update the implicit return value 'range_check_ptr' in:"
+                    ],
+                    "start_col": 20,
+                    "start_line": 16
+                }
+            },
+            "96": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 19
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 57,
+                        "__main__.main.distorted_num_b": 58,
+                        "__main__.main.num_a": 54,
+                        "__main__.main.num_b": 55,
+                        "__main__.main.output_ptr": 61,
+                        "__main__.main.pedersen_ptr": 59,
+                        "__main__.main.range_check_ptr": 56,
+                        "__main__.main.result": 60
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 71,
+                    "end_line": 16,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 65,
+                            "end_line": 36,
+                            "input_file": {
+                                "filename": "integration.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 109,
+                                    "end_line": 33,
+                                    "input_file": {
+                                        "filename": "integration.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 13,
+                                            "end_line": 40,
+                                            "input_file": {
+                                                "filename": "integration.cairo"
+                                            },
+                                            "start_col": 5,
+                                            "start_line": 40
+                                        },
+                                        "While trying to retrieve the implicit argument 'bitwise_ptr' in:"
+                                    ],
+                                    "start_col": 81,
+                                    "start_line": 33
+                                },
+                                "While expanding the reference 'bitwise_ptr' in:"
+                            ],
+                            "start_col": 29,
+                            "start_line": 36
+                        },
+                        "While trying to update the implicit return value 'bitwise_ptr' in:"
+                    ],
+                    "start_col": 43,
+                    "start_line": 16
+                }
+            },
+            "97": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 20
+                    },
+                    "reference_ids": {
+                        "__main__.main.bitwise_ptr": 57,
+                        "__main__.main.distorted_num_b": 58,
+                        "__main__.main.num_a": 54,
+                        "__main__.main.num_b": 55,
+                        "__main__.main.output_ptr": 61,
+                        "__main__.main.pedersen_ptr": 59,
+                        "__main__.main.range_check_ptr": 56,
+                        "__main__.main.result": 60
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 13,
+                    "end_line": 40,
+                    "input_file": {
+                        "filename": "integration.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 40
+                }
+            }
+        }
+    },
+    "hints": {},
+    "identifiers": {
+        "__main__.BitwiseBuiltin": {
+            "destination": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+            "type": "alias"
+        },
+        "__main__.HashBuiltin": {
+            "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+            "type": "alias"
+        },
+        "__main__.bitwise_and": {
+            "destination": "starkware.cairo.common.bitwise.bitwise_and",
+            "type": "alias"
+        },
+        "__main__.bitwise_or": {
+            "destination": "starkware.cairo.common.bitwise.bitwise_or",
+            "type": "alias"
+        },
+        "__main__.bitwise_xor": {
+            "destination": "starkware.cairo.common.bitwise.bitwise_xor",
+            "type": "alias"
+        },
+        "__main__.distort_value": {
+            "decorators": [],
+            "pc": 34,
+            "type": "function"
+        },
+        "__main__.distort_value.Args": {
+            "full_name": "__main__.distort_value.Args",
+            "members": {
+                "loop_num": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                },
+                "secondary_value": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                },
+                "value": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 3,
+            "type": "struct"
+        },
+        "__main__.distort_value.ImplicitArgs": {
+            "full_name": "__main__.distort_value.ImplicitArgs",
+            "members": {
+                "bitwise_ptr": {
+                    "cairo_type": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin*",
+                    "offset": 1
+                },
+                "range_check_ptr": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "__main__.distort_value.Return": {
+            "cairo_type": "(r : felt)",
+            "type": "type_definition"
+        },
+        "__main__.distort_value.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.distort_value.__temp0": {
+            "cairo_type": "felt",
+            "full_name": "__main__.distort_value.__temp0",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 1
+                    },
+                    "pc": 43,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.distort_value.__temp1": {
+            "cairo_type": "felt",
+            "full_name": "__main__.distort_value.__temp1",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 2
+                    },
+                    "pc": 44,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.distort_value.bitwise_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin*",
+            "full_name": "__main__.distort_value.bitwise_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 0
+                    },
+                    "pc": 34,
+                    "value": "[cast(fp + (-6), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 9
+                    },
+                    "pc": 50,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 16
+                    },
+                    "pc": 56,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 23
+                    },
+                    "pc": 61,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 7,
+                        "offset": 0
+                    },
+                    "pc": 71,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.distort_value.distorted_value": {
+            "cairo_type": "felt",
+            "full_name": "__main__.distort_value.distorted_value",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 23
+                    },
+                    "pc": 61,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.distort_value.distorted_value_a": {
+            "cairo_type": "felt",
+            "full_name": "__main__.distort_value.distorted_value_a",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 9
+                    },
+                    "pc": 50,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.distort_value.distorted_value_b": {
+            "cairo_type": "felt",
+            "full_name": "__main__.distort_value.distorted_value_b",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 16
+                    },
+                    "pc": 56,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.distort_value.loop_num": {
+            "cairo_type": "felt",
+            "full_name": "__main__.distort_value.loop_num",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 0
+                    },
+                    "pc": 34,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.distort_value.range_check_ptr": {
+            "cairo_type": "felt",
+            "full_name": "__main__.distort_value.range_check_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 0
+                    },
+                    "pc": 34,
+                    "value": "[cast(fp + (-7), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 2
+                    },
+                    "pc": 45,
+                    "value": "cast([fp + (-7)] + 2, felt)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 7,
+                        "offset": 0
+                    },
+                    "pc": 71,
+                    "value": "[cast(ap + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.distort_value.secondary_value": {
+            "cairo_type": "felt",
+            "full_name": "__main__.distort_value.secondary_value",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 0
+                    },
+                    "pc": 34,
+                    "value": "[cast(fp + (-4), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.distort_value.value": {
+            "cairo_type": "felt",
+            "full_name": "__main__.distort_value.value",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 0
+                    },
+                    "pc": 34,
+                    "value": "[cast(fp + (-5), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.get_hash": {
+            "decorators": [],
+            "pc": 28,
+            "type": "function"
+        },
+        "__main__.get_hash.Args": {
+            "full_name": "__main__.get_hash.Args",
+            "members": {
+                "hash_ptr": {
+                    "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                    "offset": 0
+                },
+                "num_a": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                },
+                "num_b": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                }
+            },
+            "size": 3,
+            "type": "struct"
+        },
+        "__main__.get_hash.ImplicitArgs": {
+            "full_name": "__main__.get_hash.ImplicitArgs",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.get_hash.Return": {
+            "cairo_type": "(hash_ptr : starkware.cairo.common.cairo_builtins.HashBuiltin*, r : felt)",
+            "type": "type_definition"
+        },
+        "__main__.get_hash.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.get_hash.hash_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "full_name": "__main__.get_hash.hash_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 0
+                    },
+                    "pc": 28,
+                    "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 7
+                    },
+                    "pc": 33,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.get_hash.num_a": {
+            "cairo_type": "felt",
+            "full_name": "__main__.get_hash.num_a",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 0
+                    },
+                    "pc": 28,
+                    "value": "[cast(fp + (-4), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.get_hash.num_b": {
+            "cairo_type": "felt",
+            "full_name": "__main__.get_hash.num_b",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 0
+                    },
+                    "pc": 28,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.get_hash.result": {
+            "cairo_type": "felt",
+            "full_name": "__main__.get_hash.result",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 7
+                    },
+                    "pc": 33,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.hash2": {
+            "destination": "starkware.cairo.common.hash.hash2",
+            "type": "alias"
+        },
+        "__main__.main": {
+            "decorators": [],
+            "pc": 72,
+            "type": "function"
+        },
+        "__main__.main.Args": {
+            "full_name": "__main__.main.Args",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.ImplicitArgs": {
+            "full_name": "__main__.main.ImplicitArgs",
+            "members": {
+                "bitwise_ptr": {
+                    "cairo_type": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin*",
+                    "offset": 3
+                },
+                "output_ptr": {
+                    "cairo_type": "felt*",
+                    "offset": 0
+                },
+                "pedersen_ptr": {
+                    "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                    "offset": 1
+                },
+                "range_check_ptr": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                }
+            },
+            "size": 4,
+            "type": "struct"
+        },
+        "__main__.main.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "__main__.main.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.main.bitwise_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin*",
+            "full_name": "__main__.main.bitwise_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 0
+                    },
+                    "pc": 72,
+                    "value": "[cast(fp + (-3), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 0
+                    },
+                    "pc": 82,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.distorted_num_b": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.distorted_num_b",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 0
+                    },
+                    "pc": 82,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.num_a": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.num_a",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 0
+                    },
+                    "pc": 72,
+                    "value": "cast(123568, felt)"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.num_b": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.num_b",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 0
+                    },
+                    "pc": 72,
+                    "value": "cast(5673940, felt)"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.output_ptr": {
+            "cairo_type": "felt*",
+            "full_name": "__main__.main.output_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 0
+                    },
+                    "pc": 72,
+                    "value": "[cast(fp + (-6), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 17
+                    },
+                    "pc": 94,
+                    "value": "[cast(ap + (-1), felt**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "full_name": "__main__.main.pedersen_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 0
+                    },
+                    "pc": 72,
+                    "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 12
+                    },
+                    "pc": 88,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.range_check_ptr": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.range_check_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 0
+                    },
+                    "pc": 72,
+                    "value": "[cast(fp + (-4), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 0
+                    },
+                    "pc": 82,
+                    "value": "[cast(ap + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.result": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.result",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 12
+                    },
+                    "pc": 88,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.serialize_word": {
+            "destination": "starkware.cairo.common.serialize.serialize_word",
+            "type": "alias"
+        },
+        "starkware.cairo.common.bitwise.ALL_ONES": {
+            "type": "const",
+            "value": -106710729501573572985208420194530329073740042555888586719234
+        },
+        "starkware.cairo.common.bitwise.BitwiseBuiltin": {
+            "destination": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+            "type": "alias"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and": {
+            "decorators": [],
+            "pc": 6,
+            "type": "function"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.Args": {
+            "full_name": "starkware.cairo.common.bitwise.bitwise_and.Args",
+            "members": {
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.bitwise.bitwise_and.ImplicitArgs",
+            "members": {
+                "bitwise_ptr": {
+                    "cairo_type": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.Return": {
+            "cairo_type": "(x_and_y : felt)",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.bitwise_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin*",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_and.bitwise_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 6,
+                    "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 8,
+                    "value": "cast([fp + (-5)] + 5, starkware.cairo.common.cairo_builtins.BitwiseBuiltin*)"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.x": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_and.x",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 6,
+                    "value": "[cast(fp + (-4), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.x_and_y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_and.x_and_y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 8,
+                    "value": "[cast([fp + (-5)] + 2, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.x_or_y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_and.x_or_y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 8,
+                    "value": "[cast([fp + (-5)] + 4, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.x_xor_y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_and.x_xor_y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 8,
+                    "value": "[cast([fp + (-5)] + 3, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_and.y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_and.y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 6,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_or": {
+            "decorators": [],
+            "pc": 18,
+            "type": "function"
+        },
+        "starkware.cairo.common.bitwise.bitwise_or.Args": {
+            "full_name": "starkware.cairo.common.bitwise.bitwise_or.Args",
+            "members": {
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.bitwise.bitwise_or.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.bitwise.bitwise_or.ImplicitArgs",
+            "members": {
+                "bitwise_ptr": {
+                    "cairo_type": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.bitwise.bitwise_or.Return": {
+            "cairo_type": "(x_or_y : felt)",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.bitwise.bitwise_or.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.bitwise.bitwise_or.bitwise_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin*",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_or.bitwise_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "pc": 18,
+                    "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "pc": 20,
+                    "value": "cast([fp + (-5)] + 5, starkware.cairo.common.cairo_builtins.BitwiseBuiltin*)"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_or.x": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_or.x",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "pc": 18,
+                    "value": "[cast(fp + (-4), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_or.x_and_y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_or.x_and_y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "pc": 20,
+                    "value": "[cast([fp + (-5)] + 2, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_or.x_or_y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_or.x_or_y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "pc": 20,
+                    "value": "[cast([fp + (-5)] + 4, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_or.x_xor_y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_or.x_xor_y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "pc": 20,
+                    "value": "[cast([fp + (-5)] + 3, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_or.y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_or.y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "pc": 18,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_xor": {
+            "decorators": [],
+            "pc": 12,
+            "type": "function"
+        },
+        "starkware.cairo.common.bitwise.bitwise_xor.Args": {
+            "full_name": "starkware.cairo.common.bitwise.bitwise_xor.Args",
+            "members": {
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.bitwise.bitwise_xor.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.bitwise.bitwise_xor.ImplicitArgs",
+            "members": {
+                "bitwise_ptr": {
+                    "cairo_type": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.bitwise.bitwise_xor.Return": {
+            "cairo_type": "(x_xor_y : felt)",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.bitwise.bitwise_xor.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.bitwise.bitwise_xor.bitwise_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin*",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_xor.bitwise_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 12,
+                    "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 14,
+                    "value": "cast([fp + (-5)] + 5, starkware.cairo.common.cairo_builtins.BitwiseBuiltin*)"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_xor.x": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_xor.x",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 12,
+                    "value": "[cast(fp + (-4), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_xor.x_and_y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_xor.x_and_y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 14,
+                    "value": "[cast([fp + (-5)] + 2, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_xor.x_or_y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_xor.x_or_y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 14,
+                    "value": "[cast([fp + (-5)] + 4, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_xor.x_xor_y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_xor.x_xor_y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 14,
+                    "value": "[cast([fp + (-5)] + 3, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bitwise.bitwise_xor.y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.bitwise.bitwise_xor.y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 12,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.cairo_builtins.BitwiseBuiltin": {
+            "full_name": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+            "members": {
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "x_and_y": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                },
+                "x_or_y": {
+                    "cairo_type": "felt",
+                    "offset": 4
+                },
+                "x_xor_y": {
+                    "cairo_type": "felt",
+                    "offset": 3
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 5,
+            "type": "struct"
+        },
+        "starkware.cairo.common.cairo_builtins.EcOpBuiltin": {
+            "full_name": "starkware.cairo.common.cairo_builtins.EcOpBuiltin",
+            "members": {
+                "m": {
+                    "cairo_type": "felt",
+                    "offset": 4
+                },
+                "p": {
+                    "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+                    "offset": 0
+                },
+                "q": {
+                    "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+                    "offset": 2
+                },
+                "r": {
+                    "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+                    "offset": 5
+                }
+            },
+            "size": 7,
+            "type": "struct"
+        },
+        "starkware.cairo.common.cairo_builtins.EcPoint": {
+            "destination": "starkware.cairo.common.ec_point.EcPoint",
+            "type": "alias"
+        },
+        "starkware.cairo.common.cairo_builtins.HashBuiltin": {
+            "full_name": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+            "members": {
+                "result": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                },
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 3,
+            "type": "struct"
+        },
+        "starkware.cairo.common.cairo_builtins.SignatureBuiltin": {
+            "full_name": "starkware.cairo.common.cairo_builtins.SignatureBuiltin",
+            "members": {
+                "message": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                },
+                "pub_key": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.ec_point.EcPoint": {
+            "full_name": "starkware.cairo.common.ec_point.EcPoint",
+            "members": {
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.hash.HashBuiltin": {
+            "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+            "type": "alias"
+        },
+        "starkware.cairo.common.hash.hash2": {
+            "decorators": [],
+            "pc": 0,
+            "type": "function"
+        },
+        "starkware.cairo.common.hash.hash2.Args": {
+            "full_name": "starkware.cairo.common.hash.hash2.Args",
+            "members": {
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.hash.hash2.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.hash.hash2.ImplicitArgs",
+            "members": {
+                "hash_ptr": {
+                    "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.hash.hash2.Return": {
+            "cairo_type": "(result : felt)",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.hash.hash2.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.hash.hash2.hash_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "full_name": "starkware.cairo.common.hash.hash2.hash_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 2,
+                    "value": "cast([fp + (-5)] + 3, starkware.cairo.common.cairo_builtins.HashBuiltin*)"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash.hash2.result": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.hash.hash2.result",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 2,
+                    "value": "[cast([fp + (-5)] + 2, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash.hash2.x": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.hash.hash2.x",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "[cast(fp + (-4), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash.hash2.y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.hash.hash2.y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.serialize.serialize_word": {
+            "decorators": [],
+            "pc": 24,
+            "type": "function"
+        },
+        "starkware.cairo.common.serialize.serialize_word.Args": {
+            "full_name": "starkware.cairo.common.serialize.serialize_word.Args",
+            "members": {
+                "word": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.serialize.serialize_word.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.serialize.serialize_word.ImplicitArgs",
+            "members": {
+                "output_ptr": {
+                    "cairo_type": "felt*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.serialize.serialize_word.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.serialize.serialize_word.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.serialize.serialize_word.output_ptr": {
+            "cairo_type": "felt*",
+            "full_name": "starkware.cairo.common.serialize.serialize_word.output_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 24,
+                    "value": "[cast(fp + (-4), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 25,
+                    "value": "cast([fp + (-4)] + 1, felt*)"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.serialize.serialize_word.word": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.serialize.serialize_word.word",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 24,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        }
+    },
+    "main_scope": "__main__",
+    "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+    "reference_manager": {
+        "references": [
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 0,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 0,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 0,
+                "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 2,
+                "value": "[cast([fp + (-5)] + 2, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 2,
+                "value": "cast([fp + (-5)] + 3, starkware.cairo.common.cairo_builtins.HashBuiltin*)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 6,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 6,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 6,
+                "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 8,
+                "value": "[cast([fp + (-5)] + 2, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 8,
+                "value": "[cast([fp + (-5)] + 3, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 8,
+                "value": "[cast([fp + (-5)] + 4, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 8,
+                "value": "cast([fp + (-5)] + 5, starkware.cairo.common.cairo_builtins.BitwiseBuiltin*)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 0
+                },
+                "pc": 12,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 0
+                },
+                "pc": 12,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 0
+                },
+                "pc": 12,
+                "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 0
+                },
+                "pc": 14,
+                "value": "[cast([fp + (-5)] + 2, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 0
+                },
+                "pc": 14,
+                "value": "[cast([fp + (-5)] + 3, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 0
+                },
+                "pc": 14,
+                "value": "[cast([fp + (-5)] + 4, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 0
+                },
+                "pc": 14,
+                "value": "cast([fp + (-5)] + 5, starkware.cairo.common.cairo_builtins.BitwiseBuiltin*)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 3,
+                    "offset": 0
+                },
+                "pc": 18,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 3,
+                    "offset": 0
+                },
+                "pc": 18,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 3,
+                    "offset": 0
+                },
+                "pc": 18,
+                "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 3,
+                    "offset": 0
+                },
+                "pc": 20,
+                "value": "[cast([fp + (-5)] + 2, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 3,
+                    "offset": 0
+                },
+                "pc": 20,
+                "value": "[cast([fp + (-5)] + 3, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 3,
+                    "offset": 0
+                },
+                "pc": 20,
+                "value": "[cast([fp + (-5)] + 4, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 3,
+                    "offset": 0
+                },
+                "pc": 20,
+                "value": "cast([fp + (-5)] + 5, starkware.cairo.common.cairo_builtins.BitwiseBuiltin*)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 0
+                },
+                "pc": 24,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 0
+                },
+                "pc": 24,
+                "value": "[cast(fp + (-4), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 0
+                },
+                "pc": 25,
+                "value": "cast([fp + (-4)] + 1, felt*)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 5,
+                    "offset": 0
+                },
+                "pc": 28,
+                "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 5,
+                    "offset": 0
+                },
+                "pc": 28,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 5,
+                    "offset": 0
+                },
+                "pc": 28,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 5,
+                    "offset": 7
+                },
+                "pc": 33,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 5,
+                    "offset": 7
+                },
+                "pc": 33,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 0
+                },
+                "pc": 34,
+                "value": "[cast(fp + (-5), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 0
+                },
+                "pc": 34,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 0
+                },
+                "pc": 34,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 0
+                },
+                "pc": 34,
+                "value": "[cast(fp + (-7), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 0
+                },
+                "pc": 34,
+                "value": "[cast(fp + (-6), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 1
+                },
+                "pc": 43,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 2
+                },
+                "pc": 44,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 2
+                },
+                "pc": 45,
+                "value": "cast([fp + (-7)] + 2, felt)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 9
+                },
+                "pc": 50,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 9
+                },
+                "pc": 50,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 16
+                },
+                "pc": 56,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 16
+                },
+                "pc": 56,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 23
+                },
+                "pc": 61,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 23
+                },
+                "pc": 61,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 7,
+                    "offset": 0
+                },
+                "pc": 71,
+                "value": "[cast(ap + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 7,
+                    "offset": 0
+                },
+                "pc": 71,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 0
+                },
+                "pc": 72,
+                "value": "[cast(fp + (-6), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 0
+                },
+                "pc": 72,
+                "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 0
+                },
+                "pc": 72,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 0
+                },
+                "pc": 72,
+                "value": "[cast(fp + (-3), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 0
+                },
+                "pc": 72,
+                "value": "cast(123568, felt)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 0
+                },
+                "pc": 72,
+                "value": "cast(5673940, felt)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 9,
+                    "offset": 0
+                },
+                "pc": 82,
+                "value": "[cast(ap + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 9,
+                    "offset": 0
+                },
+                "pc": 82,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 9,
+                    "offset": 0
+                },
+                "pc": 82,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 9,
+                    "offset": 12
+                },
+                "pc": 88,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 9,
+                    "offset": 12
+                },
+                "pc": 88,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 9,
+                    "offset": 17
+                },
+                "pc": 94,
+                "value": "[cast(ap + (-1), felt**)]"
+            }
+        ]
+    }
+}

--- a/tests/support/integration_with_alloc_locals.cairo
+++ b/tests/support/integration_with_alloc_locals.cairo
@@ -1,0 +1,42 @@
+%builtins output pedersen range_check bitwise
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.hash import hash2
+from starkware.cairo.common.bitwise import bitwise_and, bitwise_or, bitwise_xor
+from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
+from starkware.cairo.common.serialize import serialize_word
+
+func get_distorted_pedersen{hash_ptr: HashBuiltin*, bitwise_ptr: BitwiseBuiltin*}(num_a: felt, num_b: felt) -> (r: felt):
+    let num_y: felt = bitwise_xor(num_a, num_b)
+    let num_x: felt = bitwise_and(num_a, num_b)
+    let pedersen_result: felt = hash2(num_x, num_y)
+    return(pedersen_result)
+end 
+
+func distort_value{range_check_ptr: felt, bitwise_ptr: BitwiseBuiltin*}(value: felt, secondary_value: felt, loop_num: felt) -> (r: felt):
+    if loop_num == 0:
+        return (value)
+    end
+
+    # Check that 0 <= secondary_value < 2**64.
+    [range_check_ptr] = secondary_value
+    assert [range_check_ptr + 1] = 2 ** 64 - 1 - secondary_value
+    let range_check_ptr = range_check_ptr + 2
+
+    let distorted_value_a: felt = bitwise_xor(value, secondary_value)
+    let distorted_value_b: felt = bitwise_or(value, secondary_value/2)
+    let distorted_value: felt = bitwise_and(distorted_value_a, distorted_value_b)
+
+    return distort_value(distorted_value, secondary_value*3, loop_num - 1)
+end
+
+func main{output_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr: felt, bitwise_ptr: BitwiseBuiltin*}():
+    alloc_locals
+    let num_a = 99
+    let num_b = 105
+    let first_result: felt = get_distorted_pedersen{hash_ptr=pedersen_ptr}(num_a, num_b)
+    let final_result: felt = distort_value(first_result, 17896542, 10)
+    assert final_result = 1659553275753748707961758488122491333947144556174897006960881236685908158848
+    serialize_word(final_result)
+    return()
+end


### PR DESCRIPTION
What was changed in this PR:
- Add the following integration tests:
- bitwise + output
- bitwise recursion (bitwise + output + range_check)
- integration (bitwise + output + range_check + pedersen)
- Swap BTreeMap for Vec for builtin_runners 
- Fix inconsistent auto-deduction error being thrown when trying to verify None values (memory gaps)
- Add integration program to benchmarks
Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
