### PR TITLE
remove modules from main.rs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,8 @@
 #![deny(warnings)]
-mod cairo_run;
-mod math_utils;
-mod serde;
-mod types;
-mod utils;
-mod vm;
-use crate::vm::errors::cairo_run_errors::CairoRunError;
-use crate::vm::errors::runner_errors::RunnerError;
 use clap::{Parser, ValueHint};
+use cleopatra_cairo::cairo_run;
+use cleopatra_cairo::vm::errors::cairo_run_errors::CairoRunError;
+use cleopatra_cairo::vm::errors::runner_errors::RunnerError;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]


### PR DESCRIPTION
# Remove modules from main.rs

## Description

The VM modules were duplicated( in lib.rs and main.rs). So, we remove the mods from main.rs


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
