### PR TITLE
Make traces optional

### DIFF
--- a/bench/criterion/criterion_benchmark.rs
+++ b/bench/criterion/criterion_benchmark.rs
@@ -16,7 +16,7 @@ const BENCH_PATH: &'static str = "cairo_programs/benchmarks/";
 pub fn criterion_benchmarks(c: &mut Criterion) {
     for benchmark_name in build_bench_strings() {
         c.bench_function(&benchmark_name.0, |b| {
-            b.iter(|| cairo_run::cairo_run(black_box(Path::new(&benchmark_name.1))))
+            b.iter(|| cairo_run::cairo_run(black_box(Path::new(&benchmark_name.1)), false))
         });
     }
 }

--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -7,13 +7,13 @@ use std::fs::File;
 use std::io::{self, Error, ErrorKind, Write};
 use std::path::Path;
 
-pub fn cairo_run(path: &Path) -> Result<CairoRunner, CairoRunError> {
+pub fn cairo_run(path: &Path, trace_enabled: bool) -> Result<CairoRunner, CairoRunError> {
     let program = match Program::new(path) {
         Ok(program) => program,
         Err(error) => return Err(CairoRunError::Program(error)),
     };
 
-    let mut cairo_runner = CairoRunner::new(&program);
+    let mut cairo_runner = CairoRunner::new(&program, trace_enabled);
     cairo_runner.initialize_segments(None);
 
     let end = match cairo_runner.initialize_main_entrypoint() {
@@ -121,7 +121,7 @@ mod tests {
             Err(e) => return Err(CairoRunError::Program(e)),
         };
 
-        let mut cairo_runner = CairoRunner::new(&program);
+        let mut cairo_runner = CairoRunner::new(&program, true);
 
         cairo_runner.initialize_segments(None);
 
@@ -161,7 +161,7 @@ mod tests {
         // it should fail when the program is loaded.
         let no_data_program_path = Path::new("cairo_programs/no_data_program.json");
 
-        assert!(cairo_run(no_data_program_path).is_err());
+        assert!(cairo_run(no_data_program_path, false).is_err());
     }
 
     #[test]
@@ -170,7 +170,7 @@ mod tests {
         // it should fail when trying to run initialize_main_entrypoint.
         let no_main_program_path = Path::new("cairo_programs/no_main_program.json");
 
-        assert!(cairo_run(no_main_program_path).is_err());
+        assert!(cairo_run(no_main_program_path, false).is_err());
     }
 
     #[test]
@@ -179,7 +179,7 @@ mod tests {
         // decode the instruction.
         let invalid_memory = Path::new("cairo_programs/invalid_memory.json");
 
-        assert!(cairo_run(invalid_memory).is_err());
+        assert!(cairo_run(invalid_memory, false).is_err());
     }
 
     #[test]
@@ -194,9 +194,14 @@ mod tests {
 
         // relocate memory so we can dump it to file
         assert!(cairo_runner.relocate().is_ok());
+        assert!(cairo_runner.vm.trace.is_some());
+        assert!(cairo_runner.relocated_trace.is_some());
 
         // write cleopatra vm trace file
-        assert!(write_binary_trace(&cairo_runner.relocated_trace, cleopatra_trace_path).is_ok());
+        assert!(
+            write_binary_trace(&cairo_runner.relocated_trace.unwrap(), cleopatra_trace_path)
+                .is_ok()
+        );
 
         // compare that the original cairo vm trace file and cleopatra vm trace files are equal
         assert!(compare_files(cleopatra_trace_path, expected_trace_path).is_ok());
@@ -220,5 +225,22 @@ mod tests {
 
         // compare that the original cairo vm memory file and cleopatra vm memory files are equal
         assert!(compare_files(cleopatra_memory_path, expected_memory_path).is_ok());
+    }
+
+    #[test]
+    fn run_with_no_trace() {
+        let program_path = Path::new("cairo_programs/struct.json");
+        let program = Program::new(program_path).unwrap();
+        let mut cairo_runner = CairoRunner::new(&program, false);
+
+        cairo_runner.initialize_segments(None);
+
+        let end = cairo_runner.initialize_main_entrypoint().unwrap();
+
+        assert!(cairo_runner.initialize_vm().is_ok());
+
+        assert!(cairo_runner.run_until_pc(end).is_ok());
+
+        assert!(cairo_runner.vm.trace.is_none());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ fn main() -> Result<(), CairoRunError> {
             .relocated_trace
             .as_ref()
             .ok_or(CairoRunError::Trace(TraceError::TraceNotEnabled))?;
-        match cairo_run::write_binary_trace(&relocated_trace, &trace_path) {
+        match cairo_run::write_binary_trace(relocated_trace, &trace_path) {
             Ok(()) => (),
             Err(_e) => return Err(CairoRunError::Runner(RunnerError::WriteFail)),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use clap::{Parser, ValueHint};
 use cleopatra_cairo::cairo_run;
 use cleopatra_cairo::vm::errors::cairo_run_errors::CairoRunError;
 use cleopatra_cairo::vm::errors::runner_errors::RunnerError;
+use cleopatra_cairo::vm::errors::trace_errors::TraceError;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
@@ -21,13 +22,18 @@ struct Args {
 
 fn main() -> Result<(), CairoRunError> {
     let args = Args::parse();
-    let mut cairo_runner = match cairo_run::cairo_run(&args.filename) {
+    let trace_enabled = args.trace_file.is_some();
+    let mut cairo_runner = match cairo_run::cairo_run(&args.filename, trace_enabled) {
         Ok(runner) => runner,
         Err(error) => return Err(error),
     };
 
     if let Some(trace_path) = args.trace_file {
-        match cairo_run::write_binary_trace(&cairo_runner.relocated_trace, &trace_path) {
+        let relocated_trace = cairo_runner
+            .relocated_trace
+            .as_ref()
+            .ok_or(CairoRunError::Trace(TraceError::TraceNotEnabled))?;
+        match cairo_run::write_binary_trace(&relocated_trace, &trace_path) {
             Ok(()) => (),
             Err(_e) => return Err(CairoRunError::Runner(RunnerError::WriteFail)),
         }

--- a/src/vm/errors/trace_errors.rs
+++ b/src/vm/errors/trace_errors.rs
@@ -3,6 +3,8 @@ use std::fmt;
 
 #[derive(Debug, PartialEq)]
 pub enum TraceError {
+    TraceNotEnabled,
+    AlreadyRelocated,
     RegNotRelocatable,
     NoRelocationFound,
     MemoryError(MemoryError),
@@ -11,6 +13,8 @@ pub enum TraceError {
 impl fmt::Display for TraceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            TraceError::TraceNotEnabled => write!(f, "Trace is not enabled for this run"),
+            TraceError::AlreadyRelocated => write!(f, "Trace is already relocated"),
             TraceError::RegNotRelocatable => write!(f, "Trace register must be relocatable"),
             TraceError::NoRelocationFound => write!(f, "No relocation found for this segment"),
             TraceError::MemoryError(memory_error) => memory_error.fmt(f),

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -82,6 +82,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             //ap value is (0,0)
             Vec::new(),
+            false,
         );
         //ids and references are not needed for this test
         execute_hint(&mut vm, hint_code, HashMap::new()).expect("Error while executing hint");
@@ -100,6 +101,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         //Add 3 segments to the memory
         for _ in 0..3 {
@@ -123,6 +125,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         //Add 3 segments to the memory
         for _ in 0..3 {
@@ -155,6 +158,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         assert_eq!(
             execute_hint(&mut vm, hint_code, HashMap::new()),
@@ -174,6 +178,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -220,6 +225,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -268,6 +274,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -313,6 +320,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         assert_eq!(
             execute_hint(&mut vm, &hint_code, HashMap::new()),
@@ -327,6 +335,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -371,6 +380,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -400,6 +410,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -440,6 +451,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -486,6 +498,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -812,6 +825,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
 
         vm.segments.add(&mut vm.memory, None);
@@ -854,6 +868,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -898,6 +913,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
 
         vm.segments.add(&mut vm.memory, None);
@@ -945,6 +961,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
 
         vm.segments.add(&mut vm.memory, None);
@@ -989,6 +1006,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
 
         vm.segments.add(&mut vm.memory, None);
@@ -1032,6 +1050,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![],
+            false,
         );
 
         vm.segments.add(&mut vm.memory, None);
@@ -1076,6 +1095,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
 
         vm.segments.add(&mut vm.memory, None);
@@ -1112,6 +1132,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -1192,6 +1213,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -1272,6 +1294,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -1354,6 +1377,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -1437,6 +1461,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -1483,6 +1508,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -1524,6 +1550,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -1586,6 +1613,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -1642,6 +1670,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -1710,6 +1739,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -1772,6 +1802,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -1828,6 +1859,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -1890,6 +1922,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -1952,6 +1985,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         //Create references
         vm.references = HashMap::from([(
@@ -1989,6 +2023,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         //Create references
         vm.references = HashMap::from([(
@@ -2029,6 +2064,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         //Create references
         vm.references = HashMap::from([(
@@ -2072,6 +2108,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         //Create references
         vm.references = HashMap::from([(
@@ -2112,6 +2149,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         //Create references
         vm.references = HashMap::from([(
@@ -2155,6 +2193,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         vm.references = HashMap::from([(
             0,
@@ -2195,6 +2234,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -2235,6 +2275,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -2272,6 +2313,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -2367,6 +2409,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -2466,6 +2509,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -2525,6 +2569,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -2584,6 +2629,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -2646,6 +2692,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -576,6 +576,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -633,6 +634,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -696,6 +698,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -760,6 +763,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -2758,6 +2762,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -2812,6 +2817,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -2866,6 +2872,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -2940,6 +2940,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -3026,6 +3027,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -3107,6 +3109,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -3188,6 +3191,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -3281,6 +3285,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -3360,6 +3365,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -3430,6 +3436,7 @@ mod tests {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
+            false,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -3441,7 +3448,7 @@ mod tests {
         vm.memory
             .insert(
                 &MaybeRelocatable::from((0, 0)),
-                &MaybeRelocatable::from(bigint!(1).shl(251)),
+                &MaybeRelocatable::from(bigint!(1).shl(251i32)),
             )
             .unwrap();
         //Create ids
@@ -3483,7 +3490,7 @@ mod tests {
         assert_eq!(
             execute_hint(&mut vm, hint_code, ids),
             Err(VirtualMachineError::ValueOutside250BitRange(
-                bigint!(1).shl(251)
+                bigint!(1).shl(251i32)
             ))
         );
     }
@@ -3499,6 +3506,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -3586,6 +3594,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -3668,6 +3677,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -3747,6 +3757,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -3840,6 +3851,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -3933,6 +3945,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -4013,6 +4026,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         //Initialize memory segements
         for _ in 0..3 {
@@ -4079,6 +4093,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         //Initialize memory segements
         for _ in 0..3 {
@@ -4148,6 +4163,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         //Initialize memory segements
         for _ in 0..3 {
@@ -4219,6 +4235,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         //Initialize memory segements
         for _ in 0..3 {
@@ -4289,6 +4306,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         //Initialize memory segements
         for _ in 0..3 {
@@ -4360,6 +4378,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         //Initialize memory segements
         for _ in 0..3 {
@@ -4431,6 +4450,7 @@ mod tests {
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
+            false,
         );
         //Initialize memory segements
         for _ in 0..3 {

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -93,7 +93,7 @@ impl VirtualMachine {
             _program_base: None,
             memory: Memory::new(),
             accessed_addresses: None,
-            trace: trace,
+            trace,
             current_step: 0,
             skip_instruction_execution: false,
             segments: MemorySegmentManager::new(),

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -2082,7 +2082,6 @@ mod tests {
             opcode: Opcode::NOp,
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
         let mut vm = VirtualMachine::new(bigint!(127), Vec::new(), false);
         vm.accessed_addresses = Some(HashSet::new());
         vm.memory.data.push(Vec::new());

--- a/tests/bitwise_test.rs
+++ b/tests/bitwise_test.rs
@@ -9,7 +9,7 @@ use cleopatra_cairo::{
 fn bitwise_integration_test() {
     let program = Program::new(Path::new("cairo_programs/bitwise_builtin_test.json"))
         .expect("Failed to deserialize program");
-    let mut cairo_runner = CairoRunner::new(&program);
+    let mut cairo_runner = CairoRunner::new(&program, true);
     cairo_runner.initialize_segments(None);
     let end = cairo_runner.initialize_main_entrypoint().unwrap();
 
@@ -250,6 +250,6 @@ fn bitwise_integration_test() {
         },
     ];
     for (i, entry) in python_vm_relocated_trace.iter().enumerate() {
-        assert_eq!(&cairo_runner.relocated_trace[i], entry);
+        assert_eq!(&cairo_runner.relocated_trace.as_ref().unwrap()[i], entry);
     }
 }

--- a/tests/cairo_run_test.rs
+++ b/tests/cairo_run_test.rs
@@ -64,9 +64,10 @@ fn cairo_run_assert_le_felt_hint() {
 
 #[test]
 fn cairo_run_assert_250_bit_element_array() {
-    cairo_run::cairo_run(Path::new(
-        "cairo_programs/assert_250_bit_element_array.json",
-    ))
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/assert_250_bit_element_array.json"),
+        false,
+    )
     .expect("Couldn't run program");
 }
 
@@ -117,7 +118,7 @@ fn cairo_run_split_int_big() {
 
 #[test]
 fn cairo_run_split_felt() {
-    cairo_run::cairo_run(Path::new("cairo_programs/split_felt.json"))
+    cairo_run::cairo_run(Path::new("cairo_programs/split_felt.json"), false)
         .expect("Couldn't run program");
 }
 
@@ -129,12 +130,12 @@ fn cairo_run_is_le_felt() {
 
 #[test]
 fn cairo_run_unsigned_div_rem() {
-    cairo_run::cairo_run(Path::new("cairo_programs/unsigned_div_rem.json"))
+    cairo_run::cairo_run(Path::new("cairo_programs/unsigned_div_rem.json"), false)
         .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_assert_lt_felt() {
-    cairo_run::cairo_run(Path::new("cairo_programs/assert_lt_felt.json"))
+    cairo_run::cairo_run(Path::new("cairo_programs/assert_lt_felt.json"), false)
         .expect("Couldn't run program");
 }

--- a/tests/cairo_run_test.rs
+++ b/tests/cairo_run_test.rs
@@ -4,56 +4,61 @@ use cleopatra_cairo::cairo_run;
 
 #[test]
 fn cairo_run_test() {
-    cairo_run::cairo_run(Path::new("cairo_programs/fibonacci.json")).expect("Couldn't run program");
+    cairo_run::cairo_run(Path::new("cairo_programs/fibonacci.json"), false)
+        .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_bitwise_output() {
-    cairo_run::cairo_run(Path::new("cairo_programs/bitwise_output.json"))
+    cairo_run::cairo_run(Path::new("cairo_programs/bitwise_output.json"), false)
         .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_bitwise_recursion() {
-    cairo_run::cairo_run(Path::new("cairo_programs/bitwise_recursion.json"))
+    cairo_run::cairo_run(Path::new("cairo_programs/bitwise_recursion.json"), false)
         .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_integration() {
-    cairo_run::cairo_run(Path::new("cairo_programs/integration.json"))
+    cairo_run::cairo_run(Path::new("cairo_programs/integration.json"), false)
         .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_integration_with_alloc_locals() {
-    cairo_run::cairo_run(Path::new(
-        "cairo_programs/integration_with_alloc_locals.json",
-    ))
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/integration_with_alloc_locals.json"),
+        false,
+    )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_compare_arrays() {
-    cairo_run::cairo_run(Path::new("cairo_programs/compare_arrays.json"))
+    cairo_run::cairo_run(Path::new("cairo_programs/compare_arrays.json"), false)
         .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_compare_greater_array() {
-    cairo_run::cairo_run(Path::new("cairo_programs/compare_greater_array.json"))
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/compare_greater_array.json"),
+        false,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_compare_lesser_array() {
-    cairo_run::cairo_run(Path::new("cairo_programs/compare_lesser_array.json"))
+    cairo_run::cairo_run(Path::new("cairo_programs/compare_lesser_array.json"), false)
         .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_assert_le_felt_hint() {
-    cairo_run::cairo_run(Path::new("cairo_programs/assert_le_felt_hint.json"))
+    cairo_run::cairo_run(Path::new("cairo_programs/assert_le_felt_hint.json"), false)
         .expect("Couldn't run program");
 }
 
@@ -67,19 +72,23 @@ fn cairo_run_assert_250_bit_element_array() {
 
 #[test]
 fn cairo_abs_value() {
-    cairo_run::cairo_run(Path::new("cairo_programs/abs_value_array.json"))
+    cairo_run::cairo_run(Path::new("cairo_programs/abs_value_array.json"), false)
         .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_compare_different_arrays() {
-    cairo_run::cairo_run(Path::new("cairo_programs/compare_different_arrays.json"))
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/compare_different_arrays.json"),
+        false,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_assert_nn() {
-    cairo_run::cairo_run(Path::new("cairo_programs/assert_nn.json")).expect("Couldn't run program");
+    cairo_run::cairo_run(Path::new("cairo_programs/assert_nn.json"), false)
+        .expect("Couldn't run program");
 }
 
 #[test]
@@ -89,18 +98,19 @@ fn cairo_run_sqrt() {
 
 #[test]
 fn cairo_run_assert_not_zero() {
-    cairo_run::cairo_run(Path::new("cairo_programs/assert_not_zero.json"))
+    cairo_run::cairo_run(Path::new("cairo_programs/assert_not_zero.json"), false)
         .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_split_int() {
-    cairo_run::cairo_run(Path::new("cairo_programs/split_int.json")).expect("Couldn't run program");
+    cairo_run::cairo_run(Path::new("cairo_programs/split_int.json"), false)
+        .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_split_int_big() {
-    cairo_run::cairo_run(Path::new("cairo_programs/split_int_big.json"))
+    cairo_run::cairo_run(Path::new("cairo_programs/split_int_big.json"), false)
         .expect("Couldn't run program");
 }
 

--- a/tests/cairo_run_test.rs
+++ b/tests/cairo_run_test.rs
@@ -93,7 +93,8 @@ fn cairo_run_assert_nn() {
 
 #[test]
 fn cairo_run_sqrt() {
-    cairo_run::cairo_run(Path::new("cairo_programs/sqrt.json")).expect("Couldn't run program");
+    cairo_run::cairo_run(Path::new("cairo_programs/sqrt.json"), false)
+        .expect("Couldn't run program");
 }
 
 #[test]
@@ -122,7 +123,7 @@ fn cairo_run_split_felt() {
 
 #[test]
 fn cairo_run_is_le_felt() {
-    cairo_run::cairo_run(Path::new("cairo_programs/math_cmp_is_le_felt.json"))
+    cairo_run::cairo_run(Path::new("cairo_programs/math_cmp_is_le_felt.json"), false)
         .expect("Couldn't run program");
 }
 

--- a/tests/pedersen_test.rs
+++ b/tests/pedersen_test.rs
@@ -9,7 +9,7 @@ use cleopatra_cairo::{
 fn pedersen_integration_test() {
     let program = Program::new(Path::new("cairo_programs/pedersen_test.json"))
         .expect("Failed to deserialize program");
-    let mut cairo_runner = CairoRunner::new(&program);
+    let mut cairo_runner = CairoRunner::new(&program, true);
     cairo_runner.initialize_segments(None);
     let end = cairo_runner.initialize_main_entrypoint().unwrap();
     assert!(cairo_runner.initialize_vm() == Ok(()), "Execution failed");
@@ -88,5 +88,8 @@ fn pedersen_integration_test() {
             fp: 25,
         },
     ];
-    assert_eq!(cairo_runner.relocated_trace, python_vm_relocated_trace);
+    assert_eq!(
+        cairo_runner.relocated_trace,
+        Some(python_vm_relocated_trace)
+    );
 }

--- a/tests/struct_test.rs
+++ b/tests/struct_test.rs
@@ -9,7 +9,7 @@ use cleopatra_cairo::{
 fn struct_integration_test() {
     let program = Program::new(Path::new("cairo_programs/struct.json"))
         .expect("Failed to deserialize program");
-    let mut cairo_runner = CairoRunner::new(&program);
+    let mut cairo_runner = CairoRunner::new(&program, true);
     cairo_runner.initialize_segments(None);
     let end = cairo_runner.initialize_main_entrypoint().unwrap();
 
@@ -22,5 +22,5 @@ fn struct_integration_test() {
         fp: 4,
     };
 
-    assert_eq!(cairo_runner.relocated_trace[0], relocated_entry);
+    assert_eq!(cairo_runner.relocated_trace, Some(vec![relocated_entry]));
 }


### PR DESCRIPTION
# Make tracing programs optional

## Description

After this changeset traces will only be computed if a trace file was passed on the command line.
Benchmarks suggest an improvement of 2-5% in runtime when tracing is disabled.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
