### PR TITLE
Assert not zero hint implementation

### DIFF
--- a/cairo_programs/assert_not_zero.cairo
+++ b/cairo_programs/assert_not_zero.cairo
@@ -1,0 +1,31 @@
+from starkware.cairo.common.math import assert_not_zero
+
+func assert_not_zero_manual_implementation(value):
+    %{
+        from starkware.cairo.common.math_utils import assert_integer
+        assert_integer(ids.value)
+        assert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'
+    %}
+    if value == 0:
+        # If value == 0, add an unsatisfiable requirement.
+        value = 1
+    end
+
+    return ()
+end
+
+func main():
+    assert_not_zero(1)
+    assert_not_zero(-1)
+    let x = 500 * 5
+    assert_not_zero(x)
+    tempvar y = -80
+    assert_not_zero(y)
+
+    assert_not_zero_manual_implementation(1)
+    assert_not_zero_manual_implementation(-1)
+    assert_not_zero_manual_implementation(x)
+    assert_not_zero_manual_implementation(y)
+
+    return ()
+end

--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -44,6 +44,7 @@ pub enum VirtualMachineError {
     DiffTypeComparison(MaybeRelocatable, MaybeRelocatable),
     AssertNotEqualFail(MaybeRelocatable, MaybeRelocatable),
     DiffIndexComp(Relocatable, Relocatable),
+    AssertNotZero(BigInt, BigInt),
 }
 
 impl fmt::Display for VirtualMachineError {
@@ -128,6 +129,9 @@ impl fmt::Display for VirtualMachineError {
             },
             VirtualMachineError::DiffIndexComp(a, b) => {
                 write!(f, "Failed to compare {:?} and  {:?}, cant compare two relocatable values of different segment indexes", a, b)
+            },
+            VirtualMachineError::AssertNotZero(value, prime) => {
+                write!(f, "Assertion failed, {} % {} is equal to 0", value, prime)
             },
         }
     }

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -5,7 +5,8 @@ use num_bigint::BigInt;
 use crate::types::instruction::Register;
 use crate::vm::errors::vm_errors::VirtualMachineError;
 use crate::vm::hints::hint_utils::{
-    add_segment, assert_le_felt, assert_nn, assert_not_equal, is_nn, is_nn_out_of_range,
+    add_segment, assert_le_felt, assert_nn, assert_not_equal, assert_not_zero, is_nn,
+    is_nn_out_of_range,
 };
 use crate::vm::vm_core::VirtualMachine;
 
@@ -30,6 +31,8 @@ pub fn execute_hint(
         ) => assert_not_equal(vm, ids),
         Ok("from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert 0 <= ids.a % PRIME < range_check_builtin.bound, f'a = {ids.a} is out of range.'"
         ) => assert_nn(vm, ids),
+        Ok("from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'"
+        ) => assert_not_zero(vm, ids),
         Ok(hint_code) => Err(VirtualMachineError::UnknownHint(String::from(hint_code))),
         Err(_) => Err(VirtualMachineError::InvalidHintEncoding(
             vm.run_context.pc.clone(),

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -1452,4 +1452,218 @@ mod tests {
             ))
         );
     }
+
+    #[test]
+    fn run_assert_not_zero_true() {
+        let hint_code =
+    "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'".as_bytes();
+        let mut vm = VirtualMachine::new(
+            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            Vec::new(),
+        );
+        //Create references
+        vm.references = vec![HintReference {
+            register: Register::FP,
+            offset: -1,
+        }];
+        vm.segments.add(&mut vm.memory, None);
+        // }
+        // //Initialize ap, fp
+        vm.run_context.ap = MaybeRelocatable::from((1, 0));
+        vm.run_context.fp = MaybeRelocatable::from((0, 1));
+        //Insert ids into memory
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((0, 0)),
+                &MaybeRelocatable::from(bigint!(5)),
+            )
+            .unwrap();
+        //Create ids
+        let mut ids = HashMap::<String, BigInt>::new();
+        ids.insert(String::from("value"), bigint!(0));
+
+        assert_eq!(execute_hint(&mut vm, hint_code, ids), Ok(()));
+    }
+
+    #[test]
+    fn run_assert_not_zero_false() {
+        let hint_code =
+    "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'".as_bytes();
+        let mut vm = VirtualMachine::new(
+            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            Vec::new(),
+        );
+        //Create references
+        vm.references = vec![HintReference {
+            register: Register::FP,
+            offset: -1,
+        }];
+        vm.segments.add(&mut vm.memory, None);
+        // }
+        // //Initialize ap, fp
+        vm.run_context.ap = MaybeRelocatable::from((1, 0));
+        vm.run_context.fp = MaybeRelocatable::from((0, 1));
+        //Insert ids into memory
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((0, 0)),
+                &MaybeRelocatable::from(bigint!(0)),
+            )
+            .unwrap();
+        //Create ids
+        let mut ids = HashMap::<String, BigInt>::new();
+        ids.insert(String::from("value"), bigint!(0));
+
+        assert_eq!(
+            execute_hint(&mut vm, hint_code, ids),
+            Err(VirtualMachineError::AssertNotZero(bigint!(0), vm.prime))
+        );
+    }
+
+    #[test]
+    fn run_assert_not_zero_false_with_prime() {
+        let hint_code =
+    "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'".as_bytes();
+        let mut vm = VirtualMachine::new(
+            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            Vec::new(),
+        );
+        //Create references
+        vm.references = vec![HintReference {
+            register: Register::FP,
+            offset: -1,
+        }];
+        vm.segments.add(&mut vm.memory, None);
+        // }
+        // //Initialize ap, fp
+        vm.run_context.ap = MaybeRelocatable::from((1, 0));
+        vm.run_context.fp = MaybeRelocatable::from((0, 1));
+        //Insert ids into memory
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((0, 0)),
+                &MaybeRelocatable::from(vm.prime.clone()),
+            )
+            .unwrap();
+        //Create ids
+        let mut ids = HashMap::<String, BigInt>::new();
+        ids.insert(String::from("value"), bigint!(0));
+
+        assert_eq!(
+            execute_hint(&mut vm, hint_code, ids),
+            Err(VirtualMachineError::AssertNotZero(
+                vm.prime.clone(),
+                vm.prime
+            ))
+        );
+    }
+
+    #[test]
+    fn run_assert_not_zero_failed_to_get_reference() {
+        let hint_code =
+    "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'".as_bytes();
+        let mut vm = VirtualMachine::new(
+            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            Vec::new(),
+        );
+        //Create references
+        vm.references = vec![HintReference {
+            register: Register::FP,
+            offset: -1,
+        }];
+        vm.segments.add(&mut vm.memory, None);
+        // }
+        // //Initialize ap, fp
+        vm.run_context.ap = MaybeRelocatable::from((1, 0));
+        vm.run_context.fp = MaybeRelocatable::from((0, 1));
+        //Insert ids into memory
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((0, 0)),
+                &MaybeRelocatable::from(bigint!(5)),
+            )
+            .unwrap();
+        //Create invalid id value
+        let mut ids = HashMap::<String, BigInt>::new();
+        ids.insert(String::from("value"), bigint!(10));
+
+        assert_eq!(
+            execute_hint(&mut vm, hint_code, ids),
+            Err(VirtualMachineError::FailedToGetReference(bigint!(10)))
+        );
+    }
+
+    #[test]
+    fn run_assert_not_zero_incorrect_id() {
+        let hint_code =
+    "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'".as_bytes();
+        let mut vm = VirtualMachine::new(
+            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            Vec::new(),
+        );
+        //Create references
+        vm.references = vec![HintReference {
+            register: Register::FP,
+            offset: -1,
+        }];
+        vm.segments.add(&mut vm.memory, None);
+        // }
+        // //Initialize ap, fp
+        vm.run_context.ap = MaybeRelocatable::from((1, 0));
+        vm.run_context.fp = MaybeRelocatable::from((0, 1));
+        //Insert ids into memory
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((0, 0)),
+                &MaybeRelocatable::from(bigint!(0)),
+            )
+            .unwrap();
+        //Create invalid id key
+        let mut ids = HashMap::<String, BigInt>::new();
+        ids.insert(String::from("incorrect_id"), bigint!(0));
+
+        assert_eq!(
+            execute_hint(&mut vm, hint_code, ids),
+            Err(VirtualMachineError::IncorrectIds(
+                vec![String::from("value")],
+                vec![String::from("incorrect_id")],
+            ))
+        );
+    }
+
+    #[test]
+    fn run_assert_not_zero_expected_integer_error() {
+        let hint_code =
+    "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'".as_bytes();
+        let mut vm = VirtualMachine::new(
+            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            Vec::new(),
+        );
+        vm.references = vec![HintReference {
+            register: Register::FP,
+            offset: -1,
+        }];
+        vm.segments.add(&mut vm.memory, None);
+        // }
+        // //Initialize ap, fp
+        vm.run_context.ap = MaybeRelocatable::from((1, 0));
+        vm.run_context.fp = MaybeRelocatable::from((0, 1));
+        //Insert ids into memory
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((0, 0)),
+                &MaybeRelocatable::from((0, 0)),
+            )
+            .unwrap();
+        //Create ids
+        let mut ids = HashMap::<String, BigInt>::new();
+        ids.insert(String::from("value"), bigint!(0));
+
+        assert_eq!(
+            execute_hint(&mut vm, hint_code, ids),
+            Err(VirtualMachineError::ExpectedInteger(
+                MaybeRelocatable::from((0, 0))
+            ))
+        );
+    }
 }

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -407,3 +407,49 @@ pub fn assert_nn(
     }
     Err(VirtualMachineError::NoRangeCheckBuiltin)
 }
+
+//Implements hint:from starkware.cairo.common.math.cairo
+// %{
+// from starkware.cairo.common.math_utils import assert_integer
+// assert_integer(ids.value)
+// assert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'
+// %}
+pub fn assert_not_zero(
+    vm: &mut VirtualMachine,
+    ids: HashMap<String, BigInt>,
+) -> Result<(), VirtualMachineError> {
+    let value_ref = if let Some(value_ref) = ids.get(&String::from("value")) {
+        value_ref
+    } else {
+        return Err(VirtualMachineError::IncorrectIds(
+            vec![String::from("value")],
+            ids.into_keys().collect(),
+        ));
+    };
+    //Check that each reference id corresponds to a value in the reference manager
+    let value_addr = if let Some(value_addr) =
+        get_address_from_reference(value_ref, &vm.references, &vm.run_context)
+    {
+        value_addr
+    } else {
+        return Err(VirtualMachineError::FailedToGetReference(value_ref.clone()));
+    };
+    match vm.memory.get(&value_addr) {
+        Ok(Some(maybe_rel_value)) => {
+            //Check that the value at the ids address is an Int
+            if let &MaybeRelocatable::Int(ref value) = maybe_rel_value {
+                if value % &vm.prime == bigint!(0) {
+                    Err(VirtualMachineError::AssertNotZero(
+                        value.clone(),
+                        vm.prime.clone(),
+                    ))
+                } else {
+                    Ok(())
+                }
+            } else {
+                Err(VirtualMachineError::ExpectedInteger(value_addr.clone()))
+            }
+        }
+        _ => Err(VirtualMachineError::FailedToGetIds),
+    }
+}

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -438,7 +438,7 @@ pub fn assert_not_zero(
         Ok(Some(maybe_rel_value)) => {
             //Check that the value at the ids address is an Int
             if let &MaybeRelocatable::Int(ref value) = maybe_rel_value {
-                if value % &vm.prime == bigint!(0) {
+                if value.is_multiple_of(&vm.prime) {
                     Err(VirtualMachineError::AssertNotZero(
                         value.clone(),
                         vm.prime.clone(),

--- a/tests/cairo_run_test.rs
+++ b/tests/cairo_run_test.rs
@@ -67,3 +67,9 @@ fn cairo_run_compare_different_arrays() {
 fn cairo_run_assert_nn() {
     cairo_run::cairo_run(Path::new("cairo_programs/assert_nn.json")).expect("Couldn't run program");
 }
+
+#[test]
+fn cairo_run_assert_not_zero() {
+    cairo_run::cairo_run(Path::new("cairo_programs/assert_not_zero.json"))
+        .expect("Couldn't run program");
+}


### PR DESCRIPTION
# Add implementation for hint on `assert_not_zero` (math.cairo)

Reimplementation of PR #225 

Add implementation of `assert_not_zero` cairo hint (math.cairo)
https://github.com/starkware-libs/cairo-lang/blob/167b28bcd940fd25ea3816204fa882a0b0a49603/src/starkware/cairo/common/math.cairo#L4

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [x] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
