### PR TITLE
docs: add documentation link to benchmark page

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,6 +96,10 @@
         <strong class="header-label">Repository:</strong>
         <a id="repository-link" rel="noopener"></a>
       </div>
+      <div class="header-item">
+        <strong class="header-label">Documentation:</strong>
+        <a id="documentation-link" rel="noopener" href="https://lambdaclass.github.io/cleopatra_cairo/cleopatra_cairo/index.html">https://lambdaclass.github.io/cleopatra_cairo/cleopatra_cairo/index.html</a>
+      </div>
     </header>
     <main id="main"></main>
     <footer>


### PR DESCRIPTION
## Description

Partially addresses #75, providing rendered documentation on github pages. 

This pull adds an additional link to the benchmark page currently serving as the gh-pages index. 

The current benchmark CI task will continue to update that index as before. A new CI task in [PR#200](https://github.com/lambdaclass/cleopatra_cairo/pull/200) will update the html documentation itself.

## Checklist
- [x] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
