### PR TITLE
[CU-2yzxequ] Refactor unwraps from verify_auto_deductions in vm_core

### DIFF
--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -569,17 +569,17 @@ impl VirtualMachine {
                                     &self.memory,
                                 ) {
                                     Ok(None) => None,
-                                    Ok(Some(v)) => {
-                                        if Some(&v) != value.as_ref() {
+                                    Ok(Some(deduced_memory_cell)) => {
+                                        if Some(&deduced_memory_cell) != value.as_ref() {
                                             return Err(
                                                 VirtualMachineError::InconsistentAutoDeduction(
                                                     name.to_owned(),
-                                                    v,
+                                                    deduced_memory_cell,
                                                     value.to_owned(),
                                                 ),
                                             );
                                         }
-                                        Some(v)
+                                        Some(deduced_memory_cell)
                                     }
                                     _ => {
                                         return Err(VirtualMachineError::InvalidInstructionEncoding)

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -561,17 +561,33 @@ impl VirtualMachine {
         for (i, segment) in self.memory.data.iter().enumerate() {
             for (j, value) in segment.iter().enumerate() {
                 for (name, builtin) in self.builtin_runners.iter_mut() {
-                    if builtin.base().unwrap().segment_index == i {
-                        let deduced_value = builtin
-                            .deduce_memory_cell(&MaybeRelocatable::from((i, j)), &self.memory)
-                            .unwrap();
-                        if deduced_value != None && &deduced_value != value {
-                            return Err(VirtualMachineError::InconsistentAutoDeduction(
-                                name.to_owned(),
-                                deduced_value.unwrap(),
-                                value.to_owned(),
-                            ));
+                    match builtin.base() {
+                        Some(builtin_base) => {
+                            if builtin_base.segment_index == i {
+                                match builtin.deduce_memory_cell(
+                                    &MaybeRelocatable::from((i, j)),
+                                    &self.memory,
+                                ) {
+                                    Ok(None) => None,
+                                    Ok(Some(v)) => {
+                                        if Some(&v) != value.as_ref() {
+                                            return Err(
+                                                VirtualMachineError::InconsistentAutoDeduction(
+                                                    name.to_owned(),
+                                                    v,
+                                                    value.to_owned(),
+                                                ),
+                                            );
+                                        }
+                                        Some(v)
+                                    }
+                                    _ => {
+                                        return Err(VirtualMachineError::InvalidInstructionEncoding)
+                                    }
+                                };
+                            }
                         }
+                        _ => return Err(VirtualMachineError::InvalidInstructionEncoding),
                     }
                 }
             }


### PR DESCRIPTION
# Refactor unwraps from verify_auto_deductions in vm_core

## Description
There were some remaining `unwraps()` in the `verify_auto_deductions` function. This PR refactors them.
