### PR TITLE
Add support to deserialize reference manager from json compiled programs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ark-ff"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,6 +215,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "regex",
  "rusty-hook",
  "serde",
  "serde_bytes",
@@ -760,6 +770,8 @@ version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ hex = "0.4.3"
 bincode = "1.2.1"
 starknet-crypto = "0.1.0"
 clap = { version = "3.2.5", features = ["derive"] }
+regex = "1.5"
 
 [dev-dependencies.rusty-hook]
 version = "0.11"

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -41,6 +41,7 @@ pub struct ApTracking {
     pub group: usize,
     pub offset: usize,
 }
+
 #[derive(Deserialize, Debug)]
 pub struct Identifier {
     pub pc: Option<usize>,
@@ -196,85 +197,6 @@ impl<'de> de::Visitor<'de> for ValueAddressVisitor {
         })
     }
 }
-
-// struct ReferenceVisitor;
-
-// impl<'de> de::Visitor<'de> for ReferenceVisitor {
-//     type Value = Reference;
-
-//     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-//         formatter.write_str("a list with references")
-//     }
-
-//     fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
-//     where
-//         A: MapAccess<'de>,
-//     {
-//         let mut ap_tracking: ApTracking;
-//         let mut pc: usize;
-//         let mut value: String;
-
-//         while let Some((k, v)) = map.next_entry>()? {
-//             match k {
-//                 ReferenceKey::ApTracking => {
-//                     ap_tracking = v;
-//                 }
-//                 ReferenceKey::Pc => {
-//                     pc = v;
-//                 }
-//                 ReferenceKey::Value => {
-//                     value = v;
-//                 }
-//                 _ => {
-//                     ap_tracking = ApTracking { group: 0, offset: 0};
-//                     pc = 0;
-//                     value = String::from("hola");
-//                     return Err("Reference deserialize error").map_err(de::Error::custom)
-//                 }
-//             }
-//         }
-
-//         Ok(Reference{ap_tracking_data: ap_tracking, pc: Some(pc), value: value })
-//     }
-
-// }
-
-// #[derive(Deserialize, Debug)]
-// enum ReferenceKey {
-//     ApTracking,
-//     Pc,
-//     Value,
-// }
-
-// #[derive(Deserialize, Debug)]
-// enum ReferenceValue {
-//     ApTracking(ApTracking),
-//     Pc(usize),
-//     Value(String),
-
-// }
-
-// struct ReferenceKeyVisitor;
-
-// impl <'de> de::Visitor<'de> for ReferenceKeyVisitor {
-//     type Value = ReferenceKey;
-
-//     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-//         formatter.write_str("a map with string keys and integer values")
-//     }
-
-//     fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-//         where E: de::Error,
-//     {
-//         match value {
-//             "ap_tracking_data" => Ok(ReferenceKey::ApTracking),
-//             "pc" => Ok(ReferenceKey::Pc),
-//             "value" => Ok(ReferenceKey::Value),
-//             _ => Err("Hola").map_err(de::Error::custom),
-//         }
-
-//     }
-// }
 
 pub fn deserialize_bigint_hex<'de, D: Deserializer<'de>>(d: D) -> Result<BigInt, D::Error> {
     d.deserialize_str(BigIntVisitor)

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -169,7 +169,7 @@ impl<'de> de::Visitor<'de> for ValueAddressVisitor {
     type Value = ValueAddress;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("Could not deserialize hexadecimal string")
+        formatter.write_str("a string representing the address in memory of a variable")
     }
 
     fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
@@ -177,9 +177,15 @@ impl<'de> de::Visitor<'de> for ValueAddressVisitor {
         E: de::Error,
     {
         // regex for capturing the register the address is referenced to
-        let register_re = Regex::new(r".p").unwrap();
+        let register_re = match Regex::new(r"[af]p") {
+            Ok(register_re) => register_re,
+            Err(e) => return Err(e).map_err(de::Error::custom),
+        };
         // regex for capturing the offset of the reference
-        let offset_re = Regex::new(r"(-?\d+)").unwrap();
+        let offset_re = match Regex::new(r"(-?\d+)") {
+            Ok(offset_re) => offset_re,
+            Err(e) => return Err(e).map_err(de::Error::custom),
+        };
 
         let register_capture = register_re.captures(value);
         let offset_capture = offset_re.captures(value);

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -57,8 +57,8 @@ pub struct Reference {
 
 #[derive(Deserialize, Debug, PartialEq)]
 pub struct ValueAddress {
-    register: Register,
-    offset: i32,
+    pub register: Register,
+    pub offset: i32,
 }
 
 struct BigIntVisitor;
@@ -157,42 +157,34 @@ impl<'de> de::Visitor<'de> for ReferenceIdsVisitor {
     }
 }
 
-struct ReferencesVisitor;
+// struct ReferenceVisitor;
 
-impl<'de> de::Visitor<'de> for ReferencesVisitor {
-    type Value = Vec<Reference>;
+// impl<'de> de::Visitor<'de> for ReferenceVisitor {
+//     type Value = Reference;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("a list with references")
-    }
+//     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+//         formatter.write_str("a list with references")
+//     }
 
-    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-    where
-        A: SeqAccess<'de>,
-    {
-        let mut data: Vec<Reference> = vec![];
+//     fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+//     where
+//         A: MapAccess<'de>,
+//     {
+//         while let Some(entry) = map.next_entry()? {
+//             match entry.0 {
 
-        while let Some(value) = seq.next_element::<String>()? {
-            if let Some(no_prefix_hex) = value.strip_prefix("0x") {
-                // Add padding if necessary
-                let no_prefix_hex = maybe_add_padding(no_prefix_hex.to_string());
-                let decoded_result: Result<Vec<u8>, hex::FromHexError> =
-                    hex::decode(&no_prefix_hex);
+//                 data.insert(key, BigInt::from_bytes_le(Sign::Plus, &value.to_le_bytes()));
+//             } else {
+//                 data.insert(
+//                     key,
+//                     BigInt::from_bytes_le(Sign::Minus, &abs(value).to_le_bytes()),
+//                 );
+//             }
+//         }
 
-                match decoded_result {
-                    Ok(decoded_hex) => data.push(MaybeRelocatable::Int(BigInt::from_bytes_be(
-                        Sign::Plus,
-                        &decoded_hex,
-                    ))),
-                    Err(e) => return Err(e).map_err(de::Error::custom),
-                };
-            } else {
-                return Err(String::from("hex prefix error")).map_err(de::Error::custom);
-            };
-        }
-        Ok(data)
-    }
-}
+//         Ok(data)
+
+// }
 
 pub fn deserialize_bigint_hex<'de, D: Deserializer<'de>>(d: D) -> Result<BigInt, D::Error> {
     d.deserialize_str(BigIntVisitor)

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -176,25 +176,28 @@ impl<'de> de::Visitor<'de> for ValueAddressVisitor {
     where
         E: de::Error,
     {
-        let num_re = Regex::new(r"(-?\d+)").unwrap();
-        let reg_re = Regex::new(r".p").unwrap();
+        // regex for capturing the register the address is referenced to
+        let register_re = Regex::new(r".p").unwrap();
+        // regex for capturing the offset of the reference
+        let offset_re = Regex::new(r"(-?\d+)").unwrap();
 
-        let offset_capture = num_re.captures(value);
-        let register_capture = reg_re.captures(value);
+        let register_capture = register_re.captures(value);
+        let offset_capture = offset_re.captures(value);
 
-        let offset = match offset_capture {
-            Some(offset_str) => match i32::from_str(&offset_str[0]) {
-                Ok(offset) => Some(offset),
-                Err(e) => return Err(e).map_err(de::Error::custom),
-            },
-            _ => None,
-        };
-
+        // if `fp` or `ap` are not captured, assign None to register
         let register = match register_capture {
             Some(register_str) => match &register_str[0] {
                 "fp" => Some(Register::FP),
                 "ap" => Some(Register::AP),
                 _ => None,
+            },
+            _ => None,
+        };
+
+        let offset = match offset_capture {
+            Some(offset_str) => match i32::from_str(&offset_str[0]) {
+                Ok(offset) => Some(offset),
+                Err(e) => return Err(e).map_err(de::Error::custom),
             },
             _ => None,
         };

--- a/src/types/instruction.rs
+++ b/src/types/instruction.rs
@@ -1,6 +1,7 @@
 use num_bigint::BigInt;
+use serde::Deserialize;
 
-#[derive(Debug, PartialEq)]
+#[derive(Deserialize, Debug, PartialEq)]
 pub enum Register {
     AP,
     FP,


### PR DESCRIPTION
# Deserialize Reference Manager

## Description
This PR adds support for deserializing the reference manager from compiled json cairo programs.
The approach is not the cleanest, and will be probably changed in the future, but it is good enough for a PoC.
The reference manager has information about the variables in the cairo program, so it is needed for hints execution implementation. The way the values of the variables of the program are referenced is by a string which has the information about the address in memory of the variable. This information is being parsed using regular expressions and then transformed to the struct `ValueAddress`.

## Checklist
- [x] Unit tests added
