### PR TITLE
[CU-2z5j3jx] Remove unwraps in deserialize_program.rs, Handle ProgramErrors

### DIFF
--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -4,7 +4,7 @@ use std::io;
 use std::path::Path;
 
 pub fn cairo_run(path: &Path) {
-    let program = Program::new(path);
+    let program = Program::new(path).unwrap();
     let mut cairo_runner = CairoRunner::new(&program);
     cairo_runner.initialize_segments(None);
     let end = cairo_runner.initialize_main_entrypoint().unwrap();

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -1,4 +1,6 @@
-use crate::types::{program::Program, relocatable::MaybeRelocatable};
+use crate::types::{
+    errors::program_errors::ProgramError, program::Program, relocatable::MaybeRelocatable,
+};
 use num_bigint::{BigInt, Sign};
 use serde::{de, de::SeqAccess, Deserialize, Deserializer};
 use std::{collections::HashMap, fmt, fs::File, io::BufReader, ops::Rem, path::Path};
@@ -104,21 +106,23 @@ fn maybe_add_padding(mut hex: String) -> String {
     hex
 }
 
-pub fn deserialize_program_json(path: &Path) -> ProgramJson {
-    let file = File::open(path).unwrap();
+pub fn deserialize_program_json(path: &Path) -> Result<ProgramJson, ProgramError> {
+    let file = File::open(path)?;
     let mut reader = BufReader::new(file);
 
-    serde_json::from_reader(&mut reader).unwrap()
+    let program_json = serde_json::from_reader(&mut reader)?;
+
+    Ok(program_json)
 }
 
-pub fn deserialize_program(path: &Path) -> Program {
-    let program_json: ProgramJson = deserialize_program_json(path);
-    Program {
+pub fn deserialize_program(path: &Path) -> Result<Program, ProgramError> {
+    let program_json: ProgramJson = deserialize_program_json(path)?;
+    Ok(Program {
         builtins: program_json.builtins,
         prime: program_json.prime,
         data: program_json.data,
         main: program_json.identifiers["__main__.main"].pc,
-    }
+    })
 }
 
 #[cfg(test)]
@@ -271,7 +275,8 @@ mod tests {
 
     #[test]
     fn deserialize_program_test() {
-        let program: Program = deserialize_program(Path::new("tests/support/valid_program_a.json"));
+        let program: Program = deserialize_program(Path::new("tests/support/valid_program_a.json"))
+            .expect("Failed to deserialize program");
 
         let builtins: Vec<String> = Vec::new();
         let data: Vec<MaybeRelocatable> = vec![

--- a/src/types/errors/mod.rs
+++ b/src/types/errors/mod.rs
@@ -1,0 +1,1 @@
+pub mod program_errors;

--- a/src/types/errors/program_errors.rs
+++ b/src/types/errors/program_errors.rs
@@ -1,0 +1,19 @@
+use std::io;
+
+#[derive(Debug)]
+pub enum ProgramError {
+    IO(io::Error),
+    Parse(serde_json::Error),
+}
+
+impl From<serde_json::Error> for ProgramError {
+    fn from(err: serde_json::Error) -> Self {
+        ProgramError::Parse(err)
+    }
+}
+
+impl From<io::Error> for ProgramError {
+    fn from(err: io::Error) -> Self {
+        ProgramError::IO(err)
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,3 +1,4 @@
+pub mod errors;
 pub mod instruction;
 pub mod program;
 pub mod relocatable;

--- a/src/types/program.rs
+++ b/src/types/program.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use crate::serde::deserialize_program;
+use crate::types::errors::program_errors::ProgramError;
 use crate::types::relocatable::MaybeRelocatable;
 use num_bigint::BigInt;
 
@@ -13,7 +14,7 @@ pub struct Program {
 }
 
 impl Program {
-    pub fn new(path: &Path) -> Program {
+    pub fn new(path: &Path) -> Result<Program, ProgramError> {
         deserialize_program::deserialize_program(path)
     }
 }
@@ -25,7 +26,8 @@ mod tests {
 
     #[test]
     fn deserialize_program_test() {
-        let program: Program = Program::new(Path::new("tests/support/valid_program_a.json"));
+        let program: Program = Program::new(Path::new("tests/support/valid_program_a.json"))
+            .expect("Failed to deserialize program");
 
         let builtins: Vec<String> = Vec::new();
         let data: Vec<MaybeRelocatable> = vec![

--- a/tests/bitwise_test.rs
+++ b/tests/bitwise_test.rs
@@ -7,7 +7,8 @@ use cleopatra_cairo::{
 
 #[test]
 fn bitwise_integration_test() {
-    let program = Program::new(Path::new("tests/support/bitwise_builtin_test.json"));
+    let program = Program::new(Path::new("tests/support/bitwise_builtin_test.json"))
+        .expect("Failed to deserialize program");
     let mut cairo_runner = CairoRunner::new(&program);
     cairo_runner.initialize_segments(None);
     let end = cairo_runner.initialize_main_entrypoint().unwrap();

--- a/tests/pedersen_test.rs
+++ b/tests/pedersen_test.rs
@@ -7,7 +7,8 @@ use cleopatra_cairo::{
 
 #[test]
 fn pedersen_integration_test() {
-    let program = Program::new(Path::new("tests/support/pedersen_test.json"));
+    let program = Program::new(Path::new("tests/support/pedersen_test.json"))
+        .expect("Failed to deserialize program");
     let mut cairo_runner = CairoRunner::new(&program);
     cairo_runner.initialize_segments(None);
     let end = cairo_runner.initialize_main_entrypoint().unwrap();

--- a/tests/struct_test.rs
+++ b/tests/struct_test.rs
@@ -7,7 +7,8 @@ use cleopatra_cairo::{
 
 #[test]
 fn struct_integration_test() {
-    let program = Program::new(Path::new("tests/support/struct_compiled.json"));
+    let program = Program::new(Path::new("tests/support/struct_compiled.json"))
+        .expect("Failed to deserialize program");
     let mut cairo_runner = CairoRunner::new(&program);
     cairo_runner.initialize_segments(None);
     let end = cairo_runner.initialize_main_entrypoint().unwrap();


### PR DESCRIPTION
# Remove unwraps in deserialize_program.rs, Handle ProgramErrors

## Description
* Create Enum ProgramErrors to handle ProgramErrors.
* Remove unwraps in deserialize_program.rs.

Issue: #130 

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
