### PR TITLE
Replace looping insertion by .extend call

### DIFF
--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -411,9 +411,8 @@ impl VirtualMachine {
             ap: self.run_context.ap.clone(),
             fp: self.run_context.fp.clone(),
         });
-        for addr in operands_mem_addresses.iter() {
-            self.accessed_addresses.insert(addr.clone());
-        }
+        self.accessed_addresses
+            .extend(operands_mem_addresses.iter().map(Clone::clone));
         self.accessed_addresses.insert(self.run_context.pc.clone());
 
         self.update_registers(instruction, operands)?;


### PR DESCRIPTION
Inserting values into the accessed addresses set take ~15% of time in
most benchmarks. By removing a loop for inserting the operands'
addresses and using the `.extend()` method instead, we obtain a 1-5%
reduction in total runtime, depending on the particular benchmark.

# TITLE

## Description

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
