### PR TITLE
Add error tests of functions in cairo_run

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,10 @@ fn main() -> Result<(), CairoRunError> {
     };
 
     if let Some(trace_path) = args.trace_file {
-        cairo_run::write_binary_trace(&cairo_runner.relocated_trace, &trace_path);
+        match cairo_run::write_binary_trace(&cairo_runner.relocated_trace, &trace_path) {
+            Ok(()) => (),
+            Err(_e) => return Err(CairoRunError::Runner(RunnerError::WriteFail)),
+        }
     }
 
     if args.print_output {

--- a/tests/support/invalid_memory.json
+++ b/tests/support/invalid_memory.json
@@ -1,0 +1,133 @@
+{
+    "attributes": [],
+    "builtins": [],
+    "data": [
+        "0x208b7fff7fff7ffef"
+    ],
+    "debug_info": {
+        "file_contents": {},
+        "instruction_locations": {
+            "0": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.main.struct_instance": 0,
+                        "__main__.main.struct_instance_2": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 13,
+                    "end_line": 9,
+                    "input_file": {
+                        "filename": "struct.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 9
+                }
+            }
+        }
+    },
+    "hints": {},
+    "identifiers": {
+        "__main__.MyStruct": {
+            "full_name": "__main__.MyStruct",
+            "members": {
+                "first_member": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "second_member": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "__main__.main": {
+            "decorators": [],
+            "pc": 0,
+            "type": "function"
+        },
+        "__main__.main.Args": {
+            "full_name": "__main__.main.Args",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.ImplicitArgs": {
+            "full_name": "__main__.main.ImplicitArgs",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "__main__.main.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.main.struct_instance": {
+            "cairo_type": "__main__.MyStruct",
+            "full_name": "__main__.main.struct_instance",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "cast((1, 2), __main__.MyStruct)"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.struct_instance_2": {
+            "cairo_type": "__main__.MyStruct",
+            "full_name": "__main__.main.struct_instance_2",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "cast((3, 4), __main__.MyStruct)"
+                }
+            ],
+            "type": "reference"
+        }
+    },
+    "main_scope": "__main__",
+    "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+    "reference_manager": {
+        "references": [
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 0,
+                "value": "cast((1, 2), __main__.MyStruct)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 0,
+                "value": "cast((3, 4), __main__.MyStruct)"
+            }
+        ]
+    }
+}

--- a/tests/support/no_data_program.json
+++ b/tests/support/no_data_program.json
@@ -1,0 +1,130 @@
+{
+    "attributes": [],
+    "builtins": [],
+    "debug_info": {
+        "file_contents": {},
+        "instruction_locations": {
+            "0": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.main.struct_instance": 0,
+                        "__main__.main.struct_instance_2": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 13,
+                    "end_line": 9,
+                    "input_file": {
+                        "filename": "struct.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 9
+                }
+            }
+        }
+    },
+    "hints": {},
+    "identifiers": {
+        "__main__.MyStruct": {
+            "full_name": "__main__.MyStruct",
+            "members": {
+                "first_member": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "second_member": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "__main__.main": {
+            "decorators": [],
+            "pc": 0,
+            "type": "function"
+        },
+        "__main__.main.Args": {
+            "full_name": "__main__.main.Args",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.ImplicitArgs": {
+            "full_name": "__main__.main.ImplicitArgs",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "__main__.main.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.main.struct_instance": {
+            "cairo_type": "__main__.MyStruct",
+            "full_name": "__main__.main.struct_instance",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "cast((1, 2), __main__.MyStruct)"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.struct_instance_2": {
+            "cairo_type": "__main__.MyStruct",
+            "full_name": "__main__.main.struct_instance_2",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "cast((3, 4), __main__.MyStruct)"
+                }
+            ],
+            "type": "reference"
+        }
+    },
+    "main_scope": "__main__",
+    "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+    "reference_manager": {
+        "references": [
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 0,
+                "value": "cast((1, 2), __main__.MyStruct)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 0,
+                "value": "cast((3, 4), __main__.MyStruct)"
+            }
+        ]
+    }
+}

--- a/tests/support/no_main_program.json
+++ b/tests/support/no_main_program.json
@@ -1,0 +1,133 @@
+{
+    "attributes": [],
+    "builtins": [],
+    "data": [
+        "0x208b7fff7fff7ffe"
+    ],
+    "debug_info": {
+        "file_contents": {},
+        "instruction_locations": {
+            "0": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.main.struct_instance": 0,
+                        "__main__.main.struct_instance_2": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 13,
+                    "end_line": 9,
+                    "input_file": {
+                        "filename": "struct.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 9
+                }
+            }
+        }
+    },
+    "hints": {},
+    "identifiers": {
+        "__main__.MyStruct": {
+            "full_name": "__main__.MyStruct",
+            "members": {
+                "first_member": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "second_member": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "__main__.main": {
+            "decorators": [],
+            "pc": null,
+            "type": "function"
+        },
+        "__main__.main.Args": {
+            "full_name": "__main__.main.Args",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.ImplicitArgs": {
+            "full_name": "__main__.main.ImplicitArgs",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "__main__.main.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.main.struct_instance": {
+            "cairo_type": "__main__.MyStruct",
+            "full_name": "__main__.main.struct_instance",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "cast((1, 2), __main__.MyStruct)"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.struct_instance_2": {
+            "cairo_type": "__main__.MyStruct",
+            "full_name": "__main__.main.struct_instance_2",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "cast((3, 4), __main__.MyStruct)"
+                }
+            ],
+            "type": "reference"
+        }
+    },
+    "main_scope": "__main__",
+    "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+    "reference_manager": {
+        "references": [
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 0,
+                "value": "cast((1, 2), __main__.MyStruct)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 0,
+                "value": "cast((3, 4), __main__.MyStruct)"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
# Add error tests of functions in cairo_run

## Description
Add tests for errors in `cairo_run`.
Some invalid programs were added to `tests/support` to make functions return errors.

## Checklist
- [ ] Unit tests added
