### PR TITLE
Use references for hot functions

### DIFF
--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -70,8 +70,7 @@ impl MaybeRelocatable {
     pub fn add_usize_mod(&self, other: usize, prime: Option<BigInt>) -> MaybeRelocatable {
         match *self {
             MaybeRelocatable::Int(ref value) => {
-                let mut num = Clone::clone(value);
-                num = other + num;
+                let mut num = value + other;
                 if let Some(num_prime) = prime {
                     num %= num_prime;
                 }

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -42,8 +42,8 @@ impl MaybeRelocatable {
     ///Adds a bigint to self, then performs mod prime
     pub fn add_int_mod(
         &self,
-        other: BigInt,
-        prime: BigInt,
+        other: &BigInt,
+        prime: &BigInt,
     ) -> Result<MaybeRelocatable, VirtualMachineError> {
         match *self {
             MaybeRelocatable::Int(ref value) => {
@@ -189,7 +189,7 @@ mod tests {
     #[test]
     fn add_bigint_to_int() {
         let addr = MaybeRelocatable::from(bigint!(7));
-        let added_addr = addr.add_int_mod(bigint!(2), bigint!(17));
+        let added_addr = addr.add_int_mod(&bigint!(2), &bigint!(17));
         assert_eq!(Ok(MaybeRelocatable::Int(bigint!(9))), added_addr);
     }
 
@@ -203,7 +203,7 @@ mod tests {
     #[test]
     fn add_bigint_to_relocatable() {
         let addr = MaybeRelocatable::RelocatableValue(relocatable!(7, 65));
-        let added_addr = addr.add_int_mod(bigint!(2), bigint!(121));
+        let added_addr = addr.add_int_mod(&bigint!(2), &bigint!(121));
         assert_eq!(Ok(MaybeRelocatable::from((7, 67))), added_addr);
     }
 
@@ -211,8 +211,8 @@ mod tests {
     fn add_int_mod_offset_exceeded() {
         let addr = MaybeRelocatable::from((0, 0));
         let error = addr.add_int_mod(
-            bigint_str!(b"18446744073709551616"),
-            bigint_str!(b"18446744073709551617"),
+            &bigint_str!(b"18446744073709551616"),
+            &bigint_str!(b"18446744073709551617"),
         );
         assert_eq!(
             error,
@@ -229,7 +229,7 @@ mod tests {
     #[test]
     fn add_usize_to_relocatable() {
         let addr = MaybeRelocatable::RelocatableValue(relocatable!(7, 65));
-        let added_addr = addr.add_int_mod(bigint!(2), bigint!(121));
+        let added_addr = addr.add_int_mod(&bigint!(2), &bigint!(121));
         assert_eq!(Ok(MaybeRelocatable::from((7, 67))), added_addr);
     }
 
@@ -243,8 +243,8 @@ mod tests {
             ],
         ));
         let added_addr = addr.add_int_mod(
-            bigint!(1),
-            BigInt::new(
+            &bigint!(1),
+            &BigInt::new(
                 Sign::Plus,
                 vec![
                     4294967089, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295,
@@ -259,8 +259,8 @@ mod tests {
     fn add_bigint_to_relocatable_prime() {
         let addr = MaybeRelocatable::RelocatableValue(relocatable!(1, 9));
         let added_addr = addr.add_int_mod(
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            &BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            &BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
         );
         assert_eq!(
             Ok(MaybeRelocatable::RelocatableValue(relocatable!(1, 9))),

--- a/src/vm/context/run_context.rs
+++ b/src/vm/context/run_context.rs
@@ -21,7 +21,7 @@ impl RunContext {
             Register::AP => &self.ap,
             Register::FP => &self.fp,
         };
-        base_addr.add_int_mod(instruction.off0.clone(), self.prime.clone())
+        base_addr.add_int_mod(&instruction.off0, &self.prime)
     }
 
     pub fn compute_op0_addr(
@@ -32,7 +32,7 @@ impl RunContext {
             Register::AP => &self.ap,
             Register::FP => &self.fp,
         };
-        base_addr.add_int_mod(instruction.off1.clone(), self.prime.clone())
+        base_addr.add_int_mod(&instruction.off1, &self.prime)
     }
 
     pub fn compute_op1_addr(
@@ -48,13 +48,11 @@ impl RunContext {
                 false => return Err(VirtualMachineError::ImmShouldBe1),
             },
             Op1Addr::Op0 => match op0 {
-                Some(addr) => {
-                    return addr.add_int_mod(instruction.off2.clone(), self.prime.clone())
-                }
+                Some(addr) => return addr.add_int_mod(&instruction.off2, &self.prime),
                 None => return Err(VirtualMachineError::UnknownOp0),
             },
         };
-        base_addr.add_int_mod(instruction.off2.clone(), self.prime.clone())
+        base_addr.add_int_mod(&instruction.off2, &self.prime)
     }
 }
 

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -150,10 +150,9 @@ impl VirtualMachine {
             },
             PcUpdate::JumpRel => match operands.res.clone() {
                 Some(res) => match res {
-                    MaybeRelocatable::Int(num_res) => self
-                        .run_context
-                        .pc
-                        .add_int_mod(num_res, self.prime.clone())?,
+                    MaybeRelocatable::Int(num_res) => {
+                        self.run_context.pc.add_int_mod(&num_res, &self.prime)?
+                    }
 
                     _ => return Err(VirtualMachineError::PureValue),
                 },

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -519,7 +519,7 @@ impl VirtualMachine {
         }
 
         if matches!(res, None) {
-            match (op0.clone(), op1.clone()) {
+            match (&op0, &op1) {
                 (Some(ref unwrapped_op0), Some(ref unwrapped_op1)) => {
                     res = self.compute_res(instruction, unwrapped_op0, unwrapped_op1)?;
                 }
@@ -568,7 +568,7 @@ impl VirtualMachine {
             };
         }
 
-        match (dst, op0.clone(), op1.clone()) {
+        match (dst, op0, op1) {
             (Some(unwrapped_dst), Some(unwrapped_op0), Some(unwrapped_op1)) => Ok((
                 Operands {
                     dst: unwrapped_dst,


### PR DESCRIPTION
# Replace instances of `clone` by references in hot path

## Description

Several functions in the hot path (operand deduction and result computation, according to flamegraphs) were performing copies of their arguments in several places.
Over 10% reductions in runtime were reported in benchmarks by replacing those by references.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
- [ ] Documentation has been added/updated.
