### PR TITLE
Add CLI option to specify entrypoint

### DIFF
--- a/bench/criterion/criterion_benchmark.rs
+++ b/bench/criterion/criterion_benchmark.rs
@@ -21,6 +21,7 @@ pub fn criterion_benchmarks(c: &mut Criterion) {
             b.iter(|| {
                 cairo_run::cairo_run(
                     black_box(Path::new(&benchmark_name.1)),
+                    "main",
                     false,
                     &HINT_EXECUTOR,
                 )

--- a/cairo_programs/not_main.cairo
+++ b/cairo_programs/not_main.cairo
@@ -1,0 +1,8 @@
+func not_main():
+    [ap] = 123
+    ret
+end
+
+func main():
+    ret
+end

--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -9,10 +9,11 @@ use std::path::Path;
 
 pub fn cairo_run(
     path: &Path,
+    entrypoint: &str,
     trace_enabled: bool,
     hint_executor: &'static dyn HintExecutor,
 ) -> Result<CairoRunner, CairoRunError> {
-    let program = match Program::new(path) {
+    let program = match Program::new(path, entrypoint) {
         Ok(program) => program,
         Err(error) => return Err(CairoRunError::Program(error)),
     };
@@ -128,7 +129,7 @@ mod tests {
     static HINT_EXECUTOR: BuiltinHintExecutor = BuiltinHintExecutor {};
 
     fn run_test_program(program_path: &Path) -> Result<CairoRunner, CairoRunError> {
-        let program = match Program::new(program_path) {
+        let program = match Program::new(program_path, "main") {
             Ok(program) => program,
             Err(e) => return Err(CairoRunError::Program(e)),
         };
@@ -173,7 +174,7 @@ mod tests {
         // it should fail when the program is loaded.
         let no_data_program_path = Path::new("cairo_programs/no_data_program.json");
 
-        assert!(cairo_run(no_data_program_path, false, &HINT_EXECUTOR).is_err());
+        assert!(cairo_run(no_data_program_path, "main", false, &HINT_EXECUTOR).is_err());
     }
 
     #[test]
@@ -182,7 +183,7 @@ mod tests {
         // it should fail when trying to run initialize_main_entrypoint.
         let no_main_program_path = Path::new("cairo_programs/no_main_program.json");
 
-        assert!(cairo_run(no_main_program_path, false, &HINT_EXECUTOR).is_err());
+        assert!(cairo_run(no_main_program_path, "main", false, &HINT_EXECUTOR).is_err());
     }
 
     #[test]
@@ -191,7 +192,7 @@ mod tests {
         // decode the instruction.
         let invalid_memory = Path::new("cairo_programs/invalid_memory.json");
 
-        assert!(cairo_run(invalid_memory, false, &HINT_EXECUTOR).is_err());
+        assert!(cairo_run(invalid_memory, "main", false, &HINT_EXECUTOR).is_err());
     }
 
     #[test]
@@ -242,7 +243,7 @@ mod tests {
     #[test]
     fn run_with_no_trace() {
         let program_path = Path::new("cairo_programs/struct.json");
-        let program = Program::new(program_path).unwrap();
+        let program = Program::new(program_path, "main").unwrap();
         let mut cairo_runner = CairoRunner::new(&program, false, &HINT_EXECUTOR);
 
         cairo_runner.initialize_segments(None);

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,8 @@ struct Args {
     trace_file: Option<PathBuf>,
     #[structopt(long = "--print_output")]
     print_output: bool,
+    #[structopt(long = "--entrypoint", default_value = "main")]
+    entrypoint: String,
     trace: Option<PathBuf>,
     #[structopt(long = "--memory_file")]
     memory_file: Option<PathBuf>,
@@ -33,8 +35,12 @@ fn main() -> Result<(), CairoRunError> {
 
     let args = Args::parse();
     let trace_enabled = args.trace_file.is_some();
-    let mut cairo_runner = match cairo_run::cairo_run(&args.filename, trace_enabled, &HINT_EXECUTOR)
-    {
+    let mut cairo_runner = match cairo_run::cairo_run(
+        &args.filename,
+        &args.entrypoint,
+        trace_enabled,
+        &HINT_EXECUTOR,
+    ) {
         Ok(runner) => runner,
         Err(error) => return Err(error),
     };

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -255,13 +255,21 @@ pub fn deserialize_program_json(path: &Path) -> Result<ProgramJson, ProgramError
     Ok(program_json)
 }
 
-pub fn deserialize_program(path: &Path) -> Result<Program, ProgramError> {
+pub fn deserialize_program(path: &Path, entrypoint: &str) -> Result<Program, ProgramError> {
     let program_json: ProgramJson = deserialize_program_json(path)?;
+
+    let main_pc = match program_json
+        .identifiers
+        .get(&format!("__main__.{}", entrypoint))
+    {
+        Some(entrypoint_identifier) => entrypoint_identifier.pc,
+        None => return Err(ProgramError::EntrypointNotFound(entrypoint.to_string())),
+    };
     Ok(Program {
         builtins: program_json.builtins,
         prime: program_json.prime,
         data: program_json.data,
-        main: program_json.identifiers["__main__.main"].pc,
+        main: main_pc,
         hints: program_json.hints,
         reference_manager: program_json.reference_manager,
     })
@@ -580,10 +588,24 @@ mod tests {
     }
 
     #[test]
+    fn deserialize_missing_entrypoint_gives_error() {
+        let deserialization_result = deserialize_program(
+            Path::new("cairo_programs/manually_compiled/valid_program_a.json"),
+            "missing_function",
+        );
+        assert!(deserialization_result.is_err());
+        assert!(matches!(
+            deserialization_result,
+            Err(ProgramError::EntrypointNotFound(_))
+        ));
+    }
+
+    #[test]
     fn deserialize_program_test() {
-        let program: Program = deserialize_program(Path::new(
-            "cairo_programs/manually_compiled/valid_program_a.json",
-        ))
+        let program: Program = deserialize_program(
+            Path::new("cairo_programs/manually_compiled/valid_program_a.json"),
+            "main",
+        )
         .expect("Failed to deserialize program");
 
         let builtins: Vec<String> = Vec::new();

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -258,7 +258,7 @@ pub fn deserialize_program_json(path: &Path) -> Result<ProgramJson, ProgramError
 pub fn deserialize_program(path: &Path, entrypoint: &str) -> Result<Program, ProgramError> {
     let program_json: ProgramJson = deserialize_program_json(path)?;
 
-    let main_pc = match program_json
+    let entrypoint_pc = match program_json
         .identifiers
         .get(&format!("__main__.{}", entrypoint))
     {
@@ -269,7 +269,7 @@ pub fn deserialize_program(path: &Path, entrypoint: &str) -> Result<Program, Pro
         builtins: program_json.builtins,
         prime: program_json.prime,
         data: program_json.data,
-        main: main_pc,
+        main: entrypoint_pc,
         hints: program_json.hints,
         reference_manager: program_json.reference_manager,
     })

--- a/src/types/errors/program_errors.rs
+++ b/src/types/errors/program_errors.rs
@@ -5,6 +5,7 @@ use std::io;
 pub enum ProgramError {
     IO(io::Error),
     Parse(serde_json::Error),
+    EntrypointNotFound(String),
 }
 
 impl From<serde_json::Error> for ProgramError {
@@ -30,6 +31,21 @@ impl fmt::Display for ProgramError {
                 write!(f, "Parsing error: ")?;
                 error.fmt(f)
             }
+            ProgramError::EntrypointNotFound(entrypoint) => {
+                f.write_fmt(format_args!("Entrypoint {} not found", entrypoint))
+            }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_entrypoint_not_found_error() {
+        let error = ProgramError::EntrypointNotFound(String::from("my_function"));
+        let formatted_error = format!("{}", error);
+        assert_eq!(formatted_error, "Entrypoint my_function not found");
     }
 }

--- a/src/types/program.rs
+++ b/src/types/program.rs
@@ -15,8 +15,8 @@ pub struct Program {
 }
 
 impl Program {
-    pub fn new(path: &Path) -> Result<Program, ProgramError> {
-        deserialize_program(path)
+    pub fn new(path: &Path, entrypoint: &str) -> Result<Program, ProgramError> {
+        deserialize_program(path, entrypoint)
     }
 }
 
@@ -27,9 +27,10 @@ mod tests {
 
     #[test]
     fn deserialize_program_test() {
-        let program: Program = Program::new(Path::new(
-            "cairo_programs/manually_compiled/valid_program_a.json",
-        ))
+        let program: Program = Program::new(
+            Path::new("cairo_programs/manually_compiled/valid_program_a.json"),
+            "main",
+        )
         .expect("Failed to deserialize program");
 
         let builtins: Vec<String> = Vec::new();

--- a/tests/bitwise_test.rs
+++ b/tests/bitwise_test.rs
@@ -11,8 +11,11 @@ use cleopatra_cairo::{
 static HINT_EXECUTOR: BuiltinHintExecutor = BuiltinHintExecutor {};
 #[test]
 fn bitwise_integration_test() {
-    let program = Program::new(Path::new("cairo_programs/bitwise_builtin_test.json"))
-        .expect("Failed to deserialize program");
+    let program = Program::new(
+        Path::new("cairo_programs/bitwise_builtin_test.json"),
+        "main",
+    )
+    .expect("Failed to deserialize program");
     let mut cairo_runner = CairoRunner::new(&program, true, &HINT_EXECUTOR);
     cairo_runner.initialize_segments(None);
     let end = cairo_runner.initialize_main_entrypoint().unwrap();

--- a/tests/cairo_run_test.rs
+++ b/tests/cairo_run_test.rs
@@ -9,6 +9,7 @@ static HINT_EXECUTOR: BuiltinHintExecutor = BuiltinHintExecutor {};
 fn cairo_run_test() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/fibonacci.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -19,6 +20,7 @@ fn cairo_run_test() {
 fn cairo_run_bitwise_output() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/bitwise_output.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -29,6 +31,7 @@ fn cairo_run_bitwise_output() {
 fn cairo_run_bitwise_recursion() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/bitwise_recursion.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -39,6 +42,7 @@ fn cairo_run_bitwise_recursion() {
 fn cairo_run_integration() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/integration.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -49,6 +53,7 @@ fn cairo_run_integration() {
 fn cairo_run_integration_with_alloc_locals() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/integration_with_alloc_locals.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -59,6 +64,7 @@ fn cairo_run_integration_with_alloc_locals() {
 fn cairo_run_compare_arrays() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/compare_arrays.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -69,6 +75,7 @@ fn cairo_run_compare_arrays() {
 fn cairo_run_compare_greater_array() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/compare_greater_array.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -79,6 +86,7 @@ fn cairo_run_compare_greater_array() {
 fn cairo_run_compare_lesser_array() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/compare_lesser_array.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -89,6 +97,7 @@ fn cairo_run_compare_lesser_array() {
 fn cairo_run_assert_le_felt_hint() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/assert_le_felt_hint.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -99,6 +108,7 @@ fn cairo_run_assert_le_felt_hint() {
 fn cairo_run_assert_250_bit_element_array() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/assert_250_bit_element_array.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -109,6 +119,7 @@ fn cairo_run_assert_250_bit_element_array() {
 fn cairo_abs_value() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/abs_value_array.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -119,6 +130,7 @@ fn cairo_abs_value() {
 fn cairo_run_compare_different_arrays() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/compare_different_arrays.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -129,6 +141,7 @@ fn cairo_run_compare_different_arrays() {
 fn cairo_run_assert_nn() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/assert_nn.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -137,14 +150,20 @@ fn cairo_run_assert_nn() {
 
 #[test]
 fn cairo_run_sqrt() {
-    cairo_run::cairo_run(Path::new("cairo_programs/sqrt.json"), false, &HINT_EXECUTOR)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/sqrt.json"),
+        "main",
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_assert_not_zero() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/assert_not_zero.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -155,6 +174,7 @@ fn cairo_run_assert_not_zero() {
 fn cairo_run_split_int() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/split_int.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -165,6 +185,7 @@ fn cairo_run_split_int() {
 fn cairo_run_split_int_big() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/split_int_big.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -175,6 +196,7 @@ fn cairo_run_split_int_big() {
 fn cairo_run_split_felt() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/split_felt.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -185,6 +207,7 @@ fn cairo_run_split_felt() {
 fn cairo_run_math_cmp() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/math_cmp.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -195,6 +218,7 @@ fn cairo_run_math_cmp() {
 fn cairo_run_unsigned_div_rem() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/unsigned_div_rem.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -205,6 +229,7 @@ fn cairo_run_unsigned_div_rem() {
 fn cairo_run_signed_div_rem() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/signed_div_rem.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -215,6 +240,7 @@ fn cairo_run_signed_div_rem() {
 fn cairo_run_assert_lt_felt() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/assert_lt_felt.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -225,6 +251,7 @@ fn cairo_run_assert_lt_felt() {
 fn cairo_run_memcpy() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/memcpy_test.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -235,6 +262,7 @@ fn cairo_run_memcpy() {
 fn cairo_run_memset() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/memset.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -243,20 +271,31 @@ fn cairo_run_memset() {
 
 #[test]
 fn cairo_run_pow() {
-    cairo_run::cairo_run(Path::new("cairo_programs/pow.json"), false, &HINT_EXECUTOR)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/pow.json"),
+        "main",
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_dict() {
-    cairo_run::cairo_run(Path::new("cairo_programs/dict.json"), false, &HINT_EXECUTOR)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/dict.json"),
+        "main",
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_dict_update() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/dict_update.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -267,6 +306,7 @@ fn cairo_run_dict_update() {
 fn cairo_run_uint256() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/uint256.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -277,6 +317,7 @@ fn cairo_run_uint256() {
 fn cairo_run_find_element() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/find_element.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -287,6 +328,7 @@ fn cairo_run_find_element() {
 fn cairo_run_search_sorted_lower() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/search_sorted_lower.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -297,6 +339,7 @@ fn cairo_run_search_sorted_lower() {
 fn cairo_run_usort() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/usort.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -307,6 +350,7 @@ fn cairo_run_usort() {
 fn cairo_run_usort_bad() {
     let err = cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/bad_usort.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     );
@@ -321,12 +365,14 @@ fn cairo_run_usort_bad() {
 fn cairo_run_dict_write_bad() {
     assert!(cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/bad_dict_new.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
     .is_err());
     let err = cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/bad_dict_new.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -341,12 +387,14 @@ fn cairo_run_dict_write_bad() {
 fn cairo_run_dict_update_bad() {
     assert!(cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/bad_dict_update.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
     .is_err());
     let err = cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/bad_dict_update.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -361,6 +409,7 @@ fn cairo_run_dict_update_bad() {
 fn cairo_run_squash_dict() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/squash_dict.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -371,6 +420,7 @@ fn cairo_run_squash_dict() {
 fn cairo_run_dict_squash() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/dict_squash.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -381,6 +431,7 @@ fn cairo_run_dict_squash() {
 fn cairo_run_set_add() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/set_add.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -389,14 +440,20 @@ fn cairo_run_set_add() {
 
 #[test]
 fn cairo_run_secp() {
-    cairo_run::cairo_run(Path::new("cairo_programs/secp.json"), false, &HINT_EXECUTOR)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/secp.json"),
+        "main",
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_signature() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/signature.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -407,6 +464,7 @@ fn cairo_run_signature() {
 fn cairo_run_secp_ec() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/secp_ec.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -417,6 +475,7 @@ fn cairo_run_secp_ec() {
 fn cairo_run_blake2s_hello_world_hash() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/blake2s_hello_world_hash.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -427,6 +486,7 @@ fn cairo_run_blake2s_hello_world_hash() {
 fn cairo_run_finalize_blake2s() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/finalize_blake2s.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -436,6 +496,7 @@ fn cairo_run_finalize_blake2s() {
 fn cairo_run_unsafe_keccak() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/unsafe_keccak.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -446,6 +507,7 @@ fn cairo_run_unsafe_keccak() {
 fn cairo_run_blake2s_felts() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/blake2s_felts.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -456,6 +518,7 @@ fn cairo_run_blake2s_felts() {
 fn cairo_run_unsafe_keccak_finalize() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/unsafe_keccak_finalize.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -466,6 +529,7 @@ fn cairo_run_unsafe_keccak_finalize() {
 fn cairo_run_keccak_add_uint256() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/keccak_add_uint256.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -476,6 +540,7 @@ fn cairo_run_keccak_add_uint256() {
 fn cairo_run_private_keccak() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/_keccak.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -486,6 +551,7 @@ fn cairo_run_private_keccak() {
 fn cairo_run_keccak_copy_inputs() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/keccak_copy_inputs.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -496,6 +562,7 @@ fn cairo_run_keccak_copy_inputs() {
 fn cairo_run_finalize_keccak() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/cairo_finalize_keccak.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -506,6 +573,7 @@ fn cairo_run_finalize_keccak() {
 fn cairo_run_operations_with_data() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/operations_with_data_structures.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -516,6 +584,7 @@ fn cairo_run_operations_with_data() {
 fn cairo_run_sha256() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/sha256.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -526,6 +595,7 @@ fn cairo_run_sha256() {
 fn cairo_run_math_cmp_and_pow_integration() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/math_cmp_and_pow_integration_tests.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -546,6 +616,7 @@ fn cairo_run_uint256_integration() {
 fn cairo_run_memory_module_integration() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/memory_integration_tests.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -556,6 +627,7 @@ fn cairo_run_memory_module_integration() {
 fn cairo_run_dict_integration() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/dict_integration_tests.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -566,6 +638,7 @@ fn cairo_run_dict_integration() {
 fn cairo_run_keccak_integration() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/keccak_integration_tests.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )

--- a/tests/cairo_run_test.rs
+++ b/tests/cairo_run_test.rs
@@ -606,6 +606,7 @@ fn cairo_run_math_cmp_and_pow_integration() {
 fn cairo_run_uint256_integration() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/uint256_integration_tests.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )
@@ -649,6 +650,7 @@ fn cairo_run_keccak_integration() {
 fn cairo_run_blake2s_integration() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/blake2s_integration_tests.json"),
+        "main",
         false,
         &HINT_EXECUTOR,
     )

--- a/tests/pedersen_test.rs
+++ b/tests/pedersen_test.rs
@@ -9,7 +9,7 @@ static HINT_EXECUTOR: BuiltinHintExecutor = BuiltinHintExecutor {};
 
 #[test]
 fn pedersen_integration_test() {
-    let program = Program::new(Path::new("cairo_programs/pedersen_test.json"))
+    let program = Program::new(Path::new("cairo_programs/pedersen_test.json"), "main")
         .expect("Failed to deserialize program");
     let mut cairo_runner = CairoRunner::new(&program, true, &HINT_EXECUTOR);
     cairo_runner.initialize_segments(None);

--- a/tests/struct_test.rs
+++ b/tests/struct_test.rs
@@ -9,7 +9,7 @@ use cleopatra_cairo::{
 static HINT_EXECUTOR: BuiltinHintExecutor = BuiltinHintExecutor {};
 #[test]
 fn struct_integration_test() {
-    let program = Program::new(Path::new("cairo_programs/struct.json"))
+    let program = Program::new(Path::new("cairo_programs/struct.json"), "main")
         .expect("Failed to deserialize program");
     let mut cairo_runner = CairoRunner::new(&program, true, &HINT_EXECUTOR);
     cairo_runner.initialize_segments(None);


### PR DESCRIPTION
# Configurable entrypoint

## Description

As described in #180, it might be useful to be able to run another function than the `main` function as an entrypoint.

## Checklist
- [x] Linked to Github Issue
- [x] Unit tests added
- [x] Integration tests added.
