### PR TITLE
Remove unwrap from relocate_value function

### DIFF
--- a/src/vm/errors/memory_errors.rs
+++ b/src/vm/errors/memory_errors.rs
@@ -10,6 +10,7 @@ pub enum MemoryError {
     FoundNonInt,
     InconsistentMemory(MaybeRelocatable, MaybeRelocatable, MaybeRelocatable),
     EffectiveSizesNotCalled,
+    Relocation,
 }
 
 impl fmt::Display for MemoryError {
@@ -39,6 +40,7 @@ impl fmt::Display for MemoryError {
                 f,
                 "compute_effective_sizes should be called before relocate_segments"
             ),
+            MemoryError::Relocation => write!(f, "Inconsistent Relocation"),
         }
     }
 }

--- a/src/vm/errors/trace_errors.rs
+++ b/src/vm/errors/trace_errors.rs
@@ -1,14 +1,17 @@
+use crate::vm::errors::memory_errors::MemoryError;
 use std::fmt;
 
 #[derive(Debug, PartialEq)]
 pub enum TraceError {
     RegNotRelocatable,
+    MemoryError(MemoryError),
 }
 
 impl fmt::Display for TraceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             TraceError::RegNotRelocatable => write!(f, "Trace register must be relocatable"),
+            TraceError::MemoryError(memory_error) => memory_error.fmt(f),
         }
     }
 }

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -279,10 +279,9 @@ impl CairoRunner {
             .segments
             .relocate_segments()
             .expect("compute_effective_sizes called but relocate_memory still returned error");
-        match self.relocate_memory(&relocation_table) {
-            Err(memory_error) => return Err(TraceError::MemoryError(memory_error)),
-            Ok(()) => (),
-        };
+        if let Err(memory_error) = self.relocate_memory(&relocation_table) {
+            return Err(TraceError::MemoryError(memory_error));
+        }
         self.relocate_trace(&relocation_table)?;
         Ok(())
     }


### PR DESCRIPTION
# Remove unwrap from relocate_value function

## Description
Issue: #130 
Add MemeryError::Relocation 
Remove unwrap from relocate_value

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
