### PR TITLE
Remove panic! in vm_core.rs

### DIFF
--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -2,6 +2,7 @@ use num_bigint::BigInt;
 use std::fmt;
 
 use crate::types::relocatable::MaybeRelocatable;
+use crate::vm::errors::runner_errors::RunnerError;
 
 #[derive(Debug, PartialEq)]
 #[allow(dead_code)]
@@ -31,7 +32,7 @@ pub enum VirtualMachineError {
     NotImplemented,
     DiffIndexSub,
     InconsistentAutoDeduction(String, MaybeRelocatable, Option<MaybeRelocatable>),
-    NonRelocatableAddress,
+    RunnerError(RunnerError),
 }
 
 impl fmt::Display for VirtualMachineError {
@@ -83,8 +84,7 @@ impl fmt::Display for VirtualMachineError {
             VirtualMachineError::InconsistentAutoDeduction(builtin_name, expected_value, current_value) => {
                 write!(f, "Inconsistent auto-deduction for builtin {}, expected {:?}, got {:?}", builtin_name, expected_value, current_value)
             },
-            VirtualMachineError::NonRelocatableAddress => write!(f, "Memory addresses must be relocatable"),
-
+            VirtualMachineError::RunnerError(runner_error) => runner_error.fmt(f),
         }
     }
 }

--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -31,6 +31,7 @@ pub enum VirtualMachineError {
     NotImplemented,
     DiffIndexSub,
     InconsistentAutoDeduction(String, MaybeRelocatable, Option<MaybeRelocatable>),
+    NonRelocatableAddress,
 }
 
 impl fmt::Display for VirtualMachineError {
@@ -82,6 +83,8 @@ impl fmt::Display for VirtualMachineError {
             VirtualMachineError::InconsistentAutoDeduction(builtin_name, expected_value, current_value) => {
                 write!(f, "Inconsistent auto-deduction for builtin {}, expected {:?}, got {:?}", builtin_name, expected_value, current_value)
             },
+            VirtualMachineError::NonRelocatableAddress => write!(f, "Memory addresses must be relocatable"),
+
         }
     }
 }

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -3,6 +3,7 @@ use crate::types::instruction::{ApUpdate, FpUpdate, Instruction, Opcode, PcUpdat
 use crate::types::relocatable::MaybeRelocatable;
 use crate::vm::context::run_context::RunContext;
 use crate::vm::decoding::decoder::decode_instruction;
+use crate::vm::errors::runner_errors::RunnerError;
 use crate::vm::errors::vm_errors::VirtualMachineError;
 use crate::vm::runners::builtin_runner::BuiltinRunner;
 use crate::vm::trace::trace_entry::TraceEntry;
@@ -281,7 +282,7 @@ impl VirtualMachine {
                     if base.segment_index == addr.segment_index {
                         match builtin.deduce_memory_cell(address, &self.memory) {
                             Ok(maybe_reloc) => return Ok(maybe_reloc),
-                            Err(_error) => return Err(VirtualMachineError::NonRelocatableAddress),
+                            Err(error) => return Err(VirtualMachineError::RunnerError(error)),
                         };
                     }
                 }
@@ -289,7 +290,9 @@ impl VirtualMachine {
             return Ok(None);
         }
 
-        Err(VirtualMachineError::NonRelocatableAddress)
+        Err(VirtualMachineError::RunnerError(
+            RunnerError::NonRelocatableAddress,
+        ))
     }
 
     ///Computes the value of res if possible

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -271,18 +271,25 @@ impl VirtualMachine {
         Ok((None, None))
     }
 
-    fn deduce_memory_cell(&mut self, address: &MaybeRelocatable) -> Option<MaybeRelocatable> {
+    fn deduce_memory_cell(
+        &mut self,
+        address: &MaybeRelocatable,
+    ) -> Result<Option<MaybeRelocatable>, VirtualMachineError> {
         if let MaybeRelocatable::RelocatableValue(addr) = address {
             for (_, builtin) in self.builtin_runners.iter_mut() {
                 if let Some(base) = builtin.base() {
                     if base.segment_index == addr.segment_index {
-                        return builtin.deduce_memory_cell(address, &self.memory).unwrap();
+                        match builtin.deduce_memory_cell(address, &self.memory) {
+                            Ok(maybe_reloc) => return Ok(maybe_reloc),
+                            Err(_error) => return Err(VirtualMachineError::NonRelocatableAddress),
+                        };
                     }
                 }
             }
-            return None;
+            return Ok(None);
         }
-        panic!("Memory addresses must be relocatable");
+
+        Err(VirtualMachineError::NonRelocatableAddress)
     }
 
     ///Computes the value of res if possible
@@ -434,10 +441,10 @@ impl VirtualMachine {
         let should_update_op1 = matches!(op1, None);
 
         if matches!(op0, None) {
-            op0 = self.deduce_memory_cell(&op0_addr);
+            op0 = self.deduce_memory_cell(&op0_addr)?;
         }
         if matches!(op1, None) {
-            op1 = self.deduce_memory_cell(&op1_addr);
+            op1 = self.deduce_memory_cell(&op1_addr)?;
         }
 
         if matches!(op0, None) {
@@ -2608,7 +2615,10 @@ mod tests {
     #[test]
     fn deduce_memory_cell_no_pedersen_builtin() {
         let mut vm = VirtualMachine::new(bigint!(17), BTreeMap::new());
-        assert_eq!(vm.deduce_memory_cell(&MaybeRelocatable::from((0, 0))), None);
+        assert_eq!(
+            vm.deduce_memory_cell(&MaybeRelocatable::from((0, 0))),
+            Ok(None)
+        );
     }
 
     #[test]
@@ -2639,9 +2649,9 @@ mod tests {
             .unwrap();
         assert_eq!(
             vm.deduce_memory_cell(&MaybeRelocatable::from((0, 5))),
-            Some(MaybeRelocatable::from(bigint_str!(
+            Ok(Some(MaybeRelocatable::from(bigint_str!(
                 b"3270867057177188607814717243084834301278723532952411121381966378910183338911"
-            )))
+            ))))
         );
     }
 
@@ -2848,7 +2858,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             vm.deduce_memory_cell(&MaybeRelocatable::from((0, 7))),
-            Some(MaybeRelocatable::from(bigint!(8)))
+            Ok(Some(MaybeRelocatable::from(bigint!(8))))
         );
     }
 
@@ -3034,9 +3044,9 @@ mod tests {
         let result = vm.deduce_memory_cell(&MaybeRelocatable::from((0, 6)));
         assert_eq!(
             result,
-            Some(MaybeRelocatable::from(bigint_str!(
+            Ok(Some(MaybeRelocatable::from(bigint_str!(
                 b"3598390311618116577316045819420613574162151407434885460365915347732568210029"
-            )))
+            ))))
         );
     }
 


### PR DESCRIPTION
# Remove panic! in vm_core.rs

## Description
Issue: #130 
Remove the `panic!("Memory addresses must be relocatable")` in vm_core.rs and handle the error

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
