### PR TITLE
Add implementation for hint on assert_nn (math.cairo)

### DIFF
--- a/cairo_programs/assert_nn.cairo
+++ b/cairo_programs/assert_nn.cairo
@@ -25,4 +25,4 @@ func main{range_check_ptr: felt}():
     assert_nn_manual_implementation(y)
 
     return ()
-end    
+end

--- a/cairo_programs/assert_nn.cairo
+++ b/cairo_programs/assert_nn.cairo
@@ -1,0 +1,28 @@
+%builtins range_check
+
+from starkware.cairo.common.math import assert_nn
+
+func assert_nn_manual_implementation{range_check_ptr}(a):
+    %{
+        from starkware.cairo.common.math_utils import assert_integer
+        assert_integer(ids.a)
+        assert 0 <= ids.a % PRIME < range_check_builtin.bound, f'a = {ids.a} is out of range.'
+    %}
+    a = [range_check_ptr]
+    let range_check_ptr = range_check_ptr + 1
+    return ()
+end
+
+func main{range_check_ptr: felt}():
+    let x = 64
+    tempvar y = 64 * 64
+    assert_nn(1)
+    assert_nn(x)
+    assert_nn(y)
+
+    assert_nn_manual_implementation(1)
+    assert_nn_manual_implementation(x)
+    assert_nn_manual_implementation(y)
+
+    return ()
+end    

--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -39,6 +39,7 @@ pub enum VirtualMachineError {
     FailedToGetIds,
     NonLeFelt(BigInt, BigInt),
     FailedToGetReference(BigInt),
+    ValueOutOfRange(BigInt),
     UnknownHint(String),
     DiffTypeComparison(MaybeRelocatable, MaybeRelocatable),
     AssertNotEqualFail(MaybeRelocatable, MaybeRelocatable),
@@ -113,6 +114,9 @@ impl fmt::Display for VirtualMachineError {
             },
             VirtualMachineError::FailedToGetReference(reference_id) => {
                 write!(f, "Failed to get reference for id {}", reference_id)
+            },
+            VirtualMachineError::ValueOutOfRange(a) => {
+                write!(f, "Assertion failed, 0 <= ids.a % PRIME < range_check_builtin.bound \n a = {:?} is out of range", a)
             },
             VirtualMachineError::UnknownHint(hint_code) => write!(f, "Unknown Hint: {:?}", hint_code),
             VirtualMachineError::MemoryError(memory_error) => memory_error.fmt(f),

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -5,7 +5,7 @@ use num_bigint::BigInt;
 use crate::types::instruction::Register;
 use crate::vm::errors::vm_errors::VirtualMachineError;
 use crate::vm::hints::hint_utils::{
-    add_segment, assert_le_felt, assert_not_equal, is_nn, is_nn_out_of_range,
+    add_segment, assert_le_felt, assert_nn, assert_not_equal, is_nn, is_nn_out_of_range,
 };
 use crate::vm::vm_core::VirtualMachine;
 
@@ -28,6 +28,8 @@ pub fn execute_hint(
         ) => assert_le_felt(vm, ids),
         Ok("from starkware.cairo.lang.vm.relocatable import RelocatableValue\nboth_ints = isinstance(ids.a, int) and isinstance(ids.b, int)\nboth_relocatable = (\n    isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and\n    ids.a.segment_index == ids.b.segment_index)\nassert both_ints or both_relocatable, \\\n    f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'\nassert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'"
         ) => assert_not_equal(vm, ids),
+        Ok("from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert 0 <= ids.a % PRIME < range_check_builtin.bound, f'a = {ids.a} is out of range.'"
+        ) => assert_nn(vm, ids),
         Ok(hint_code) => Err(VirtualMachineError::UnknownHint(String::from(hint_code))),
         Err(_) => Err(VirtualMachineError::InvalidHintEncoding(
             vm.run_context.pc.clone(),

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -508,10 +508,7 @@ mod tests {
             .unwrap();
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(
-            String::from("starkware.cairo.common.math.assert_nn.a"),
-            bigint!(0),
-        );
+        ids.insert(String::from("a"), bigint!(0));
         //Create references
         vm.references = vec![HintReference {
             register: Register::FP,
@@ -548,10 +545,7 @@ mod tests {
             .unwrap();
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(
-            String::from("starkware.cairo.common.math.assert_nn.a"),
-            bigint!(0),
-        );
+        ids.insert(String::from("a"), bigint!(0));
         //Create references
         vm.references = vec![HintReference {
             register: Register::FP,
@@ -600,7 +594,7 @@ mod tests {
         assert_eq!(
             execute_hint(&mut vm, hint_code, ids),
             Err(VirtualMachineError::IncorrectIds(
-                vec![String::from("starkware.cairo.common.math.assert_nn.a")],
+                vec![String::from("a")],
                 vec![String::from("incorrect_id")],
             ))
         );
@@ -632,10 +626,7 @@ mod tests {
             .unwrap();
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(
-            String::from("starkware.cairo.common.math.assert_nn.a"),
-            bigint!(0),
-        );
+        ids.insert(String::from("a"), bigint!(0));
         //Create references
         vm.references = vec![HintReference {
             register: Register::FP,
@@ -674,10 +665,7 @@ mod tests {
             .unwrap();
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(
-            String::from("starkware.cairo.common.math.assert_nn.a"),
-            bigint!(0),
-        );
+        ids.insert(String::from("a"), bigint!(0));
         //Create references
         vm.references = vec![HintReference {
             register: Register::FP,
@@ -715,10 +703,7 @@ mod tests {
             .unwrap();
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(
-            String::from("starkware.cairo.common.math.assert_nn.a"),
-            bigint!(0),
-        );
+        ids.insert(String::from("a"), bigint!(0));
         //Create references
         vm.references = vec![HintReference {
             register: Register::FP,
@@ -749,10 +734,7 @@ mod tests {
         vm.run_context.fp = MaybeRelocatable::from((0, 4));
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(
-            String::from("starkware.cairo.common.math.assert_nn.a"),
-            bigint!(0),
-        );
+        ids.insert(String::from("a"), bigint!(0));
         //Create references
         vm.references = vec![HintReference {
             register: Register::FP,

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -368,35 +368,41 @@ pub fn assert_nn(
         } else {
             return Err(VirtualMachineError::FailedToGetIds);
         };
+
     //Check that the 'a' id is in memory
-    match vm.memory.get(&a_addr) {
-        Ok(Some(maybe_rel_a)) => {
-            //assert_integer(ids.a)
-            let a = if let &MaybeRelocatable::Int(ref a) = maybe_rel_a {
-                a
+    let maybe_rel_a = if let Ok(Some(maybe_rel_a)) = vm.memory.get(&a_addr) {
+        maybe_rel_a
+    } else {
+        return Err(VirtualMachineError::FailedToGetIds);
+    };
+
+    //assert_integer(ids.a)
+    let a = if let &MaybeRelocatable::Int(ref a) = maybe_rel_a {
+        a
+    } else {
+        return Err(VirtualMachineError::ExpectedInteger(a_addr.clone()));
+    };
+
+    for (name, builtin) in &vm.builtin_runners {
+        //Check that range_check_builtin is present
+        if name == &String::from("range_check") {
+            let range_check_builtin = if let Some(range_check_builtin) =
+                builtin.as_any().downcast_ref::<RangeCheckBuiltinRunner>()
+            {
+                range_check_builtin
             } else {
-                return Err(VirtualMachineError::ExpectedInteger(a_addr.clone()));
+                return Err(VirtualMachineError::NoRangeCheckBuiltin);
             };
-            for (name, builtin) in &vm.builtin_runners {
-                //Check that range_check_builtin is present
-                if name == &String::from("range_check") {
-                    match builtin.as_any().downcast_ref::<RangeCheckBuiltinRunner>() {
-                        None => return Err(VirtualMachineError::NoRangeCheckBuiltin),
-                        Some(builtin) => {
-                            // assert 0 <= ids.a % PRIME < range_check_builtin.bound
-                            if bigint!(0) <= a.mod_floor(&vm.prime)
-                                && a.mod_floor(&vm.prime) < builtin._bound
-                            {
-                                return Ok(());
-                            } else {
-                                return Err(VirtualMachineError::ValueOutOfRange(a.clone()));
-                            }
-                        }
-                    }
-                }
+
+            // assert 0 <= ids.a % PRIME < range_check_builtin.bound
+            if bigint!(0) <= a.mod_floor(&vm.prime)
+                && a.mod_floor(&vm.prime) < range_check_builtin._bound
+            {
+                return Ok(());
+            } else {
+                return Err(VirtualMachineError::ValueOutOfRange(a.clone()));
             }
-            Err(VirtualMachineError::NoRangeCheckBuiltin)
         }
-        _ => Err(VirtualMachineError::FailedToGetIds),
     }
+    Err(VirtualMachineError::NoRangeCheckBuiltin)
 }

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -353,15 +353,14 @@ pub fn assert_nn(
     ids: HashMap<String, BigInt>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for 'a' variable used by the hint
-    let a_ref =
-        if let Some(a_ref) = ids.get(&String::from("starkware.cairo.common.math.assert_nn.a")) {
-            a_ref
-        } else {
-            return Err(VirtualMachineError::IncorrectIds(
-                vec![String::from("starkware.cairo.common.math.assert_nn.a")],
-                ids.into_keys().collect(),
-            ));
-        };
+    let a_ref = if let Some(a_ref) = ids.get(&String::from("a")) {
+        a_ref
+    } else {
+        return Err(VirtualMachineError::IncorrectIds(
+            vec![String::from("a")],
+            ids.into_keys().collect(),
+        ));
+    };
     //Check that 'a' reference id corresponds to a value in the reference manager
     let a_addr =
         if let Some(a_addr) = get_address_from_reference(a_ref, &vm.references, &vm.run_context) {
@@ -385,8 +384,8 @@ pub fn assert_nn(
                         None => return Err(VirtualMachineError::NoRangeCheckBuiltin),
                         Some(builtin) => {
                             // assert 0 <= ids.a % PRIME < range_check_builtin.bound
-                            if bigint!(0) <= a % vm.prime.clone()
-                                && a % vm.prime.clone() < builtin._bound
+                            if bigint!(0) <= a.mod_floor(&vm.prime)
+                                && a.mod_floor(&vm.prime) < builtin._bound
                             {
                                 return Ok(());
                             } else {

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -6,6 +6,7 @@ use crate::vm::{
 use crate::{bigint, vm::hints::execute_hint::HintReference};
 use num_bigint::BigInt;
 use num_integer::Integer;
+use num_traits::Signed;
 use num_traits::{FromPrimitive, ToPrimitive};
 use std::collections::HashMap;
 
@@ -395,7 +396,7 @@ pub fn assert_nn(
             };
 
             // assert 0 <= ids.a % PRIME < range_check_builtin.bound
-            if bigint!(0) <= a.mod_floor(&vm.prime)
+            if a.mod_floor(&vm.prime).is_positive()
                 && a.mod_floor(&vm.prime) < range_check_builtin._bound
             {
                 return Ok(());

--- a/tests/cairo_run_test.rs
+++ b/tests/cairo_run_test.rs
@@ -62,3 +62,8 @@ fn cairo_run_compare_different_arrays() {
     cairo_run::cairo_run(Path::new("cairo_programs/compare_different_arrays.json"))
         .expect("Couldn't run program");
 }
+
+#[test]
+fn cairo_run_assert_nn() {
+    cairo_run::cairo_run(Path::new("cairo_programs/assert_nn.json")).expect("Couldn't run program");
+}


### PR DESCRIPTION
# Add implementation for hint on assert_nn (math.cairo)

Add implementation for hint on assert_nn cairo (math.cairo)
https://github.com/starkware-libs/cairo-lang/blob/167b28bcd940fd25ea3816204fa882a0b0a49603/src/starkware/cairo/common/math.cairo#L39

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [x] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
