### PR TITLE
Add support for the hint in is_nn (math_cmp.cairo)

### DIFF
--- a/cairo_programs/assert_le_felt_hint.cairo
+++ b/cairo_programs/assert_le_felt_hint.cairo
@@ -1,0 +1,24 @@
+%builtins range_check
+
+func assert_le_felt_hint{range_check_ptr}(a, b):
+    alloc_locals
+    local small_inputs
+    %{
+        from starkware.cairo.common.math_utils import assert_integer
+        assert_integer(ids.a)
+        assert_integer(ids.b)
+        a = ids.a % PRIME
+        b = ids.b % PRIME
+        assert a <= b, f'a = {a} is not less than or equal to b = {b}.'
+
+        ids.small_inputs = int(
+            a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)
+    %}
+    assert small_inputs = 1
+    return()
+end
+	
+func main{range_check_ptr: felt}():
+    assert_le_felt_hint(1,2)
+    return ()
+end

--- a/cairo_programs/compare_greater_array.cairo
+++ b/cairo_programs/compare_greater_array.cairo
@@ -1,0 +1,37 @@
+%builtins range_check
+
+from starkware.cairo.common.bool import TRUE, FALSE
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.math_cmp import is_le
+
+#Returns TRUE is array_a is greater than array_b, which means every element in a is greater than every element in b
+func compare_greater_array{range_check_ptr: felt}(array_a: felt*, array_b: felt*, array_length: felt, iterator: felt ) -> (r: felt):
+    if iterator == array_length:
+        return(TRUE)
+    end
+    let (comparison) = is_le(array_a[iterator], array_b[iterator])
+    if comparison == TRUE:
+        return(FALSE)
+    end
+    return compare_greater_array(array_a, array_b, array_length, iterator + 1)
+end
+
+func fill_array(array: felt*, base: felt, step: felt, array_length: felt, iterator: felt):
+    if iterator == array_length:
+        return()
+    end
+    assert array[iterator] = base + step * iterator
+    return fill_array(array, base, step, array_length, iterator + 1)
+end
+	
+func main{range_check_ptr: felt}():
+    alloc_locals
+    tempvar array_length = 100
+    let (array_a : felt*) = alloc()
+    let (array_b : felt*) = alloc()
+    fill_array(array_a, 9, 5, array_length, 0)
+    fill_array(array_b, 7, 3, array_length, 0)
+    let result : felt = compare_greater_array(array_a, array_b, array_length, 0)
+    assert result = TRUE
+    return ()
+end

--- a/cairo_programs/compare_lesser_array.cairo
+++ b/cairo_programs/compare_lesser_array.cairo
@@ -4,7 +4,7 @@ from starkware.cairo.common.bool import TRUE, FALSE
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.math_cmp import is_le
 
-#Returns TRUE is array_a is greater than array_b, which means every element in a is greater than every element in b
+#Returns TRUE is array_a is lesser than array_b, which means every element in a is lesser than every element in b
 func compare_lesser_array{range_check_ptr: felt}(array_a: felt*, array_b: felt*, array_length: felt, iterator: felt ) -> (r: felt):
     if iterator == array_length:
         return(TRUE)

--- a/cairo_programs/compare_lesser_array.cairo
+++ b/cairo_programs/compare_lesser_array.cairo
@@ -1,0 +1,37 @@
+%builtins range_check
+
+from starkware.cairo.common.bool import TRUE, FALSE
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.math_cmp import is_le
+
+#Returns TRUE is array_a is greater than array_b, which means every element in a is greater than every element in b
+func compare_lesser_array{range_check_ptr: felt}(array_a: felt*, array_b: felt*, array_length: felt, iterator: felt ) -> (r: felt):
+    if iterator == array_length:
+        return(TRUE)
+    end
+    let (comparison) = is_le(array_a[iterator], array_b[iterator])
+    if comparison == FALSE:
+        return(FALSE)
+    end
+    return compare_lesser_array(array_a, array_b, array_length, iterator + 1)
+end
+
+func fill_array(array: felt*, base: felt, step: felt, array_length: felt, iterator: felt):
+    if iterator == array_length:
+        return()
+    end
+    assert array[iterator] = base + step * iterator
+    return fill_array(array, base, step, array_length, iterator + 1)
+end
+	
+func main{range_check_ptr: felt}():
+    alloc_locals
+    tempvar array_length = 100
+    let (array_a : felt*) = alloc()
+    let (array_b : felt*) = alloc()
+    fill_array(array_a, 5, 2, array_length, 0)
+    fill_array(array_b, 7, 3, array_length, 0)
+    let result : felt = compare_lesser_array(array_a, array_b, array_length, 0)
+    assert result = TRUE
+    return ()
+end

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -1,8 +1,6 @@
 use crate::types::instruction::Register;
 use crate::types::{
-    errors::program_errors::ProgramError,
-    program::{Program, ReferenceManager},
-    relocatable::MaybeRelocatable,
+    errors::program_errors::ProgramError, program::Program, relocatable::MaybeRelocatable,
 };
 use lazy_regex::regex_captures;
 use num_bigint::{BigInt, Sign};
@@ -49,12 +47,12 @@ pub struct Identifier {
     pub pc: Option<usize>,
 }
 
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, PartialEq, Clone)]
 pub struct ReferenceManager {
     pub references: Vec<Reference>,
 }
 
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, PartialEq, Clone)]
 pub struct Reference {
     pub ap_tracking_data: ApTracking,
     pub pc: Option<usize>,
@@ -63,7 +61,7 @@ pub struct Reference {
     pub value_address: ValueAddress,
 }
 
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, PartialEq, Clone)]
 pub struct ValueAddress {
     pub register: Option<Register>,
     pub offset: i32,
@@ -251,9 +249,7 @@ pub fn deserialize_program(path: &Path) -> Result<Program, ProgramError> {
         data: program_json.data,
         main: program_json.identifiers["__main__.main"].pc,
         hints: program_json.hints,
-        reference_manager: ReferenceManager {
-            references: Vec::new(),
-        },
+        reference_manager: program_json.reference_manager,
     })
 }
 

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -1,5 +1,7 @@
 use crate::types::{
-    errors::program_errors::ProgramError, program::Program, relocatable::MaybeRelocatable,
+    errors::program_errors::ProgramError,
+    program::{Program, ReferenceManager},
+    relocatable::MaybeRelocatable,
 };
 use num_bigint::{BigInt, Sign};
 use serde::{de, de::SeqAccess, Deserialize, Deserializer};
@@ -141,6 +143,9 @@ pub fn deserialize_program(path: &Path) -> Result<Program, ProgramError> {
         data: program_json.data,
         main: program_json.identifiers["__main__.main"].pc,
         hints: program_json.hints,
+        reference_manager: ReferenceManager {
+            references: Vec::new(),
+        },
     })
 }
 

--- a/src/types/instruction.rs
+++ b/src/types/instruction.rs
@@ -1,6 +1,6 @@
 use num_bigint::BigInt;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Register {
     AP,
     FP,

--- a/src/types/program.rs
+++ b/src/types/program.rs
@@ -1,8 +1,15 @@
 use crate::serde::deserialize_program::{deserialize_program, HintParams};
 use crate::types::errors::program_errors::ProgramError;
 use crate::types::relocatable::MaybeRelocatable;
+use crate::vm::hints::execute_hint::Reference;
 use num_bigint::BigInt;
 use std::{collections::HashMap, path::Path};
+
+//Remove once deserialize
+#[derive(Debug, PartialEq, Clone)]
+pub struct ReferenceManager {
+    pub references: Vec<Reference>,
+}
 
 #[derive(Clone)]
 pub struct Program {
@@ -11,6 +18,7 @@ pub struct Program {
     pub data: Vec<MaybeRelocatable>,
     pub main: Option<usize>,
     pub hints: HashMap<usize, Vec<HintParams>>,
+    pub reference_manager: ReferenceManager,
 }
 
 impl Program {

--- a/src/types/program.rs
+++ b/src/types/program.rs
@@ -1,15 +1,8 @@
-use crate::serde::deserialize_program::{deserialize_program, HintParams};
+use crate::serde::deserialize_program::{deserialize_program, HintParams, ReferenceManager};
 use crate::types::errors::program_errors::ProgramError;
 use crate::types::relocatable::MaybeRelocatable;
-use crate::vm::hints::execute_hint::Reference;
 use num_bigint::BigInt;
 use std::{collections::HashMap, path::Path};
-
-//Remove once deserialize
-#[derive(Debug, PartialEq, Clone)]
-pub struct ReferenceManager {
-    pub references: Vec<Reference>,
-}
 
 #[derive(Clone)]
 pub struct Program {

--- a/src/vm/errors/runner_errors.rs
+++ b/src/vm/errors/runner_errors.rs
@@ -39,9 +39,9 @@ impl fmt::Display for RunnerError {
             RunnerError::MissingMain => write!(f, "Missing main()"),
             RunnerError::UninitializedBase => write!(f, "Uninitialized self.base"),
             RunnerError::WriteFail => write!(f, "Failed to write program output"),
-            RunnerError::NoPC => write!(f, "Found None PC durin VM initialization"),
-            RunnerError::NoAP => write!(f, "Found None AP durin VM initialization"),
-            RunnerError::NoFP => write!(f, "Found None FP durin VM initialization"),
+            RunnerError::NoPC => write!(f, "Found None PC during VM initialization"),
+            RunnerError::NoAP => write!(f, "Found None AP during VM initialization"),
+            RunnerError::NoFP => write!(f, "Found None FP during VM initialization"),
             RunnerError::MemoryValidationError(error) => {
                 write!(f, "Memory validation failed during VM initialization.")?;
                 error.fmt(f)
@@ -63,7 +63,7 @@ impl fmt::Display for RunnerError {
                 write!(f, "Failed to retrieve value from address {:?}", addr)
             }
             RunnerError::FailedMemoryGet(error) => {
-                write!(f, "Failed fetching memory address.")?;
+                write!(f, "Failed to fetch memory address.")?;
                 error.fmt(f)
             }
 

--- a/src/vm/errors/runner_errors.rs
+++ b/src/vm/errors/runner_errors.rs
@@ -23,6 +23,7 @@ pub enum RunnerError {
     MemoryGet(MaybeRelocatable),
     FailedMemoryGet(MemoryError),
     EcOpBuiltinScalarLimit(BigInt),
+    FailedToParseIdsNameFromPath(String),
 }
 
 impl fmt::Display for RunnerError {
@@ -69,6 +70,13 @@ impl fmt::Display for RunnerError {
 
             RunnerError::EcOpBuiltinScalarLimit(scalar) => {
                 write!(f, "EcOpBuiltin: m should be at most {}", scalar)
+            }
+            RunnerError::FailedToParseIdsNameFromPath(path) => {
+                write!(
+                    f,
+                    "Failed to get variable name from path: {:?}, when parsing reference ids",
+                    path
+                )
             }
         }
     }

--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -41,6 +41,7 @@ pub enum VirtualMachineError {
     ExpectedInteger(MaybeRelocatable),
     FailedToGetIds,
     NonLeFelt(BigInt, BigInt),
+    FailedToGetReference(BigInt),
 }
 
 impl fmt::Display for VirtualMachineError {
@@ -112,6 +113,9 @@ impl fmt::Display for VirtualMachineError {
             },
             VirtualMachineError::NonLeFelt(a, b) => {
                 write!(f, "Assertion failed, {}, is not less or equal to {}", a, b)
+            },
+            VirtualMachineError::FailedToGetReference(reference_id) => {
+                write!(f, "Failed to get reference for id {}", reference_id)
             },
         }
     }

--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -35,7 +35,6 @@ pub enum VirtualMachineError {
     HintException(MaybeRelocatable),
     MemoryError(MemoryError),
     UnknownHinError(String),
-    NoIds(String),
     NoRangeCheckBuiltin,
     IncorrectIds,
 }
@@ -92,7 +91,6 @@ impl fmt::Display for VirtualMachineError {
             VirtualMachineError::HintException(address) => write!(f, "Got an exception while executing a hint at pc: {:?}", address),
             VirtualMachineError::MemoryError(memory_error) => memory_error.fmt(f),
             VirtualMachineError::UnknownHinError(hint_code) => write!(f, "Unknown Hint: {:?}", hint_code),
-            VirtualMachineError::NoIds(hint_code) => write!(f, "No ids were given for hint requiring ids: {:?}", hint_code),
             VirtualMachineError::NoRangeCheckBuiltin => {
                 write!(f, "Expected range_check builtin to be present")
             },

--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -39,6 +39,8 @@ pub enum VirtualMachineError {
     IncorrectIds(Vec<String>, Vec<String>),
     MemoryGet(MaybeRelocatable),
     ExpectedInteger(MaybeRelocatable),
+    FailedToGetIds,
+    NonLeFelt(BigInt, BigInt),
 }
 
 impl fmt::Display for VirtualMachineError {
@@ -104,6 +106,12 @@ impl fmt::Display for VirtualMachineError {
             },
             VirtualMachineError::ExpectedInteger(addr) => {
                 write!(f, "Expected integer at address {:?}", addr)
+            },
+            VirtualMachineError::FailedToGetIds => {
+                write!(f, "Failed to get ids from memory")
+            },
+            VirtualMachineError::NonLeFelt(a, b) => {
+                write!(f, "Assertion failed, {}, is not less or equal to {}", a, b)
             },
         }
     }

--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -36,6 +36,8 @@ pub enum VirtualMachineError {
     MemoryError(MemoryError),
     UnknownHinError(String),
     NoIdsError(String),
+    NoRangeCheckBuiltin,
+    IncorrectIds,
 }
 
 impl fmt::Display for VirtualMachineError {
@@ -91,6 +93,12 @@ impl fmt::Display for VirtualMachineError {
             VirtualMachineError::MemoryError(memory_error) => memory_error.fmt(f),
             VirtualMachineError::UnknownHinError(hint_code) => write!(f, "Unknown Hint: {:?}", hint_code),
             VirtualMachineError::NoIdsError(hint_code) => write!(f, "No ids were given for hint requiring ids: {:?}", hint_code),
+            VirtualMachineError::NoRangeCheckBuiltin => {
+                write!(f, "Expected range_check builtin to be present")
+            },
+            VirtualMachineError::IncorrectIds => {
+                write!(f, "Incorrect Ids")
+            },
         }
     }
 }

--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -37,6 +37,8 @@ pub enum VirtualMachineError {
     UnknownHinError(String),
     NoRangeCheckBuiltin,
     IncorrectIds(Vec<String>, Vec<String>),
+    MemoryGet(MaybeRelocatable),
+    ExpectedInteger(MaybeRelocatable),
 }
 
 impl fmt::Display for VirtualMachineError {
@@ -96,6 +98,12 @@ impl fmt::Display for VirtualMachineError {
             },
             VirtualMachineError::IncorrectIds(expected, existing) => {
                 write!(f, "Expected ids to contain {:?}, got: {:?}", expected, existing)
+            },
+            VirtualMachineError::MemoryGet(addr) => {
+                write!(f, "Failed to retrieve value from address {:?}", addr)
+            },
+            VirtualMachineError::ExpectedInteger(addr) => {
+                write!(f, "Expected integer at address {:?}", addr)
             },
         }
     }

--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -35,6 +35,7 @@ pub enum VirtualMachineError {
     HintException(MaybeRelocatable),
     MemoryError(MemoryError),
     UnknownHinError(String),
+    NoIdsError(String),
 }
 
 impl fmt::Display for VirtualMachineError {
@@ -89,6 +90,7 @@ impl fmt::Display for VirtualMachineError {
             VirtualMachineError::HintException(address) => write!(f, "Got an exception while executing a hint at pc: {:?}", address),
             VirtualMachineError::MemoryError(memory_error) => memory_error.fmt(f),
             VirtualMachineError::UnknownHinError(hint_code) => write!(f, "Unknown Hint: {:?}", hint_code),
+            VirtualMachineError::NoIdsError(hint_code) => write!(f, "No ids were given for hint requiring ids: {:?}", hint_code),
         }
     }
 }

--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -36,7 +36,7 @@ pub enum VirtualMachineError {
     MemoryError(MemoryError),
     UnknownHinError(String),
     NoRangeCheckBuiltin,
-    IncorrectIds,
+    IncorrectIds(Vec<String>, Vec<String>),
 }
 
 impl fmt::Display for VirtualMachineError {
@@ -94,8 +94,8 @@ impl fmt::Display for VirtualMachineError {
             VirtualMachineError::NoRangeCheckBuiltin => {
                 write!(f, "Expected range_check builtin to be present")
             },
-            VirtualMachineError::IncorrectIds => {
-                write!(f, "Incorrect Ids")
+            VirtualMachineError::IncorrectIds(expected, existing) => {
+                write!(f, "Expected ids to contain {:?}, got: {:?}", expected, existing)
             },
         }
     }

--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -35,7 +35,7 @@ pub enum VirtualMachineError {
     HintException(MaybeRelocatable),
     MemoryError(MemoryError),
     UnknownHinError(String),
-    NoIdsError(String),
+    NoIds(String),
     NoRangeCheckBuiltin,
     IncorrectIds,
 }
@@ -92,7 +92,7 @@ impl fmt::Display for VirtualMachineError {
             VirtualMachineError::HintException(address) => write!(f, "Got an exception while executing a hint at pc: {:?}", address),
             VirtualMachineError::MemoryError(memory_error) => memory_error.fmt(f),
             VirtualMachineError::UnknownHinError(hint_code) => write!(f, "Unknown Hint: {:?}", hint_code),
-            VirtualMachineError::NoIdsError(hint_code) => write!(f, "No ids were given for hint requiring ids: {:?}", hint_code),
+            VirtualMachineError::NoIds(hint_code) => write!(f, "No ids were given for hint requiring ids: {:?}", hint_code),
             VirtualMachineError::NoRangeCheckBuiltin => {
                 write!(f, "Expected range_check builtin to be present")
             },

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -19,21 +19,11 @@ pub fn execute_hint(
 ) -> Result<(), VirtualMachineError> {
     match std::str::from_utf8(hint_code) {
         Ok("memory[ap] = segments.add()") => add_segment(vm),
-        Ok("memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1") => {
-            is_nn(vm, ids)
-        }
+        Ok("memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1") => is_nn(vm, ids),
         Ok("memory[ap] = 0 if 0 <= ((-ids.a - 1) % PRIME) < range_check_builtin.bound else 1") => {
             is_nn_out_of_range(vm, ids)
         }
-        Ok(
-            "from starkware.cairo.common.math_utils import assert_integer
-            assert_integer(ids.a)
-            assert_integer(ids.b)
-            a = ids.a % PRIME
-            b = ids.b % PRIME
-            assert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n
-            ids.small_inputs = int(
-                a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)",
+        Ok("from starkware.cairo.common.math_utils import assert_integerassert_integer(ids.a)\nassert_integer(ids.b)\na = ids.a % PRIME\nb = ids.b % PRIME\nassert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\nids.small_inputs = int(\n    a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)",
         ) => assert_le_felt(vm, ids),
         Ok(hint_code) => Err(VirtualMachineError::UnknownHint(String::from(hint_code))),
         Err(_) => Err(VirtualMachineError::InvalidHintEncoding(
@@ -396,15 +386,7 @@ mod tests {
 
     #[test]
     fn run_assert_le_felt_valid() {
-        let hint_code = "from starkware.cairo.common.math_utils import assert_integer
-            assert_integer(ids.a)
-            assert_integer(ids.b)
-            a = ids.a % PRIME
-            b = ids.b % PRIME
-            assert a <= b, f'a = {a} is not less than or equal to b = {b}.'
-
-            ids.small_inputs = int(
-                a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"
+        let hint_code = "from starkware.cairo.common.math_utils import assert_integerassert_integer(ids.a)\nassert_integer(ids.b)\na = ids.a % PRIME\nb = ids.b % PRIME\nassert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\nids.small_inputs = int(\n    a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"
             .as_bytes();
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -476,15 +458,7 @@ mod tests {
 
     #[test]
     fn run_is_assert_le_felt_invalid() {
-        let hint_code = "from starkware.cairo.common.math_utils import assert_integer
-            assert_integer(ids.a)
-            assert_integer(ids.b)
-            a = ids.a % PRIME
-            b = ids.b % PRIME
-            assert a <= b, f'a = {a} is not less than or equal to b = {b}.'
-
-            ids.small_inputs = int(
-                a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"
+        let hint_code = "from starkware.cairo.common.math_utils import assert_integerassert_integer(ids.a)\nassert_integer(ids.b)\na = ids.a % PRIME\nb = ids.b % PRIME\nassert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\nids.small_inputs = int(\n    a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"
             .as_bytes();
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -558,15 +532,7 @@ mod tests {
 
     #[test]
     fn run_is_assert_le_felt_small_inputs_not_local() {
-        let hint_code = "from starkware.cairo.common.math_utils import assert_integer
-            assert_integer(ids.a)
-            assert_integer(ids.b)
-            a = ids.a % PRIME
-            b = ids.b % PRIME
-            assert a <= b, f'a = {a} is not less than or equal to b = {b}.'
-
-            ids.small_inputs = int(
-                a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"
+        let hint_code = "from starkware.cairo.common.math_utils import assert_integerassert_integer(ids.a)\nassert_integer(ids.b)\na = ids.a % PRIME\nb = ids.b % PRIME\nassert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\nids.small_inputs = int(\n    a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"
             .as_bytes();
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -640,15 +606,7 @@ mod tests {
 
     #[test]
     fn run_is_assert_le_felt_a_is_not_integer() {
-        let hint_code = "from starkware.cairo.common.math_utils import assert_integer
-            assert_integer(ids.a)
-            assert_integer(ids.b)
-            a = ids.a % PRIME
-            b = ids.b % PRIME
-            assert a <= b, f'a = {a} is not less than or equal to b = {b}.'
-
-            ids.small_inputs = int(
-                a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"
+        let hint_code = "from starkware.cairo.common.math_utils import assert_integerassert_integer(ids.a)\nassert_integer(ids.b)\na = ids.a % PRIME\nb = ids.b % PRIME\nassert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\nids.small_inputs = int(\n    a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"
             .as_bytes();
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -724,15 +682,7 @@ mod tests {
 
     #[test]
     fn run_is_assert_le_felt_b_is_not_integer() {
-        let hint_code = "from starkware.cairo.common.math_utils import assert_integer
-            assert_integer(ids.a)
-            assert_integer(ids.b)
-            a = ids.a % PRIME
-            b = ids.b % PRIME
-            assert a <= b, f'a = {a} is not less than or equal to b = {b}.'
-
-            ids.small_inputs = int(
-                a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"
+        let hint_code = "from starkware.cairo.common.math_utils import assert_integerassert_integer(ids.a)\nassert_integer(ids.b)\na = ids.a % PRIME\nb = ids.b % PRIME\nassert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\nids.small_inputs = int(\n    a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"
             .as_bytes();
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -803,6 +753,96 @@ mod tests {
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((0, 1))
             ))
+        );
+    }
+
+    #[test]
+    fn run_is_nn_hint_out_of_range_false() {
+        let hint_code =
+            "memory[ap] = 0 if 0 <= ((-ids.a - 1) % PRIME) < range_check_builtin.bound else 1"
+                .as_bytes();
+        let mut vm = VirtualMachine::new(
+            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            vec![(
+                "range_check".to_string(),
+                Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
+            )],
+        );
+        for _ in 0..2 {
+            vm.segments.add(&mut vm.memory, None);
+        }
+        //Initialize ap, fp
+        vm.run_context.ap = MaybeRelocatable::from((1, 0));
+        vm.run_context.fp = MaybeRelocatable::from((0, 1));
+        //Insert ids into memory
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((0, 0)),
+                &MaybeRelocatable::from(bigint!(2).pow(300)),
+            )
+            .unwrap();
+        //Create ids
+        let mut ids = HashMap::<String, BigInt>::new();
+        ids.insert(
+            String::from("starkware.cairo.common.math_cmp.is_nn.a"),
+            bigint!(0),
+        );
+        //Create references
+        vm.references = vec![HintReference {
+            register: Register::FP,
+            offset: -1,
+        }];
+        //Execute the hint
+        execute_hint(&mut vm, hint_code, ids).expect("Error while executing hint");
+        //Check that ap now contains false (0)
+        assert_eq!(
+            vm.memory.get(&MaybeRelocatable::from((1, 0))),
+            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
+        );
+    }
+
+    #[test]
+    fn run_is_nn_hint_out_of_range_true() {
+        let hint_code =
+            "memory[ap] = 0 if 0 <= ((-ids.a - 1) % PRIME) < range_check_builtin.bound else 1"
+                .as_bytes();
+        let mut vm = VirtualMachine::new(
+            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            vec![(
+                "range_check".to_string(),
+                Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
+            )],
+        );
+        for _ in 0..2 {
+            vm.segments.add(&mut vm.memory, None);
+        }
+        //Initialize ap, fp
+        vm.run_context.ap = MaybeRelocatable::from((1, 0));
+        vm.run_context.fp = MaybeRelocatable::from((0, 1));
+        //Insert ids into memory
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((0, 0)),
+                &MaybeRelocatable::from(bigint!(-1)),
+            )
+            .unwrap();
+        //Create ids
+        let mut ids = HashMap::<String, BigInt>::new();
+        ids.insert(
+            String::from("starkware.cairo.common.math_cmp.is_nn.a"),
+            bigint!(0),
+        );
+        //Create references
+        vm.references = vec![HintReference {
+            register: Register::FP,
+            offset: -1,
+        }];
+        //Execute the hint
+        execute_hint(&mut vm, hint_code, ids).expect("Error while executing hint");
+        //Check that ap now contains true (1)
+        assert_eq!(
+            vm.memory.get(&MaybeRelocatable::from((1, 0))),
+            Ok(Some(&MaybeRelocatable::from(bigint!(1))))
         );
     }
 }

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -34,7 +34,15 @@ pub fn execute_hint(
         Ok("memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1") => {
             is_nn(vm, ids)
         }
-        Ok("from starkware.cairo.common.math_utils import assert_integer\n            assert_integer(ids.a)\n            assert_integer(ids.b)\n            a = ids.a % PRIME\n            b = ids.b % PRIME\n            assert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\n            ids.small_inputs = int(\n                a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"
+        Ok(
+            "from starkware.cairo.common.math_utils import assert_integer
+            assert_integer(ids.a)
+            assert_integer(ids.b)
+            a = ids.a % PRIME
+            b = ids.b % PRIME
+            assert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n
+            ids.small_inputs = int(
+                a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)",
         ) => assert_le_felt(vm, ids),
         Ok(hint_code) => Err(VirtualMachineError::UnknownHint(String::from(hint_code))),
         Err(_) => Err(VirtualMachineError::InvalidHintEncoding(

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -170,7 +170,7 @@ mod tests {
         //Check that ap now contains false (0)
         assert_eq!(
             vm.memory.get(&MaybeRelocatable::from((1, 0))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
+            Ok(Some(&MaybeRelocatable::from(bigint!(1))))
         );
     }
 
@@ -214,7 +214,7 @@ mod tests {
         //Check that ap now contains true (1)
         assert_eq!(
             vm.memory.get(&MaybeRelocatable::from((1, 0))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(1))))
+            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
         );
     }
 
@@ -797,7 +797,7 @@ mod tests {
         //Check that ap now contains false (0)
         assert_eq!(
             vm.memory.get(&MaybeRelocatable::from((1, 0))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
+            Ok(Some(&MaybeRelocatable::from(bigint!(1))))
         );
     }
 
@@ -842,7 +842,7 @@ mod tests {
         //Check that ap now contains true (1)
         assert_eq!(
             vm.memory.get(&MaybeRelocatable::from((1, 0))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(1))))
+            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
         );
     }
 }

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -7,18 +7,6 @@ use crate::vm::errors::vm_errors::VirtualMachineError;
 use crate::vm::hints::hint_utils::{add_segment, assert_le_felt, is_nn};
 use crate::vm::vm_core::VirtualMachine;
 
-//These structs belong to serde, replace with import path
-#[derive(Debug, PartialEq, Clone)]
-pub struct Reference {
-    pub pc: Option<usize>,
-    pub value_address: ValueAddress,
-}
-
-#[derive(Debug, PartialEq, Clone)]
-pub struct ValueAddress {
-    pub register: Register,
-    pub offset: i32,
-}
 #[derive(Debug, PartialEq, Clone)]
 pub struct HintReference {
     pub register: Register,
@@ -175,7 +163,10 @@ mod tests {
             .unwrap();
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("a"), bigint!(0));
+        ids.insert(
+            String::from("starkware.cairo.common.math_cmp.is_nn.a"),
+            bigint!(0),
+        );
         //Create references
         vm.references = vec![HintReference {
             register: Register::FP,
@@ -216,7 +207,10 @@ mod tests {
             .unwrap();
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("a"), bigint!(0));
+        ids.insert(
+            String::from("starkware.cairo.common.math_cmp.is_nn.a"),
+            bigint!(0),
+        );
         //Create references
         vm.references = vec![HintReference {
             register: Register::FP,
@@ -267,7 +261,10 @@ mod tests {
             .unwrap();
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("a"), bigint!(0));
+        ids.insert(
+            String::from("starkware.cairo.common.math_cmp.is_nn.a"),
+            bigint!(0),
+        );
         //Create references
         vm.references = vec![HintReference {
             register: Register::FP,
@@ -298,13 +295,16 @@ mod tests {
         vm.run_context.ap = MaybeRelocatable::from((1, 0));
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("b"), bigint!(0));
+        ids.insert(
+            String::from("starkware.cairo.common.math_cmp.is_nn.b"),
+            bigint!(0),
+        );
         //Execute the hint
         assert_eq!(
             execute_hint(&mut vm, hint_code, ids),
             Err(VirtualMachineError::IncorrectIds(
-                vec![String::from("a")],
-                vec![String::from("b")]
+                vec![String::from("starkware.cairo.common.math_cmp.is_nn.a")],
+                vec![String::from("starkware.cairo.common.math_cmp.is_nn.b")]
             ))
         );
     }
@@ -329,7 +329,10 @@ mod tests {
         //Dont insert ids into memory
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("a"), bigint!(0));
+        ids.insert(
+            String::from("starkware.cairo.common.math_cmp.is_nn.a"),
+            bigint!(0),
+        );
         //Create references
         vm.references = vec![HintReference {
             register: Register::FP,
@@ -370,7 +373,10 @@ mod tests {
             .unwrap();
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("a"), bigint!(0));
+        ids.insert(
+            String::from("starkware.cairo.common.math_cmp.is_nn.a"),
+            bigint!(0),
+        );
         //Create references
         vm.references = vec![HintReference {
             register: Register::FP,
@@ -433,9 +439,18 @@ mod tests {
             .unwrap();
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("a"), bigint!(0));
-        ids.insert(String::from("b"), bigint!(1));
-        ids.insert(String::from("small_inputs"), bigint!(2));
+        ids.insert(
+            String::from("starkware.cairo.common.math.assert_le_felt.a"),
+            bigint!(0),
+        );
+        ids.insert(
+            String::from("starkware.cairo.common.math.assert_le_felt.b"),
+            bigint!(1),
+        );
+        ids.insert(
+            String::from("starkware.cairo.common.math.assert_le_felt.small_inputs"),
+            bigint!(2),
+        );
         //Create references
         vm.references = vec![
             HintReference {
@@ -504,9 +519,18 @@ mod tests {
             .unwrap();
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("a"), bigint!(0));
-        ids.insert(String::from("b"), bigint!(1));
-        ids.insert(String::from("small_inputs"), bigint!(2));
+        ids.insert(
+            String::from("starkware.cairo.common.math.assert_le_felt.a"),
+            bigint!(0),
+        );
+        ids.insert(
+            String::from("starkware.cairo.common.math.assert_le_felt.b"),
+            bigint!(1),
+        );
+        ids.insert(
+            String::from("starkware.cairo.common.math.assert_le_felt.small_inputs"),
+            bigint!(2),
+        );
         //Create references
         vm.references = vec![
             HintReference {
@@ -577,9 +601,18 @@ mod tests {
             .unwrap();
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("a"), bigint!(0));
-        ids.insert(String::from("b"), bigint!(1));
-        ids.insert(String::from("small_inputs"), bigint!(2));
+        ids.insert(
+            String::from("starkware.cairo.common.math.assert_le_felt.a"),
+            bigint!(0),
+        );
+        ids.insert(
+            String::from("starkware.cairo.common.math.assert_le_felt.b"),
+            bigint!(1),
+        );
+        ids.insert(
+            String::from("starkware.cairo.common.math.assert_le_felt.small_inputs"),
+            bigint!(2),
+        );
         //Create references
         vm.references = vec![
             HintReference {
@@ -650,9 +683,18 @@ mod tests {
             .unwrap();
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("a"), bigint!(0));
-        ids.insert(String::from("b"), bigint!(1));
-        ids.insert(String::from("small_inputs"), bigint!(2));
+        ids.insert(
+            String::from("starkware.cairo.common.math.assert_le_felt.a"),
+            bigint!(0),
+        );
+        ids.insert(
+            String::from("starkware.cairo.common.math.assert_le_felt.b"),
+            bigint!(1),
+        );
+        ids.insert(
+            String::from("starkware.cairo.common.math.assert_le_felt.small_inputs"),
+            bigint!(2),
+        );
         //Create references
         vm.references = vec![
             HintReference {
@@ -725,9 +767,18 @@ mod tests {
             .unwrap();
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("a"), bigint!(0));
-        ids.insert(String::from("b"), bigint!(1));
-        ids.insert(String::from("small_inputs"), bigint!(2));
+        ids.insert(
+            String::from("starkware.cairo.common.math.assert_le_felt.a"),
+            bigint!(0),
+        );
+        ids.insert(
+            String::from("starkware.cairo.common.math.assert_le_felt.b"),
+            bigint!(1),
+        );
+        ids.insert(
+            String::from("starkware.cairo.common.math.assert_le_felt.small_inputs"),
+            bigint!(2),
+        );
         //Create references
         vm.references = vec![
             HintReference {

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -16,8 +16,8 @@ pub struct Reference {
 
 #[derive(Debug, PartialEq)]
 pub struct ValueAddress {
-    register: Register,
-    offset: i32,
+    pub register: Register,
+    pub offset: i32,
 }
 pub fn execute_hint(
     vm: &mut VirtualMachine,

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -1,21 +1,31 @@
 use std::collections::HashMap;
 
-use num_bigint::BigInt;
-
+use crate::types::relocatable::MaybeRelocatable;
 use crate::vm::errors::vm_errors::VirtualMachineError;
-use crate::vm::hints::hint_utils::{add_segment, is_nn};
+use crate::vm::hints::hint_utils::{add_segment, assert_le_felt, is_nn};
 use crate::vm::vm_core::VirtualMachine;
 
 pub fn execute_hint(
     vm: &mut VirtualMachine,
     hint_code: &[u8],
-    ids: HashMap<String, BigInt>,
+    ids: HashMap<String, MaybeRelocatable>,
 ) -> Result<(), VirtualMachineError> {
     match std::str::from_utf8(hint_code) {
         Ok("memory[ap] = segments.add()") => add_segment(vm),
         Ok("memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1") => {
             is_nn(vm, ids)
         }
+        Ok(
+            "from starkware.cairo.common.math_utils import assert_integer
+        assert_integer(ids.a)
+        assert_integer(ids.b)
+        a = ids.a % PRIME
+        b = ids.b % PRIME
+        assert a <= b, f'a = {a} is not less than or equal to b = {b}.'
+
+        ids.small_inputs = int(
+            a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)",
+        ) => assert_le_felt(vm, ids),
         Ok(hint_code) => Err(VirtualMachineError::UnknownHinError(String::from(
             hint_code,
         ))),
@@ -104,9 +114,16 @@ mod tests {
         }
         //Initialize ap
         vm.run_context.ap = MaybeRelocatable::from((1, 0));
+        //Insert ids into memory
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((0, 0)),
+                &MaybeRelocatable::from(bigint!(-1)),
+            )
+            .unwrap();
         //Create ids
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("a"), bigint!(-1));
+        let mut ids = HashMap::<String, MaybeRelocatable>::new();
+        ids.insert(String::from("a"), MaybeRelocatable::from((0, 0)));
         //Execute the hint
         execute_hint(&mut vm, hint_code, ids).expect("Error while executing hint");
         //Check that ap now contains false (0)
@@ -132,9 +149,16 @@ mod tests {
         }
         //Initialize ap
         vm.run_context.ap = MaybeRelocatable::from((1, 0));
+        //Insert ids into memory
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((0, 0)),
+                &MaybeRelocatable::from(bigint!(1)),
+            )
+            .unwrap();
         //Create ids
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("a"), bigint!(1));
+        let mut ids = HashMap::<String, MaybeRelocatable>::new();
+        ids.insert(String::from("a"), MaybeRelocatable::from((0, 0)));
         //Execute the hint
         execute_hint(&mut vm, hint_code, ids).expect("Error while executing hint");
         //Check that ap now contains true (1)
@@ -157,9 +181,16 @@ mod tests {
         }
         //Initialize ap
         vm.run_context.ap = MaybeRelocatable::from((1, 0));
+        //Insert ids into memory
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((0, 0)),
+                &MaybeRelocatable::from(bigint!(1)),
+            )
+            .unwrap();
         //Create ids
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("a"), bigint!(1));
+        let mut ids = HashMap::<String, MaybeRelocatable>::new();
+        ids.insert(String::from("a"), MaybeRelocatable::from((0, 0)));
         //Execute the hint
         assert_eq!(
             execute_hint(&mut vm, hint_code, ids),
@@ -184,14 +215,78 @@ mod tests {
         //Initialize ap
         vm.run_context.ap = MaybeRelocatable::from((1, 0));
         //Create ids
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("b"), bigint!(1));
+        let mut ids = HashMap::<String, MaybeRelocatable>::new();
+        ids.insert(String::from("b"), MaybeRelocatable::from((0, 0)));
         //Execute the hint
         assert_eq!(
             execute_hint(&mut vm, hint_code, ids),
             Err(VirtualMachineError::IncorrectIds(
                 vec![String::from("a")],
                 vec![String::from("b")]
+            ))
+        );
+    }
+
+    #[test]
+    fn run_is_nn_hint_cant_get_ids_from_memory() {
+        let hint_code =
+            "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1".as_bytes();
+        let mut vm = VirtualMachine::new(
+            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            vec![(
+                "range_check".to_string(),
+                Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
+            )],
+        );
+        for _ in 0..2 {
+            vm.segments.add(&mut vm.memory, None);
+        }
+        //Initialize ap
+        vm.run_context.ap = MaybeRelocatable::from((1, 0));
+        //Dont insert ids into memory
+        //Create ids
+        let mut ids = HashMap::<String, MaybeRelocatable>::new();
+        ids.insert(String::from("a"), MaybeRelocatable::from((0, 0)));
+        //Execute the hint
+        assert_eq!(
+            execute_hint(&mut vm, hint_code, ids),
+            Err(VirtualMachineError::MemoryGet(MaybeRelocatable::from((
+                0, 0
+            ))))
+        );
+    }
+
+    #[test]
+    fn run_is_nn_hint_ids_are_relocatable_values() {
+        let hint_code =
+            "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1".as_bytes();
+        let mut vm = VirtualMachine::new(
+            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            vec![(
+                "range_check".to_string(),
+                Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
+            )],
+        );
+        for _ in 0..2 {
+            vm.segments.add(&mut vm.memory, None);
+        }
+        //Initialize ap
+        vm.run_context.ap = MaybeRelocatable::from((1, 0));
+        //Insert ids into memory
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((0, 0)),
+                &MaybeRelocatable::from((2, 3)),
+            )
+            .unwrap();
+        //Create ids
+        let mut ids = HashMap::<String, MaybeRelocatable>::new();
+        ids.insert(String::from("a"), MaybeRelocatable::from((0, 0)));
+        //Execute the hint
+        assert_eq!(
+            execute_hint(&mut vm, hint_code, ids),
+            Err(VirtualMachineError::ExpectedInteger(
+                MaybeRelocatable::from((0, 0))
             ))
         );
     }

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -33,9 +33,10 @@ pub fn execute_hint(
 
 #[cfg(test)]
 mod tests {
-    use num_bigint::{BigInt, Sign};
-
     use crate::types::relocatable::MaybeRelocatable;
+    use crate::{bigint, vm::runners::builtin_runner::RangeCheckBuiltinRunner};
+    use num_bigint::{BigInt, Sign};
+    use num_traits::FromPrimitive;
 
     use super::*;
     #[test]
@@ -90,6 +91,34 @@ mod tests {
             Err(VirtualMachineError::UnknownHinError(
                 String::from_utf8(hint_code.to_vec()).unwrap()
             ))
+        );
+    }
+
+    #[test]
+    fn run_is_nn_hint_false() {
+        let hint_code =
+            "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1".as_bytes();
+        let mut vm = VirtualMachine::new(
+            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            vec![(
+                "range_check".to_string(),
+                Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
+            )],
+        );
+        for _ in 0..2 {
+            vm.segments.add(&mut vm.memory, None);
+        }
+        //Initialize ap
+        vm.run_context.ap = MaybeRelocatable::from((1, 0));
+        //Create ids
+        let mut ids = HashMap::<String, BigInt>::new();
+        ids.insert(String::from("a"), bigint!(-1));
+        //Execute the hint
+        execute_hint(&mut vm, hint_code, Some(ids)).expect("Error while executing hint");
+        //Check that ap now contains false (0)
+        assert_eq!(
+            vm.memory.get(&MaybeRelocatable::from((1, 0))),
+            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
         );
     }
 }

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -23,7 +23,7 @@ pub fn execute_hint(
         Ok("memory[ap] = 0 if 0 <= ((-ids.a - 1) % PRIME) < range_check_builtin.bound else 1") => {
             is_nn_out_of_range(vm, ids)
         }
-        Ok("from starkware.cairo.common.math_utils import assert_integerassert_integer(ids.a)\nassert_integer(ids.b)\na = ids.a % PRIME\nb = ids.b % PRIME\nassert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\nids.small_inputs = int(\n    a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)",
+        Ok("from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\na = ids.a % PRIME\nb = ids.b % PRIME\nassert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\nids.small_inputs = int(\n    a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)",
         ) => assert_le_felt(vm, ids),
         Ok(hint_code) => Err(VirtualMachineError::UnknownHint(String::from(hint_code))),
         Err(_) => Err(VirtualMachineError::InvalidHintEncoding(

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -189,7 +189,10 @@ mod tests {
         //Execute the hint
         assert_eq!(
             execute_hint(&mut vm, hint_code, ids),
-            Err(VirtualMachineError::IncorrectIds)
+            Err(VirtualMachineError::IncorrectIds(
+                vec![String::from("a")],
+                vec![String::from("b")]
+            ))
         );
     }
 }

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -4,7 +4,7 @@ use num_bigint::BigInt;
 
 use crate::types::instruction::Register;
 use crate::vm::errors::vm_errors::VirtualMachineError;
-use crate::vm::hints::hint_utils::{add_segment, assert_le_felt, is_nn};
+use crate::vm::hints::hint_utils::{add_segment, assert_le_felt, is_nn, is_nn_out_of_range};
 use crate::vm::vm_core::VirtualMachine;
 
 #[derive(Debug, PartialEq, Clone)]
@@ -21,6 +21,9 @@ pub fn execute_hint(
         Ok("memory[ap] = segments.add()") => add_segment(vm),
         Ok("memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1") => {
             is_nn(vm, ids)
+        }
+        Ok("memory[ap] = 0 if 0 <= ((-ids.a - 1) % PRIME) < range_check_builtin.bound else 1") => {
+            is_nn_out_of_range(vm, ids)
         }
         Ok(
             "from starkware.cairo.common.math_utils import assert_integer

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -8,13 +8,13 @@ use crate::vm::hints::hint_utils::{add_segment, assert_le_felt, is_nn};
 use crate::vm::vm_core::VirtualMachine;
 
 //This strucuts belong to serde, replace with import path
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Reference {
     pub pc: Option<usize>,
     pub value_address: ValueAddress,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct ValueAddress {
     pub register: Register,
     pub offset: i32,

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -22,7 +22,6 @@ pub fn execute_hint(
                 )))
             }
         }
-
         Ok(hint_code) => Err(VirtualMachineError::UnknownHinError(String::from(
             hint_code,
         ))),

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -7,7 +7,7 @@ use crate::vm::errors::vm_errors::VirtualMachineError;
 use crate::vm::hints::hint_utils::{add_segment, assert_le_felt, is_nn};
 use crate::vm::vm_core::VirtualMachine;
 
-//This strucuts belong to serde, replace with import path
+//These structs belong to serde, replace with import path
 #[derive(Debug, PartialEq, Clone)]
 pub struct Reference {
     pub pc: Option<usize>,

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -156,10 +156,7 @@ mod tests {
             .unwrap();
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(
-            String::from("starkware.cairo.common.math_cmp.is_nn.a"),
-            bigint!(0),
-        );
+        ids.insert(String::from("a"), bigint!(0));
         //Create references
         vm.references = vec![HintReference {
             register: Register::FP,
@@ -200,10 +197,7 @@ mod tests {
             .unwrap();
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(
-            String::from("starkware.cairo.common.math_cmp.is_nn.a"),
-            bigint!(0),
-        );
+        ids.insert(String::from("a"), bigint!(0));
         //Create references
         vm.references = vec![HintReference {
             register: Register::FP,
@@ -254,10 +248,7 @@ mod tests {
             .unwrap();
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(
-            String::from("starkware.cairo.common.math_cmp.is_nn.a"),
-            bigint!(0),
-        );
+        ids.insert(String::from("a"), bigint!(0));
         //Create references
         vm.references = vec![HintReference {
             register: Register::FP,
@@ -288,16 +279,13 @@ mod tests {
         vm.run_context.ap = MaybeRelocatable::from((1, 0));
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(
-            String::from("starkware.cairo.common.math_cmp.is_nn.b"),
-            bigint!(0),
-        );
+        ids.insert(String::from("b"), bigint!(0));
         //Execute the hint
         assert_eq!(
             execute_hint(&mut vm, hint_code, ids),
             Err(VirtualMachineError::IncorrectIds(
-                vec![String::from("starkware.cairo.common.math_cmp.is_nn.a")],
-                vec![String::from("starkware.cairo.common.math_cmp.is_nn.b")]
+                vec![String::from("a")],
+                vec![String::from("b")]
             ))
         );
     }
@@ -322,10 +310,7 @@ mod tests {
         //Dont insert ids into memory
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(
-            String::from("starkware.cairo.common.math_cmp.is_nn.a"),
-            bigint!(0),
-        );
+        ids.insert(String::from("a"), bigint!(0));
         //Create references
         vm.references = vec![HintReference {
             register: Register::FP,
@@ -366,10 +351,7 @@ mod tests {
             .unwrap();
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(
-            String::from("starkware.cairo.common.math_cmp.is_nn.a"),
-            bigint!(0),
-        );
+        ids.insert(String::from("a"), bigint!(0));
         //Create references
         vm.references = vec![HintReference {
             register: Register::FP,
@@ -386,7 +368,7 @@ mod tests {
 
     #[test]
     fn run_assert_le_felt_valid() {
-        let hint_code = "from starkware.cairo.common.math_utils import assert_integerassert_integer(ids.a)\nassert_integer(ids.b)\na = ids.a % PRIME\nb = ids.b % PRIME\nassert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\nids.small_inputs = int(\n    a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"
+        let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\na = ids.a % PRIME\nb = ids.b % PRIME\nassert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\nids.small_inputs = int(\n    a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"
             .as_bytes();
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -424,18 +406,9 @@ mod tests {
             .unwrap();
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(
-            String::from("starkware.cairo.common.math.assert_le_felt.a"),
-            bigint!(0),
-        );
-        ids.insert(
-            String::from("starkware.cairo.common.math.assert_le_felt.b"),
-            bigint!(1),
-        );
-        ids.insert(
-            String::from("starkware.cairo.common.math.assert_le_felt.small_inputs"),
-            bigint!(2),
-        );
+        ids.insert(String::from("a"), bigint!(0));
+        ids.insert(String::from("b"), bigint!(1));
+        ids.insert(String::from("small_inputs"), bigint!(2));
         //Create references
         vm.references = vec![
             HintReference {
@@ -458,7 +431,7 @@ mod tests {
 
     #[test]
     fn run_is_assert_le_felt_invalid() {
-        let hint_code = "from starkware.cairo.common.math_utils import assert_integerassert_integer(ids.a)\nassert_integer(ids.b)\na = ids.a % PRIME\nb = ids.b % PRIME\nassert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\nids.small_inputs = int(\n    a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"
+        let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\na = ids.a % PRIME\nb = ids.b % PRIME\nassert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\nids.small_inputs = int(\n    a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"
             .as_bytes();
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -496,18 +469,9 @@ mod tests {
             .unwrap();
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(
-            String::from("starkware.cairo.common.math.assert_le_felt.a"),
-            bigint!(0),
-        );
-        ids.insert(
-            String::from("starkware.cairo.common.math.assert_le_felt.b"),
-            bigint!(1),
-        );
-        ids.insert(
-            String::from("starkware.cairo.common.math.assert_le_felt.small_inputs"),
-            bigint!(2),
-        );
+        ids.insert(String::from("a"), bigint!(0));
+        ids.insert(String::from("b"), bigint!(1));
+        ids.insert(String::from("small_inputs"), bigint!(2));
         //Create references
         vm.references = vec![
             HintReference {
@@ -532,7 +496,7 @@ mod tests {
 
     #[test]
     fn run_is_assert_le_felt_small_inputs_not_local() {
-        let hint_code = "from starkware.cairo.common.math_utils import assert_integerassert_integer(ids.a)\nassert_integer(ids.b)\na = ids.a % PRIME\nb = ids.b % PRIME\nassert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\nids.small_inputs = int(\n    a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"
+        let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\na = ids.a % PRIME\nb = ids.b % PRIME\nassert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\nids.small_inputs = int(\n    a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"
             .as_bytes();
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -570,18 +534,9 @@ mod tests {
             .unwrap();
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(
-            String::from("starkware.cairo.common.math.assert_le_felt.a"),
-            bigint!(0),
-        );
-        ids.insert(
-            String::from("starkware.cairo.common.math.assert_le_felt.b"),
-            bigint!(1),
-        );
-        ids.insert(
-            String::from("starkware.cairo.common.math.assert_le_felt.small_inputs"),
-            bigint!(2),
-        );
+        ids.insert(String::from("a"), bigint!(0));
+        ids.insert(String::from("b"), bigint!(1));
+        ids.insert(String::from("small_inputs"), bigint!(2));
         //Create references
         vm.references = vec![
             HintReference {
@@ -606,7 +561,7 @@ mod tests {
 
     #[test]
     fn run_is_assert_le_felt_a_is_not_integer() {
-        let hint_code = "from starkware.cairo.common.math_utils import assert_integerassert_integer(ids.a)\nassert_integer(ids.b)\na = ids.a % PRIME\nb = ids.b % PRIME\nassert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\nids.small_inputs = int(\n    a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"
+        let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\na = ids.a % PRIME\nb = ids.b % PRIME\nassert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\nids.small_inputs = int(\n    a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"
             .as_bytes();
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -644,18 +599,9 @@ mod tests {
             .unwrap();
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(
-            String::from("starkware.cairo.common.math.assert_le_felt.a"),
-            bigint!(0),
-        );
-        ids.insert(
-            String::from("starkware.cairo.common.math.assert_le_felt.b"),
-            bigint!(1),
-        );
-        ids.insert(
-            String::from("starkware.cairo.common.math.assert_le_felt.small_inputs"),
-            bigint!(2),
-        );
+        ids.insert(String::from("a"), bigint!(0));
+        ids.insert(String::from("b"), bigint!(1));
+        ids.insert(String::from("small_inputs"), bigint!(2));
         //Create references
         vm.references = vec![
             HintReference {
@@ -682,7 +628,7 @@ mod tests {
 
     #[test]
     fn run_is_assert_le_felt_b_is_not_integer() {
-        let hint_code = "from starkware.cairo.common.math_utils import assert_integerassert_integer(ids.a)\nassert_integer(ids.b)\na = ids.a % PRIME\nb = ids.b % PRIME\nassert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\nids.small_inputs = int(\n    a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"
+        let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\na = ids.a % PRIME\nb = ids.b % PRIME\nassert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\nids.small_inputs = int(\n    a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"
             .as_bytes();
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -720,18 +666,9 @@ mod tests {
             .unwrap();
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(
-            String::from("starkware.cairo.common.math.assert_le_felt.a"),
-            bigint!(0),
-        );
-        ids.insert(
-            String::from("starkware.cairo.common.math.assert_le_felt.b"),
-            bigint!(1),
-        );
-        ids.insert(
-            String::from("starkware.cairo.common.math.assert_le_felt.small_inputs"),
-            bigint!(2),
-        );
+        ids.insert(String::from("a"), bigint!(0));
+        ids.insert(String::from("b"), bigint!(1));
+        ids.insert(String::from("small_inputs"), bigint!(2));
         //Create references
         vm.references = vec![
             HintReference {
@@ -783,10 +720,7 @@ mod tests {
             .unwrap();
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(
-            String::from("starkware.cairo.common.math_cmp.is_nn.a"),
-            bigint!(0),
-        );
+        ids.insert(String::from("a"), bigint!(0));
         //Create references
         vm.references = vec![HintReference {
             register: Register::FP,
@@ -828,10 +762,7 @@ mod tests {
             .unwrap();
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(
-            String::from("starkware.cairo.common.math_cmp.is_nn.a"),
-            bigint!(0),
-        );
+        ids.insert(String::from("a"), bigint!(0));
         //Create references
         vm.references = vec![HintReference {
             register: Register::FP,

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -19,6 +19,11 @@ pub struct ValueAddress {
     pub register: Register,
     pub offset: i32,
 }
+#[derive(Debug, PartialEq, Clone)]
+pub struct HintReference {
+    pub register: Register,
+    pub offset: i32,
+}
 pub fn execute_hint(
     vm: &mut VirtualMachine,
     hint_code: &[u8],
@@ -131,12 +136,9 @@ mod tests {
         let mut ids = HashMap::<String, BigInt>::new();
         ids.insert(String::from("a"), bigint!(0));
         //Create references
-        vm.references = vec![Reference {
-            pc: None,
-            value_address: ValueAddress {
-                register: Register::FP,
-                offset: -1,
-            },
+        vm.references = vec![HintReference {
+            register: Register::FP,
+            offset: -1,
         }];
         //Execute the hint
         execute_hint(&mut vm, hint_code, ids).expect("Error while executing hint");
@@ -175,12 +177,9 @@ mod tests {
         let mut ids = HashMap::<String, BigInt>::new();
         ids.insert(String::from("a"), bigint!(0));
         //Create references
-        vm.references = vec![Reference {
-            pc: None,
-            value_address: ValueAddress {
-                register: Register::FP,
-                offset: -1,
-            },
+        vm.references = vec![HintReference {
+            register: Register::FP,
+            offset: -1,
         }];
         //Execute the hint
         execute_hint(&mut vm, hint_code, ids).expect("Error while executing hint");
@@ -229,12 +228,9 @@ mod tests {
         let mut ids = HashMap::<String, BigInt>::new();
         ids.insert(String::from("a"), bigint!(0));
         //Create references
-        vm.references = vec![Reference {
-            pc: None,
-            value_address: ValueAddress {
-                register: Register::FP,
-                offset: -1,
-            },
+        vm.references = vec![HintReference {
+            register: Register::FP,
+            offset: -1,
         }];
         //Execute the hint
         assert_eq!(
@@ -294,12 +290,9 @@ mod tests {
         let mut ids = HashMap::<String, BigInt>::new();
         ids.insert(String::from("a"), bigint!(0));
         //Create references
-        vm.references = vec![Reference {
-            pc: None,
-            value_address: ValueAddress {
-                register: Register::FP,
-                offset: -1,
-            },
+        vm.references = vec![HintReference {
+            register: Register::FP,
+            offset: -1,
         }];
         //Execute the hint
         assert_eq!(
@@ -338,12 +331,9 @@ mod tests {
         let mut ids = HashMap::<String, BigInt>::new();
         ids.insert(String::from("a"), bigint!(0));
         //Create references
-        vm.references = vec![Reference {
-            pc: None,
-            value_address: ValueAddress {
-                register: Register::FP,
-                offset: -1,
-            },
+        vm.references = vec![HintReference {
+            register: Register::FP,
+            offset: -1,
         }];
         //Execute the hint
         assert_eq!(
@@ -407,26 +397,17 @@ mod tests {
         ids.insert(String::from("small_inputs"), bigint!(2));
         //Create references
         vm.references = vec![
-            Reference {
-                pc: None,
-                value_address: ValueAddress {
-                    register: Register::FP,
-                    offset: -4,
-                },
+            HintReference {
+                register: Register::FP,
+                offset: -4,
             },
-            Reference {
-                pc: None,
-                value_address: ValueAddress {
-                    register: Register::FP,
-                    offset: -3,
-                },
+            HintReference {
+                register: Register::FP,
+                offset: -3,
             },
-            Reference {
-                pc: None,
-                value_address: ValueAddress {
-                    register: Register::FP,
-                    offset: -2,
-                },
+            HintReference {
+                register: Register::FP,
+                offset: -2,
             },
         ];
         //Execute the hint
@@ -487,26 +468,17 @@ mod tests {
         ids.insert(String::from("small_inputs"), bigint!(2));
         //Create references
         vm.references = vec![
-            Reference {
-                pc: None,
-                value_address: ValueAddress {
-                    register: Register::FP,
-                    offset: -4,
-                },
+            HintReference {
+                register: Register::FP,
+                offset: -4,
             },
-            Reference {
-                pc: None,
-                value_address: ValueAddress {
-                    register: Register::FP,
-                    offset: -3,
-                },
+            HintReference {
+                register: Register::FP,
+                offset: -3,
             },
-            Reference {
-                pc: None,
-                value_address: ValueAddress {
-                    register: Register::FP,
-                    offset: -2,
-                },
+            HintReference {
+                register: Register::FP,
+                offset: -2,
             },
         ];
         //Execute the hint

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -101,11 +101,11 @@ pub fn is_nn(
                         return Err(VirtualMachineError::NoRangeCheckBuiltin);
                     };
                     //Main logic (assert a is not negative and within the expected range)
-                    let mut value = bigint!(0);
+                    let mut value = bigint!(1);
                     if a % vm.prime.clone() >= bigint!(0)
                         && a % vm.prime.clone() < range_check_builtin._bound
                     {
-                        value = bigint!(1);
+                        value = bigint!(0);
                     }
                     return match vm
                         .memory
@@ -165,12 +165,12 @@ pub fn is_nn_out_of_range(
                         return Err(VirtualMachineError::NoRangeCheckBuiltin);
                     };
                     //Main logic (assert a is not negative and within the expected range)
-                    let mut value = bigint!(0);
+                    let mut value = bigint!(1);
                     if (-a.clone() - bigint!(1)) % vm.prime.clone() >= bigint!(0)
                         && (-a.clone() - bigint!(1)) % &vm.prime.clone()
                             < range_check_builtin._bound
                     {
-                        value = bigint!(1);
+                        value = bigint!(0);
                     }
                     return match vm
                         .memory

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -23,38 +23,68 @@ pub fn add_segment(vm: &mut VirtualMachine) -> Result<(), VirtualMachineError> {
 //Implements hint: memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1
 pub fn is_nn(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: HashMap<String, MaybeRelocatable>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the needed values
-    if let Some(a) = ids.get(&String::from("a")) {
-        for (name, builtin) in &vm.builtin_runners {
-            //Check that range_check_builtin is present
-            if name == &String::from("range_check") {
-                match builtin.as_any().downcast_ref::<RangeCheckBuiltinRunner>() {
-                    None => return Err(VirtualMachineError::NoRangeCheckBuiltin),
-                    Some(builtin) => {
-                        //Main logic (assert a is not negative and within the expected range)
-                        let mut value = bigint!(0);
-                        if *a > bigint!(0) && *a < vm.prime && *a < builtin._bound {
-                            value = bigint!(1);
-                        }
-                        match vm
-                            .memory
-                            .insert(&vm.run_context.ap, &MaybeRelocatable::from(value))
-                        {
-                            Ok(_) => return Ok(()),
-                            Err(memory_error) => {
-                                return Err(VirtualMachineError::MemoryError(memory_error))
+    if let Some(a_addr) = ids.get(&String::from("a")) {
+        //Check that the ids are in memory
+        match vm.memory.get(a_addr) {
+            Ok(Some(maybe_rel_a)) => {
+                //Check that the value at the ids address is an Int
+                if let &MaybeRelocatable::Int(ref a) = maybe_rel_a {
+                    for (name, builtin) in &vm.builtin_runners {
+                        //Check that range_check_builtin is present
+                        if name == &String::from("range_check") {
+                            match builtin.as_any().downcast_ref::<RangeCheckBuiltinRunner>() {
+                                None => return Err(VirtualMachineError::NoRangeCheckBuiltin),
+                                Some(builtin) => {
+                                    //Main logic (assert a is not negative and within the expected range)
+                                    let mut value = bigint!(0);
+                                    if *a > bigint!(0) && *a < vm.prime && *a < builtin._bound {
+                                        value = bigint!(1);
+                                    }
+                                    match vm
+                                        .memory
+                                        .insert(&vm.run_context.ap, &MaybeRelocatable::from(value))
+                                    {
+                                        Ok(_) => return Ok(()),
+                                        Err(memory_error) => {
+                                            return Err(VirtualMachineError::MemoryError(
+                                                memory_error,
+                                            ))
+                                        }
+                                    }
+                                }
                             }
                         }
                     }
+                    return Err(VirtualMachineError::NoRangeCheckBuiltin);
+                } else {
+                    return Err(VirtualMachineError::ExpectedInteger(a_addr.clone()));
                 }
             }
-        }
-        return Err(VirtualMachineError::NoRangeCheckBuiltin);
+            Ok(None) => return Err(VirtualMachineError::MemoryGet(a_addr.clone())),
+            Err(memory_error) => return Err(VirtualMachineError::MemoryError(memory_error)),
+        };
+    } else {
+        Err(VirtualMachineError::IncorrectIds(
+            vec![String::from("a")],
+            ids.into_keys().collect(),
+        ))
     }
-    Err(VirtualMachineError::IncorrectIds(
-        vec![String::from("a")],
-        ids.into_keys().collect(),
-    ))
+}
+//Implements hint:from starkware.cairo.common.math_utils import assert_integer
+//        assert_integer(ids.a)
+//        assert_integer(ids.b)
+//        a = ids.a % PRIME
+//        b = ids.b % PRIME
+//        assert a <= b, f'a = {a} is not less than or equal to b = {b}.'
+
+//        ids.small_inputs = int(
+//            a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)
+pub fn assert_le_felt(
+    _vm: &mut VirtualMachine,
+    _ids: HashMap<String, MaybeRelocatable>,
+) -> Result<(), VirtualMachineError> {
+    Ok(())
 }

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -53,5 +53,8 @@ pub fn is_nn(
         }
         return Err(VirtualMachineError::NoRangeCheckBuiltin);
     }
-    Err(VirtualMachineError::IncorrectIds)
+    Err(VirtualMachineError::IncorrectIds(
+        vec![String::from("a")],
+        ids.into_keys().collect(),
+    ))
 }

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -1,4 +1,5 @@
 use num_bigint::BigInt;
+use num_integer::Integer;
 use num_traits::{FromPrimitive, ToPrimitive};
 use std::collections::HashMap;
 
@@ -102,7 +103,74 @@ pub fn is_nn(
                     };
                     //Main logic (assert a is not negative and within the expected range)
                     let mut value = bigint!(0);
-                    if *a > bigint!(0) && *a < vm.prime && *a < range_check_builtin._bound {
+                    if a.mod_floor(&vm.prime) > bigint!(0)
+                        && a.mod_floor(&vm.prime) < range_check_builtin._bound
+                    {
+                        value = bigint!(1);
+                    }
+                    return match vm
+                        .memory
+                        .insert(&vm.run_context.ap, &MaybeRelocatable::from(value))
+                    {
+                        Ok(_) => Ok(()),
+                        Err(memory_error) => Err(VirtualMachineError::MemoryError(memory_error)),
+                    };
+                }
+            }
+            Err(VirtualMachineError::NoRangeCheckBuiltin)
+        }
+        Ok(None) => Err(VirtualMachineError::MemoryGet(a_addr.clone())),
+        Err(memory_error) => Err(VirtualMachineError::MemoryError(memory_error)),
+    }
+}
+
+//Implements hint: memory[ap] = 0 if 0 <= ((-ids.a - 1) % PRIME) < range_check_builtin.bound else 1
+pub fn is_nn_out_of_range(
+    vm: &mut VirtualMachine,
+    ids: HashMap<String, BigInt>,
+) -> Result<(), VirtualMachineError> {
+    //Check that ids contains the reference id for each variable used by the hint
+    let a_ref =
+        if let Some(a_ref) = ids.get(&String::from("starkware.cairo.common.math_cmp.is_nn.a")) {
+            a_ref
+        } else {
+            return Err(VirtualMachineError::IncorrectIds(
+                vec![String::from("starkware.cairo.common.math_cmp.is_nn.a")],
+                ids.into_keys().collect(),
+            ));
+        };
+    //Check that each reference id corresponds to a value in the reference manager
+    let a_addr =
+        if let Some(a_addr) = get_address_from_reference(a_ref, &vm.references, &vm.run_context) {
+            a_addr
+        } else {
+            return Err(VirtualMachineError::FailedToGetReference(a_ref.clone()));
+        };
+    //Check that the ids are in memory
+    match vm.memory.get(&a_addr) {
+        Ok(Some(maybe_rel_a)) => {
+            //Check that the value at the ids address is an Int
+            let a = if let MaybeRelocatable::Int(ref a) = maybe_rel_a {
+                a
+            } else {
+                return Err(VirtualMachineError::ExpectedInteger(a_addr.clone()));
+            };
+            for (name, builtin) in &vm.builtin_runners {
+                //Check that range_check_builtin is present
+                if name == &String::from("range_check") {
+                    let range_check_builtin = if let Some(range_check_builtin) =
+                        builtin.as_any().downcast_ref::<RangeCheckBuiltinRunner>()
+                    {
+                        range_check_builtin
+                    } else {
+                        return Err(VirtualMachineError::NoRangeCheckBuiltin);
+                    };
+                    //Main logic (assert a is not negative and within the expected range)
+                    let mut value = bigint!(0);
+                    if (-a.clone() - bigint!(1)).mod_floor(&vm.prime) > bigint!(0)
+                        && (-a.clone() - bigint!(1)).mod_floor(&vm.prime)
+                            < range_check_builtin._bound
+                    {
                         value = bigint!(1);
                     }
                     return match vm

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -1,5 +1,4 @@
 use num_bigint::BigInt;
-use num_integer::Integer;
 use num_traits::{FromPrimitive, ToPrimitive};
 use std::collections::HashMap;
 
@@ -103,8 +102,8 @@ pub fn is_nn(
                     };
                     //Main logic (assert a is not negative and within the expected range)
                     let mut value = bigint!(0);
-                    if a.mod_floor(&vm.prime) > bigint!(0)
-                        && a.mod_floor(&vm.prime) < range_check_builtin._bound
+                    if a % vm.prime.clone() >= bigint!(0)
+                        && a % vm.prime.clone() < range_check_builtin._bound
                     {
                         value = bigint!(1);
                     }
@@ -167,8 +166,8 @@ pub fn is_nn_out_of_range(
                     };
                     //Main logic (assert a is not negative and within the expected range)
                     let mut value = bigint!(0);
-                    if (-a.clone() - bigint!(1)).mod_floor(&vm.prime) > bigint!(0)
-                        && (-a.clone() - bigint!(1)).mod_floor(&vm.prime)
+                    if (-a.clone() - bigint!(1)) % vm.prime.clone() >= bigint!(0)
+                        && (-a.clone() - bigint!(1)) % &vm.prime.clone()
                             < range_check_builtin._bound
                     {
                         value = bigint!(1);

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -11,36 +11,36 @@ use crate::{
     },
 };
 
-use super::execute_hint::{Reference, ValueAddress};
+use super::execute_hint::HintReference;
 fn compute_addr_from_reference(
-    value_address: &ValueAddress,
+    hint_reference: &HintReference,
     run_context: &RunContext,
 ) -> Option<MaybeRelocatable> {
-    let register = match value_address.register {
+    let register = match hint_reference.register {
         Register::FP => run_context.fp.clone(),
         Register::AP => run_context.ap.clone(),
     };
     if let MaybeRelocatable::RelocatableValue(relocatable) = register {
-        if value_address.offset.is_negative()
-            && relocatable.offset < value_address.offset.abs() as usize
+        if hint_reference.offset.is_negative()
+            && relocatable.offset < hint_reference.offset.abs() as usize
         {
             return None;
         }
         return Some(MaybeRelocatable::from((
             relocatable.segment_index,
-            (relocatable.offset as i32 + value_address.offset) as usize,
+            (relocatable.offset as i32 + hint_reference.offset) as usize,
         )));
     }
     None
 }
 fn get_address_from_reference(
     reference_id: &BigInt,
-    references: &Vec<Reference>,
+    references: &Vec<HintReference>,
     run_context: &RunContext,
 ) -> Option<MaybeRelocatable> {
     if let Some(index) = reference_id.to_usize() {
         if index < references.len() {
-            return compute_addr_from_reference(&references[index].value_address, run_context);
+            return compute_addr_from_reference(&references[index], run_context);
         }
     }
     None

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -1,3 +1,7 @@
+use std::collections::HashMap;
+
+use num_bigint::BigInt;
+
 use crate::{
     types::relocatable::MaybeRelocatable,
     vm::{errors::vm_errors::VirtualMachineError, vm_core::VirtualMachine},
@@ -10,4 +14,10 @@ pub fn add_segment(vm: &mut VirtualMachine) -> Result<(), VirtualMachineError> {
         Ok(_) => Ok(()),
         Err(memory_error) => Err(VirtualMachineError::MemoryError(memory_error)),
     }
+}
+pub fn is_nn(
+    _vm: &mut VirtualMachine,
+    _ids: HashMap<String, BigInt>,
+) -> Result<(), VirtualMachineError> {
+    Ok(())
 }

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -50,8 +50,8 @@ pub fn is_nn(
                     }
                 }
             }
-            return Err(VirtualMachineError::NoRangeCheckBuiltin);
         }
+        return Err(VirtualMachineError::NoRangeCheckBuiltin);
     }
     Err(VirtualMachineError::IncorrectIds)
 }

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -34,9 +34,9 @@ pub fn is_nn(
                     None => return Err(VirtualMachineError::NoRangeCheckBuiltin),
                     Some(builtin) => {
                         //Main logic (assert a is not negative and within the expected range)
-                        let mut value = bigint!(1);
+                        let mut value = bigint!(0);
                         if *a > bigint!(0) && *a < vm.prime && *a < builtin._bound {
-                            value = bigint!(0);
+                            value = bigint!(1);
                         }
                         match vm
                             .memory

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -65,15 +65,14 @@ pub fn is_nn(
     ids: HashMap<String, BigInt>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
-    let a_ref =
-        if let Some(a_ref) = ids.get(&String::from("starkware.cairo.common.math_cmp.is_nn.a")) {
-            a_ref
-        } else {
-            return Err(VirtualMachineError::IncorrectIds(
-                vec![String::from("starkware.cairo.common.math_cmp.is_nn.a")],
-                ids.into_keys().collect(),
-            ));
-        };
+    let a_ref = if let Some(a_ref) = ids.get(&String::from("a")) {
+        a_ref
+    } else {
+        return Err(VirtualMachineError::IncorrectIds(
+            vec![String::from("a")],
+            ids.into_keys().collect(),
+        ));
+    };
     //Check that each reference id corresponds to a value in the reference manager
     let a_addr =
         if let Some(a_addr) = get_address_from_reference(a_ref, &vm.references, &vm.run_context) {
@@ -129,15 +128,14 @@ pub fn is_nn_out_of_range(
     ids: HashMap<String, BigInt>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
-    let a_ref =
-        if let Some(a_ref) = ids.get(&String::from("starkware.cairo.common.math_cmp.is_nn.a")) {
-            a_ref
-        } else {
-            return Err(VirtualMachineError::IncorrectIds(
-                vec![String::from("starkware.cairo.common.math_cmp.is_nn.a")],
-                ids.into_keys().collect(),
-            ));
-        };
+    let a_ref = if let Some(a_ref) = ids.get(&String::from("a")) {
+        a_ref
+    } else {
+        return Err(VirtualMachineError::IncorrectIds(
+            vec![String::from("a")],
+            ids.into_keys().collect(),
+        ));
+    };
     //Check that each reference id corresponds to a value in the reference manager
     let a_addr =
         if let Some(a_addr) = get_address_from_reference(a_ref, &vm.references, &vm.run_context) {
@@ -203,23 +201,17 @@ pub fn assert_le_felt(
     //Check that ids contains the reference id for each variable used by the hint
     let (a_ref, b_ref, small_inputs_ref) =
         if let (Some(a_ref), Some(b_ref), Some(small_inputs_ref)) = (
-            ids.get(&String::from(
-                "starkware.cairo.common.math.assert_le_felt.a",
-            )),
-            ids.get(&String::from(
-                "starkware.cairo.common.math.assert_le_felt.b",
-            )),
-            ids.get(&String::from(
-                "starkware.cairo.common.math.assert_le_felt.small_inputs",
-            )),
+            ids.get(&String::from("a")),
+            ids.get(&String::from("b")),
+            ids.get(&String::from("small_inputs")),
         ) {
             (a_ref, b_ref, small_inputs_ref)
         } else {
             return Err(VirtualMachineError::IncorrectIds(
                 vec![
-                    String::from("starkware.cairo.common.math.assert_le_felt.a"),
-                    String::from("starkware.cairo.common.math.assert_le_felt.b"),
-                    String::from("starkware.cairo.common.math.assert_le_felt.small_inputs"),
+                    String::from("a"),
+                    String::from("b"),
+                    String::from("small_inputs"),
                 ],
                 ids.into_keys().collect(),
             ));

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -59,7 +59,6 @@ pub fn add_segment(vm: &mut VirtualMachine) -> Result<(), VirtualMachineError> {
 pub fn is_nn(
     vm: &mut VirtualMachine,
     ids: HashMap<String, BigInt>,
-    references: Vec<Reference>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
     let a_ref = if let Some(a_ref) = ids.get(&String::from("a")) {
@@ -72,7 +71,7 @@ pub fn is_nn(
     };
     //Check that each reference id corresponds to a value in the reference manager
     let a_addr =
-        if let Some(a_addr) = get_address_from_reference(a_ref, &references, &vm.run_context) {
+        if let Some(a_addr) = get_address_from_reference(a_ref, &vm.references, &vm.run_context) {
             a_addr
         } else {
             return Err(VirtualMachineError::FailedToGetReference(a_ref.clone()));
@@ -128,7 +127,6 @@ pub fn is_nn(
 pub fn assert_le_felt(
     vm: &mut VirtualMachine,
     ids: HashMap<String, BigInt>,
-    references: Vec<Reference>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
     if let (Some(a_ref), Some(b_ref), Some(small_inputs_ref)) = (
@@ -138,9 +136,9 @@ pub fn assert_le_felt(
     ) {
         //Check that each reference id corresponds to a value in the reference manager
         if let (Some(a_addr), Some(b_addr), Some(small_inputs_addr)) = (
-            get_address_from_reference(a_ref, &references, &vm.run_context),
-            get_address_from_reference(b_ref, &references, &vm.run_context),
-            get_address_from_reference(small_inputs_ref, &references, &vm.run_context),
+            get_address_from_reference(a_ref, &vm.references, &vm.run_context),
+            get_address_from_reference(b_ref, &vm.references, &vm.run_context),
+            get_address_from_reference(small_inputs_ref, &vm.references, &vm.run_context),
         ) {
             //Check that the ids are in memory (except for small_inputs which is local, and should contain None)
             //small_inputs needs to be None, as we cant change it value otherwise

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -1,18 +1,14 @@
+use crate::types::{instruction::Register, relocatable::MaybeRelocatable};
+use crate::vm::{
+    context::run_context::RunContext, errors::vm_errors::VirtualMachineError,
+    runners::builtin_runner::RangeCheckBuiltinRunner, vm_core::VirtualMachine,
+};
+use crate::{bigint, vm::hints::execute_hint::HintReference};
 use num_bigint::BigInt;
 use num_traits::{FromPrimitive, ToPrimitive};
 use std::collections::HashMap;
 
-use crate::{
-    bigint,
-    types::{instruction::Register, relocatable::MaybeRelocatable},
-    vm::{
-        context::run_context::RunContext, errors::vm_errors::VirtualMachineError,
-        runners::builtin_runner::RangeCheckBuiltinRunner, vm_core::VirtualMachine,
-    },
-};
-
 ///Computes the memory address indicated by the HintReference
-use super::execute_hint::HintReference;
 fn compute_addr_from_reference(
     hint_reference: &HintReference,
     run_context: &RunContext,

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -29,7 +29,7 @@ pub fn is_nn(
     if let Some(a) = ids.get(&String::from("a")) {
         for (name, builtin) in &vm.builtin_runners {
             //Check that range_check_builtin is present
-            if *name == String::from("range_check") {
+            if name == &String::from("range_check") {
                 match builtin.as_any().downcast_ref::<RangeCheckBuiltinRunner>() {
                     None => return Err(VirtualMachineError::NoRangeCheckBuiltin),
                     Some(builtin) => {

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -65,14 +65,15 @@ pub fn is_nn(
     ids: HashMap<String, BigInt>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
-    let a_ref = if let Some(a_ref) = ids.get(&String::from("a")) {
-        a_ref
-    } else {
-        return Err(VirtualMachineError::IncorrectIds(
-            vec![String::from("a")],
-            ids.into_keys().collect(),
-        ));
-    };
+    let a_ref =
+        if let Some(a_ref) = ids.get(&String::from("starkware.cairo.common.math_cmp.is_nn.a")) {
+            a_ref
+        } else {
+            return Err(VirtualMachineError::IncorrectIds(
+                vec![String::from("starkware.cairo.common.math_cmp.is_nn.a")],
+                ids.into_keys().collect(),
+            ));
+        };
     //Check that each reference id corresponds to a value in the reference manager
     let a_addr =
         if let Some(a_addr) = get_address_from_reference(a_ref, &vm.references, &vm.run_context) {
@@ -135,17 +136,23 @@ pub fn assert_le_felt(
     //Check that ids contains the reference id for each variable used by the hint
     let (a_ref, b_ref, small_inputs_ref) =
         if let (Some(a_ref), Some(b_ref), Some(small_inputs_ref)) = (
-            ids.get(&String::from("a")),
-            ids.get(&String::from("b")),
-            ids.get(&String::from("small_inputs")),
+            ids.get(&String::from(
+                "starkware.cairo.common.math.assert_le_felt.a",
+            )),
+            ids.get(&String::from(
+                "starkware.cairo.common.math.assert_le_felt.b",
+            )),
+            ids.get(&String::from(
+                "starkware.cairo.common.math.assert_le_felt.small_inputs",
+            )),
         ) {
             (a_ref, b_ref, small_inputs_ref)
         } else {
             return Err(VirtualMachineError::IncorrectIds(
                 vec![
-                    String::from("a"),
-                    String::from("b"),
-                    String::from("small_inputs"),
+                    String::from("starkware.cairo.common.math.assert_le_felt.a"),
+                    String::from("starkware.cairo.common.math.assert_le_felt.b"),
+                    String::from("starkware.cairo.common.math.assert_le_felt.small_inputs"),
                 ],
                 ids.into_keys().collect(),
             ));

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -1,10 +1,14 @@
+use num_bigint::BigInt;
+use num_traits::FromPrimitive;
 use std::collections::HashMap;
 
-use num_bigint::BigInt;
-
 use crate::{
+    bigint,
     types::relocatable::MaybeRelocatable,
-    vm::{errors::vm_errors::VirtualMachineError, vm_core::VirtualMachine},
+    vm::{
+        errors::vm_errors::VirtualMachineError, runners::builtin_runner::RangeCheckBuiltinRunner,
+        vm_core::VirtualMachine,
+    },
 };
 
 pub fn add_segment(vm: &mut VirtualMachine) -> Result<(), VirtualMachineError> {
@@ -15,9 +19,39 @@ pub fn add_segment(vm: &mut VirtualMachine) -> Result<(), VirtualMachineError> {
         Err(memory_error) => Err(VirtualMachineError::MemoryError(memory_error)),
     }
 }
+
+//Implements hint: memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1
 pub fn is_nn(
-    _vm: &mut VirtualMachine,
-    _ids: HashMap<String, BigInt>,
+    vm: &mut VirtualMachine,
+    ids: HashMap<String, BigInt>,
 ) -> Result<(), VirtualMachineError> {
-    Ok(())
+    //Check that ids contains the needed values
+    if let Some(a) = ids.get(&String::from("a")) {
+        for (name, builtin) in &vm.builtin_runners {
+            //Check that range_check_builtin is present
+            if *name == String::from("range_check") {
+                match builtin.as_any().downcast_ref::<RangeCheckBuiltinRunner>() {
+                    None => return Err(VirtualMachineError::NoRangeCheckBuiltin),
+                    Some(builtin) => {
+                        //Main logic (assert a is not negative and within the expected range)
+                        let mut value = bigint!(1);
+                        if *a > bigint!(0) && *a < vm.prime && *a < builtin._bound {
+                            value = bigint!(0);
+                        }
+                        match vm
+                            .memory
+                            .insert(&vm.run_context.ap, &MaybeRelocatable::from(value))
+                        {
+                            Ok(_) => return Ok(()),
+                            Err(memory_error) => {
+                                return Err(VirtualMachineError::MemoryError(memory_error))
+                            }
+                        }
+                    }
+                }
+            }
+            return Err(VirtualMachineError::NoRangeCheckBuiltin);
+        }
+    }
+    Err(VirtualMachineError::IncorrectIds)
 }

--- a/src/vm/runners/builtin_runner.rs
+++ b/src/vm/runners/builtin_runner.rs
@@ -1,3 +1,5 @@
+use std::any::Any;
+
 use crate::math_utils::{ec_add, ec_double};
 use crate::types::relocatable::{MaybeRelocatable, Relocatable};
 use crate::vm::errors::memory_errors::MemoryError;
@@ -17,7 +19,7 @@ pub struct RangeCheckBuiltinRunner {
     _cells_per_instance: i32,
     _n_input_cells: i32,
     _inner_rc_bound: BigInt,
-    _bound: BigInt,
+    pub _bound: BigInt,
     _n_parts: u32,
 }
 pub struct OutputBuiltinRunner {
@@ -68,6 +70,7 @@ pub trait BuiltinRunner {
         address: &MaybeRelocatable,
         memory: &Memory,
     ) -> Result<Option<MaybeRelocatable>, RunnerError>;
+    fn as_any(&self) -> &dyn Any;
 }
 
 impl RangeCheckBuiltinRunner {
@@ -134,6 +137,10 @@ impl BuiltinRunner for RangeCheckBuiltinRunner {
     ) -> Result<Option<MaybeRelocatable>, RunnerError> {
         Ok(None)
     }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }
 
 impl OutputBuiltinRunner {
@@ -177,6 +184,10 @@ impl BuiltinRunner for OutputBuiltinRunner {
         _memory: &Memory,
     ) -> Result<Option<MaybeRelocatable>, RunnerError> {
         Ok(None)
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 
@@ -269,6 +280,10 @@ impl BuiltinRunner for HashBuiltinRunner {
             Err(RunnerError::NonRelocatableAddress)
         }
     }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }
 
 impl BitwiseBuiltinRunner {
@@ -353,6 +368,10 @@ impl BuiltinRunner for BitwiseBuiltinRunner {
         } else {
             Err(RunnerError::NonRelocatableAddress)
         }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 
@@ -521,6 +540,10 @@ impl BuiltinRunner for EcOpBuiltinRunner {
         } else {
             Err(RunnerError::NonRelocatableAddress)
         }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -11,7 +11,7 @@ use crate::vm::runners::builtin_runner::{
     RangeCheckBuiltinRunner,
 };
 use crate::vm::trace::trace_entry::{relocate_trace_register, RelocatedTraceEntry};
-use crate::vm::vm_core::VirtualMachine;
+use crate::vm::vm_core::{HintData, VirtualMachine};
 use num_bigint::BigInt;
 use num_traits::FromPrimitive;
 use std::collections::HashMap;
@@ -221,11 +221,8 @@ impl CairoRunner {
             Ok(_) => Ok(()),
         }
     }
-    fn get_hint_dictionary(
-        &self,
-    ) -> HashMap<MaybeRelocatable, Vec<(Vec<u8>, HashMap<String, BigInt>)>> {
-        let mut hint_dictionary =
-            HashMap::<MaybeRelocatable, Vec<(Vec<u8>, HashMap<String, BigInt>)>>::new();
+    fn get_hint_dictionary(&self) -> HashMap<MaybeRelocatable, Vec<HintData>> {
+        let mut hint_dictionary = HashMap::<MaybeRelocatable, Vec<HintData>>::new();
         for (_hint_index, hints) in self.program.hints.iter() {
             for hint_data in hints.iter() {
                 let key = MaybeRelocatable::from((
@@ -235,10 +232,13 @@ impl CairoRunner {
                 //TODO: replace HashMap::new() with proper ids once ids is deserialized
                 if let Some(hint_list) = hint_dictionary.get_mut(&key) {
                     //Add hint code to list of hints at given pc
-                    hint_list.push((hint_data.code.clone(), HashMap::new()));
+                    hint_list.push(HintData::new(hint_data.code.clone(), HashMap::new()));
                 } else {
                     //Insert the first hint at a given pc
-                    hint_dictionary.insert(key, vec![(hint_data.code.clone(), HashMap::new())]);
+                    hint_dictionary.insert(
+                        key,
+                        vec![HintData::new(hint_data.code.clone(), HashMap::new())],
+                    );
                 }
             }
         }

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -254,13 +254,25 @@ impl CairoRunner {
                         key,
                         vec![HintData::new(
                             hint_data.code.clone(),
-                            hint_data.flow_tracking_data.reference_ids.clone(),
+                            CairoRunner::remove_path_from_reference_ids(
+                                &hint_data.flow_tracking_data.reference_ids,
+                            ),
                         )],
                     );
                 }
             }
         }
         hint_dictionary
+    }
+
+    fn remove_path_from_reference_ids(
+        referece_ids: &HashMap<String, BigInt>,
+    ) -> HashMap<String, BigInt> {
+        let mut reference_ids_new = HashMap::<String, BigInt>::new();
+        for (path, value) in referece_ids {
+            reference_ids_new.insert(path.rsplit('.').next().unwrap().to_string(), value.clone());
+        }
+        reference_ids_new
     }
 
     pub fn run_until_pc(&mut self, address: MaybeRelocatable) -> Result<(), VirtualMachineError> {

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -216,6 +216,7 @@ impl CairoRunner {
             builtin.add_validation_rule(&mut self.vm.memory);
         }
         self.vm.hints = self.get_hint_dictionary();
+        self.vm.references = self.program.reference_manager.references.clone();
         match self.vm.memory.validate_existing_memory() {
             Err(error) => Err(RunnerError::MemoryValidationError(error)),
             Ok(_) => Ok(()),
@@ -364,6 +365,7 @@ mod tests {
     use num_bigint::Sign;
 
     use super::*;
+    use crate::types::program::ReferenceManager;
     use crate::vm::trace::trace_entry::TraceEntry;
     use crate::{bigint64, bigint_str, relocatable};
     use std::collections::HashMap;
@@ -378,6 +380,9 @@ mod tests {
             data: Vec::new(),
             main: None,
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let _cairo_runner = CairoRunner::new(&program);
     }
@@ -391,6 +396,9 @@ mod tests {
             data: Vec::new(),
             main: None,
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         //We only check that the creation doesnt panic
         let _cairo_runner = CairoRunner::new(&program);
@@ -405,6 +413,9 @@ mod tests {
             data: Vec::new(),
             main: None,
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let mut cairo_runner = CairoRunner::new(&program);
         let program_base = Some(Relocatable {
@@ -445,6 +456,9 @@ mod tests {
             data: Vec::new(),
             main: None,
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let mut cairo_runner = CairoRunner::new(&program);
         cairo_runner.initialize_segments(None);
@@ -480,6 +494,9 @@ mod tests {
             data: Vec::new(),
             main: None,
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let mut cairo_runner = CairoRunner::new(&program);
         cairo_runner.program_base = Some(relocatable!(1, 0));
@@ -507,6 +524,9 @@ mod tests {
             ],
             main: None,
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let mut cairo_runner = CairoRunner::new(&program);
         for _ in 0..2 {
@@ -551,6 +571,9 @@ mod tests {
             data: Vec::new(),
             main: None,
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let mut cairo_runner = CairoRunner::new(&program);
         for _ in 0..3 {
@@ -596,6 +619,9 @@ mod tests {
             data: Vec::new(),
             main: None,
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let mut cairo_runner = CairoRunner::new(&program);
         for _ in 0..2 {
@@ -625,6 +651,9 @@ mod tests {
             data: Vec::new(),
             main: None,
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let mut cairo_runner = CairoRunner::new(&program);
         for _ in 0..2 {
@@ -650,6 +679,9 @@ mod tests {
             data: Vec::new(),
             main: None,
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let mut cairo_runner = CairoRunner::new(&program);
         for _ in 0..2 {
@@ -694,6 +726,9 @@ mod tests {
             data: Vec::new(),
             main: None,
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let mut cairo_runner = CairoRunner::new(&program);
         for _ in 0..2 {
@@ -747,6 +782,9 @@ mod tests {
             data: Vec::new(),
             main: None,
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let mut cairo_runner = CairoRunner::new(&program);
         let stack = vec![MaybeRelocatable::from(bigint!(7))];
@@ -766,6 +804,9 @@ mod tests {
             data: Vec::new(),
             main: None,
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let mut cairo_runner = CairoRunner::new(&program);
         cairo_runner.initialize_main_entrypoint().unwrap();
@@ -780,6 +821,9 @@ mod tests {
             data: Vec::new(),
             main: Some(1),
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let mut cairo_runner = CairoRunner::new(&program);
         cairo_runner.program_base = Some(relocatable!(0, 0));
@@ -797,6 +841,9 @@ mod tests {
             data: Vec::new(),
             main: Some(1),
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let mut cairo_runner = CairoRunner::new(&program);
         cairo_runner.program_base = Some(relocatable!(0, 0));
@@ -831,6 +878,9 @@ mod tests {
             data: Vec::new(),
             main: Some(1),
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let mut cairo_runner = CairoRunner::new(&program);
         cairo_runner.initial_pc = Some(relocatable!(0, 1));
@@ -885,6 +935,9 @@ mod tests {
             data: Vec::new(),
             main: Some(1),
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let mut cairo_runner = CairoRunner::new(&program);
         cairo_runner.initial_pc = Some(relocatable!(0, 1));
@@ -950,6 +1003,9 @@ mod tests {
             ],
             main: Some(3),
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let mut cairo_runner = CairoRunner::new(&program);
         cairo_runner.initialize_segments(None);
@@ -1112,6 +1168,9 @@ mod tests {
             ],
             main: Some(4),
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let mut cairo_runner = CairoRunner::new(&program);
         cairo_runner.initialize_segments(None);
@@ -1312,6 +1371,9 @@ mod tests {
             ],
             main: Some(8),
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let mut cairo_runner = CairoRunner::new(&program);
         cairo_runner.initialize_segments(None);
@@ -1544,6 +1606,9 @@ mod tests {
             ],
             main: Some(3),
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let mut cairo_runner = CairoRunner::new(&program);
         cairo_runner.initialize_segments(None);
@@ -1663,6 +1728,9 @@ mod tests {
             ],
             main: Some(8),
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let mut cairo_runner = CairoRunner::new(&program);
         cairo_runner.initialize_segments(None);
@@ -1863,6 +1931,9 @@ mod tests {
             ],
             main: Some(4),
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let mut cairo_runner = CairoRunner::new(&program);
         cairo_runner.initialize_segments(None);
@@ -2102,6 +2173,9 @@ mod tests {
             ],
             main: Some(13),
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let mut cairo_runner = CairoRunner::new(&program);
         cairo_runner.initialize_segments(None);
@@ -2363,6 +2437,9 @@ mod tests {
             data: Vec::new(),
             main: None,
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let mut cairo_runner = CairoRunner::new(&program);
         for _ in 0..4 {
@@ -2516,6 +2593,9 @@ mod tests {
             ],
             main: Some(4),
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let mut cairo_runner = CairoRunner::new(&program);
         cairo_runner.initialize_segments(None);
@@ -2649,6 +2729,9 @@ mod tests {
             ],
             main: Some(4),
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let mut cairo_runner = CairoRunner::new(&program);
         cairo_runner.initialize_segments(None);
@@ -2772,6 +2855,9 @@ mod tests {
             data: Vec::new(),
             main: None,
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let mut cairo_runner = CairoRunner::new(&program);
         cairo_runner.initialize_segments(None);
@@ -2843,6 +2929,9 @@ mod tests {
             ],
             main: Some(4),
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let mut cairo_runner = CairoRunner::new(&program);
         cairo_runner.initialize_segments(None);
@@ -2868,6 +2957,9 @@ mod tests {
             data: Vec::new(),
             main: None,
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let mut cairo_runner = CairoRunner::new(&program);
         cairo_runner.initialize_segments(None);
@@ -2911,6 +3003,9 @@ mod tests {
             data: Vec::new(),
             main: None,
             hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
         };
         let cairo_runner = CairoRunner::new(&program);
         assert_eq!(cairo_runner.vm.builtin_runners[0].0, String::from("output"));

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -221,20 +221,24 @@ impl CairoRunner {
             Ok(_) => Ok(()),
         }
     }
-    fn get_hint_dictionary(&self) -> HashMap<MaybeRelocatable, Vec<Vec<u8>>> {
-        let mut hint_dictionary = HashMap::<MaybeRelocatable, Vec<Vec<u8>>>::new();
+    fn get_hint_dictionary(
+        &self,
+    ) -> HashMap<MaybeRelocatable, Vec<(Vec<u8>, HashMap<String, BigInt>)>> {
+        let mut hint_dictionary =
+            HashMap::<MaybeRelocatable, Vec<(Vec<u8>, HashMap<String, BigInt>)>>::new();
         for (_hint_index, hints) in self.program.hints.iter() {
             for hint_data in hints.iter() {
                 let key = MaybeRelocatable::from((
                     hint_data.flow_tracking_data.ap_tracking.group,
                     hint_data.flow_tracking_data.ap_tracking.offset,
                 ));
+                //TODO: replace HashMap::new() with proper ids once ids is deserialized
                 if let Some(hint_list) = hint_dictionary.get_mut(&key) {
                     //Add hint code to list of hints at given pc
-                    hint_list.push(hint_data.code.clone());
+                    hint_list.push((hint_data.code.clone(), HashMap::new()));
                 } else {
                     //Insert the first hint at a given pc
-                    hint_dictionary.insert(key, vec![hint_data.code.clone()]);
+                    hint_dictionary.insert(key, vec![(hint_data.code.clone(), HashMap::new())]);
                 }
             }
         }

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -446,12 +446,7 @@ impl VirtualMachine {
     pub fn step(&mut self) -> Result<(), VirtualMachineError> {
         if let Some(hint_list) = self.hints.get(&self.run_context.pc) {
             for hint_data in hint_list.clone().iter() {
-                if execute_hint(self, &hint_data.hint_code.clone(), hint_data.ids.clone()).is_err()
-                {
-                    return Err(VirtualMachineError::HintException(
-                        self.run_context.pc.clone(),
-                    ));
-                }
+                execute_hint(self, &hint_data.hint_code.clone(), hint_data.ids.clone())?
             }
         }
         self.skip_instruction_execution = false;

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -26,8 +26,8 @@ pub struct Operands {
 
 pub struct HintData {
     pub hint_code: Vec<u8>,
-    //Maps the name of the variable to its location in memory
-    pub ids: HashMap<String, MaybeRelocatable>,
+    //Maps the name of the variable to its reference id
+    pub ids: HashMap<String, BigInt>,
 }
 pub struct VirtualMachine {
     pub run_context: RunContext,
@@ -54,7 +54,7 @@ pub struct VirtualMachine {
 }
 
 impl HintData {
-    pub fn new(hint_code: Vec<u8>, ids: HashMap<String, MaybeRelocatable>) -> HintData {
+    pub fn new(hint_code: Vec<u8>, ids: HashMap<String, BigInt>) -> HintData {
         HintData { hint_code, ids }
     }
 }

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -442,7 +442,13 @@ impl VirtualMachine {
     pub fn step(&mut self) -> Result<(), VirtualMachineError> {
         if let Some(hint_list) = self.hints.get(&self.run_context.pc) {
             for hint_data in hint_list.clone().iter() {
-                if execute_hint(self, &hint_data.hint_code.clone(), hint_data.ids.clone()).is_err()
+                if execute_hint(
+                    self,
+                    &hint_data.hint_code.clone(),
+                    hint_data.ids.clone(),
+                    Vec::new(),
+                )
+                .is_err()
                 {
                     return Err(VirtualMachineError::HintException(
                         self.run_context.pc.clone(),

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -14,7 +14,7 @@ use num_bigint::BigInt;
 use num_traits::{FromPrimitive, ToPrimitive};
 use std::collections::{HashMap, HashSet};
 
-use super::hints::execute_hint::Reference;
+use super::hints::execute_hint::HintReference;
 
 #[derive(PartialEq, Debug)]
 pub struct Operands {
@@ -39,7 +39,7 @@ pub struct VirtualMachine {
     //exec_scopes: Vec<HashMap<..., ...>>,
     //enter_scope:
     pub hints: HashMap<MaybeRelocatable, Vec<HintData>>,
-    pub references: Vec<Reference>,
+    pub references: Vec<HintReference>,
     //hint_locals: HashMap<..., ...>,
     //hint_pc_and_index: HashMap<i64, (MaybeRelocatable, i64)>,
     //static_locals: Option<HashMap<..., ...>>,
@@ -79,7 +79,7 @@ impl VirtualMachine {
             prime,
             builtin_runners,
             hints: HashMap::<MaybeRelocatable, Vec<HintData>>::new(),
-            references: Vec::<Reference>::new(),
+            references: Vec::<HintReference>::new(),
             _program_base: None,
             memory: Memory::new(),
             accessed_addresses: HashSet::<MaybeRelocatable>::new(),
@@ -2368,7 +2368,7 @@ mod tests {
             _program_base: None,
             builtin_runners: Vec::new(),
             hints: HashMap::<MaybeRelocatable, Vec<HintData>>::new(),
-            references: Vec::<Reference>::new(),
+            references: Vec::<HintReference>::new(),
             memory: Memory::new(),
             accessed_addresses: HashSet::<MaybeRelocatable>::new(),
             trace: Vec::<TraceEntry>::new(),

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -23,9 +23,11 @@ pub struct Operands {
 }
 
 #[derive(Clone)]
+
 pub struct HintData {
     pub hint_code: Vec<u8>,
-    pub ids: HashMap<String, BigInt>,
+    //Maps the name of the variable to its location in memory
+    pub ids: HashMap<String, MaybeRelocatable>,
 }
 pub struct VirtualMachine {
     pub run_context: RunContext,
@@ -52,7 +54,7 @@ pub struct VirtualMachine {
 }
 
 impl HintData {
-    pub fn new(hint_code: Vec<u8>, ids: HashMap<String, BigInt>) -> HintData {
+    pub fn new(hint_code: Vec<u8>, ids: HashMap<String, MaybeRelocatable>) -> HintData {
         HintData { hint_code, ids }
     }
 }

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -429,7 +429,7 @@ impl VirtualMachine {
     pub fn step(&mut self) -> Result<(), VirtualMachineError> {
         if let Some(hint_list) = self.hints.get(&self.run_context.pc) {
             for hint_code in hint_list.clone().iter() {
-                if execute_hint(self, hint_code).is_err() {
+                if execute_hint(self, hint_code, None).is_err() {
                     return Err(VirtualMachineError::HintException(
                         self.run_context.pc.clone(),
                     ));

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -446,7 +446,7 @@ impl VirtualMachine {
     pub fn step(&mut self) -> Result<(), VirtualMachineError> {
         if let Some(hint_list) = self.hints.get(&self.run_context.pc) {
             for hint_data in hint_list.clone().iter() {
-                execute_hint(self, &hint_data.hint_code.clone(), hint_data.ids.clone())?
+                execute_hint(self, &hint_data.hint_code, hint_data.ids.clone())?
             }
         }
         self.skip_instruction_execution = false;

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -24,7 +24,7 @@ pub struct Operands {
     op1: MaybeRelocatable,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 
 pub struct HintData {
     pub hint_code: Vec<u8>,

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -14,6 +14,8 @@ use num_bigint::BigInt;
 use num_traits::{FromPrimitive, ToPrimitive};
 use std::collections::{HashMap, HashSet};
 
+use super::hints::execute_hint::Reference;
+
 #[derive(PartialEq, Debug)]
 pub struct Operands {
     dst: MaybeRelocatable,
@@ -37,6 +39,7 @@ pub struct VirtualMachine {
     //exec_scopes: Vec<HashMap<..., ...>>,
     //enter_scope:
     pub hints: HashMap<MaybeRelocatable, Vec<HintData>>,
+    pub references: Vec<Reference>,
     //hint_locals: HashMap<..., ...>,
     //hint_pc_and_index: HashMap<i64, (MaybeRelocatable, i64)>,
     //static_locals: Option<HashMap<..., ...>>,
@@ -76,6 +79,7 @@ impl VirtualMachine {
             prime,
             builtin_runners,
             hints: HashMap::<MaybeRelocatable, Vec<HintData>>::new(),
+            references: Vec::<Reference>::new(),
             _program_base: None,
             memory: Memory::new(),
             accessed_addresses: HashSet::<MaybeRelocatable>::new(),
@@ -442,13 +446,7 @@ impl VirtualMachine {
     pub fn step(&mut self) -> Result<(), VirtualMachineError> {
         if let Some(hint_list) = self.hints.get(&self.run_context.pc) {
             for hint_data in hint_list.clone().iter() {
-                if execute_hint(
-                    self,
-                    &hint_data.hint_code.clone(),
-                    hint_data.ids.clone(),
-                    Vec::new(),
-                )
-                .is_err()
+                if execute_hint(self, &hint_data.hint_code.clone(), hint_data.ids.clone()).is_err()
                 {
                     return Err(VirtualMachineError::HintException(
                         self.run_context.pc.clone(),
@@ -2323,6 +2321,7 @@ mod tests {
             _program_base: None,
             builtin_runners: Vec::new(),
             hints: HashMap::<MaybeRelocatable, Vec<HintData>>::new(),
+            references: Vec::<Reference>::new(),
             memory: Memory::new(),
             accessed_addresses: HashSet::<MaybeRelocatable>::new(),
             trace: Vec::<TraceEntry>::new(),

--- a/tests/cairo_run_test.rs
+++ b/tests/cairo_run_test.rs
@@ -44,3 +44,9 @@ fn cairo_run_compare_greater_array() {
     cairo_run::cairo_run(Path::new("cairo_programs/compare_greater_array.json"))
         .expect("Couldn't run program");
 }
+
+#[test]
+fn cairo_run_compare_lesser_array() {
+    cairo_run::cairo_run(Path::new("cairo_programs/compare_lesser_array.json"))
+        .expect("Couldn't run program");
+}

--- a/tests/cairo_run_test.rs
+++ b/tests/cairo_run_test.rs
@@ -50,3 +50,9 @@ fn cairo_run_compare_lesser_array() {
     cairo_run::cairo_run(Path::new("cairo_programs/compare_lesser_array.json"))
         .expect("Couldn't run program");
 }
+
+#[test]
+fn cairo_run_assert_le_felt_hint() {
+    cairo_run::cairo_run(Path::new("cairo_programs/assert_le_felt_hint.json"))
+        .expect("Couldn't run program");
+}

--- a/tests/cairo_run_test.rs
+++ b/tests/cairo_run_test.rs
@@ -38,9 +38,3 @@ fn cairo_run_compare_arrays() {
     cairo_run::cairo_run(Path::new("cairo_programs/compare_arrays.json"))
         .expect("Couldn't run program");
 }
-
-#[test]
-fn cairo_run_compare_greater_arrays() {
-    cairo_run::cairo_run(Path::new("cairo_programs/compare_greater_array.json"))
-        .expect("Couldn't run program");
-}

--- a/tests/cairo_run_test.rs
+++ b/tests/cairo_run_test.rs
@@ -38,3 +38,9 @@ fn cairo_run_compare_arrays() {
     cairo_run::cairo_run(Path::new("cairo_programs/compare_arrays.json"))
         .expect("Couldn't run program");
 }
+
+#[test]
+fn cairo_run_compare_greater_array() {
+    cairo_run::cairo_run(Path::new("cairo_programs/compare_greater_array.json"))
+        .expect("Couldn't run program");
+}

--- a/tests/cairo_run_test.rs
+++ b/tests/cairo_run_test.rs
@@ -38,3 +38,9 @@ fn cairo_run_compare_arrays() {
     cairo_run::cairo_run(Path::new("cairo_programs/compare_arrays.json"))
         .expect("Couldn't run program");
 }
+
+#[test]
+fn cairo_run_compare_greater_arrays() {
+    cairo_run::cairo_run(Path::new("cairo_programs/compare_greater_array.json"))
+        .expect("Couldn't run program");
+}


### PR DESCRIPTION
Changes:
- Add is_nn, and is_nn_out_of_range to hint_utils, which implement the hints on is_nn (math_cmp.cairo)
- Add assert_le_felt to hint utils, which implements the hints on assert_le_felt (math.cairo) used by is_nn
- Add methods get_reference_list and get_hint_dictionary, which take and re-organize the necessary data for hint execution from the deserialized program
- Add unit tests for each new implemented hint
- Add integration tests for is_nn when comparing two positive numbers (extra hints needed for negative numbers)
- Add integration test for the hint on assert_le_felt (extra hints needed to test full function)

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [x] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
