### PR TITLE
Fix references deserialization bug

### DIFF
--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -67,6 +67,7 @@ pub struct ValueAddress {
     pub offset2: i32,
     pub immediate: Option<BigInt>,
     pub dereference: bool,
+    pub inner_dereference: bool,
 }
 
 struct BigIntVisitor;
@@ -422,6 +423,7 @@ mod tests {
                         offset2: 0,
                         immediate: None,
                         dereference: true,
+                        inner_dereference: false,
                     },
                 },
                 Reference {
@@ -436,6 +438,7 @@ mod tests {
                         offset2: 0,
                         immediate: None,
                         dereference: true,
+                        inner_dereference: false,
                     },
                 },
                 Reference {
@@ -450,6 +453,7 @@ mod tests {
                         offset2: 0,
                         immediate: Some(bigint!(2)),
                         dereference: false,
+                        inner_dereference: false,
                     },
                 },
                 Reference {
@@ -464,6 +468,7 @@ mod tests {
                         offset2: 0,
                         immediate: None,
                         dereference: true,
+                        inner_dereference: false,
                     },
                 },
             ],

--- a/src/serde/deserialize_utils.rs
+++ b/src/serde/deserialize_utils.rs
@@ -100,7 +100,7 @@ fn parse_dereference_with_one_offset(
     };
     deref.offset1 = offset1;
 
-    if splitted_value_str.contains(&"([") {
+    if splitted_value_str[0].contains(&"([") {
         deref.inner_dereference = true;
         return Ok(deref);
     }

--- a/src/serde/deserialize_utils.rs
+++ b/src/serde/deserialize_utils.rs
@@ -77,6 +77,7 @@ fn parse_dereference_no_offsets(
         offset2: 0,
         immediate: None,
         dereference: true,
+        inner_dereference: false,
     })
 }
 
@@ -99,6 +100,11 @@ fn parse_dereference_with_one_offset(
     };
     deref.offset1 = offset1;
 
+    if splitted_value_str.contains(&"([") {
+        deref.inner_dereference = true;
+        return Ok(deref);
+    }
+
     Ok(deref)
 }
 
@@ -120,6 +126,7 @@ fn parse_dereference_with_two_offsets(
         },
     };
     deref.offset2 = offset2;
+    deref.inner_dereference = true;
 
     Ok(deref)
 }
@@ -146,6 +153,7 @@ fn parse_reference_no_offsets(
         offset2: 0,
         immediate: None,
         dereference: false,
+        inner_dereference: false,
     })
 }
 
@@ -207,6 +215,7 @@ mod tests {
             offset2: 0,
             immediate: None,
             dereference: true,
+            inner_dereference: false,
         };
 
         assert_eq!(value_address, parsed_value);
@@ -225,6 +234,7 @@ mod tests {
             offset2: 1,
             immediate: None,
             dereference: true,
+            inner_dereference: true,
         };
 
         assert_eq!(value_address, parsed_value);
@@ -243,6 +253,7 @@ mod tests {
             offset2: 0,
             immediate: None,
             dereference: true,
+            inner_dereference: false,
         };
 
         assert_eq!(value_address, parsed_value);
@@ -261,6 +272,7 @@ mod tests {
             offset2: 0,
             immediate: None,
             dereference: false,
+            inner_dereference: false,
         };
 
         assert_eq!(value_address, parsed_value);
@@ -279,6 +291,7 @@ mod tests {
             offset2: 0,
             immediate: Some(bigint!(1)),
             dereference: false,
+            inner_dereference: false,
         };
 
         assert_eq!(value_address, parsed_value);
@@ -297,6 +310,7 @@ mod tests {
             offset2: 0,
             immediate: None,
             dereference: false,
+            inner_dereference: false,
         };
 
         assert_eq!(value_address, parsed_value);

--- a/src/serde/deserialize_utils.rs
+++ b/src/serde/deserialize_utils.rs
@@ -222,6 +222,25 @@ mod tests {
     }
 
     #[test]
+    fn parse_dereference_with_one_offset_and_inner_dereference_test() {
+        let value_string: &str = "[cast([fp + (-3)], felt*)]";
+        let splitted_value: Vec<&str> = value_string.split(" + ").collect();
+
+        let parsed_value = parse_dereference_with_one_offset(&splitted_value).unwrap();
+
+        let value_address = ValueAddress {
+            register: Some(Register::FP),
+            offset1: -3,
+            offset2: 0,
+            immediate: None,
+            dereference: true,
+            inner_dereference: true,
+        };
+
+        assert_eq!(value_address, parsed_value);
+    }
+
+    #[test]
     fn parse_dereference_with_two_offsets_test() {
         let value_string: &str = "[cast([fp + (-4)] + 1, felt*)]";
         let splitted_value: Vec<&str> = value_string.split(" + ").collect();

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -15,6 +15,7 @@ pub struct HintReference {
     pub register: Register,
     pub offset1: i32,
     pub offset2: i32,
+    pub inner_dereference: bool,
 }
 
 pub fn execute_hint(
@@ -188,6 +189,7 @@ mod tests {
                 register: Register::FP,
                 offset1: -1,
                 offset2: 0,
+                inner_dereference: false,
             },
         )]);
         //Execute the hint
@@ -233,6 +235,7 @@ mod tests {
                 register: Register::FP,
                 offset1: -1,
                 offset2: 0,
+                inner_dereference: false,
             },
         )]);
         //Execute the hint
@@ -283,6 +286,7 @@ mod tests {
                 register: Register::FP,
                 offset1: -1,
                 offset2: 0,
+                inner_dereference: false,
             },
         )]);
         //Execute the hint
@@ -338,6 +342,7 @@ mod tests {
                 register: Register::FP,
                 offset1: -1,
                 offset2: 0,
+                inner_dereference: false,
             },
         )]);
         //Execute the hint
@@ -404,6 +409,7 @@ mod tests {
                 register: Register::FP,
                 offset1: -1,
                 offset2: 0,
+                inner_dereference: false,
             },
         )]);
         //Execute the hint
@@ -449,6 +455,7 @@ mod tests {
                 register: Register::FP,
                 offset1: -1,
                 offset2: 0,
+                inner_dereference: false,
             },
         )]);
         //Execute the hint
@@ -511,6 +518,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -4,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -519,6 +527,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -3,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -527,6 +536,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -2,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
         ]);
@@ -809,6 +819,7 @@ mod tests {
                 register: Register::FP,
                 offset1: -4,
                 offset2: 0,
+                inner_dereference: false,
             },
         )]);
         //Execute the hint
@@ -850,6 +861,7 @@ mod tests {
                 register: Register::FP,
                 offset1: -4,
                 offset2: 0,
+                inner_dereference: false,
             },
         )]);
         //Execute the hint
@@ -893,6 +905,7 @@ mod tests {
                 register: Register::FP,
                 offset1: -4,
                 offset2: 0,
+                inner_dereference: false,
             },
         )]);
         //Execute the hint
@@ -939,6 +952,7 @@ mod tests {
                 register: Register::FP,
                 offset1: 10,
                 offset2: 0,
+                inner_dereference: false,
             },
         )]);
         //Execute the hint
@@ -982,6 +996,7 @@ mod tests {
                 register: Register::FP,
                 offset1: -4,
                 offset2: 0,
+                inner_dereference: false,
             },
         )]);
         //Execute the hint
@@ -1024,6 +1039,7 @@ mod tests {
                 register: Register::FP,
                 offset1: -4,
                 offset2: 0,
+                inner_dereference: false,
             },
         )]);
         //Execute the hint
@@ -1059,6 +1075,7 @@ mod tests {
                 register: Register::FP,
                 offset1: -4,
                 offset2: 0,
+                inner_dereference: false,
             },
         )]);
         //Execute the hint
@@ -1119,6 +1136,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -4,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -1127,6 +1145,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -3,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -1135,6 +1154,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -2,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
         ]);
@@ -1196,6 +1216,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -4,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -1204,6 +1225,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -3,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -1212,6 +1234,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -2,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
         ]);
@@ -1273,6 +1296,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -4,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -1281,6 +1305,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -3,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -1289,6 +1314,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -2,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
         ]);
@@ -1352,6 +1378,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -4,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -1360,6 +1387,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -3,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -1368,6 +1396,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -2,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
         ]);
@@ -1415,6 +1444,7 @@ mod tests {
                 register: Register::FP,
                 offset1: -1,
                 offset2: 0,
+                inner_dereference: false,
             },
         )]);
         //Execute the hint
@@ -1460,6 +1490,7 @@ mod tests {
                 register: Register::FP,
                 offset1: -1,
                 offset2: 0,
+                inner_dereference: false,
             },
         )]);
         //Execute the hint
@@ -1508,6 +1539,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -2,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -1516,6 +1548,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -1,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
         ]);
@@ -1568,6 +1601,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -2,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -1576,6 +1610,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -1,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
         ]);
@@ -1626,6 +1661,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -2,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -1634,6 +1670,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -1,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
         ]);
@@ -1688,6 +1725,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -2,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -1696,6 +1734,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -1,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
         ]);
@@ -1748,6 +1787,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -2,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -1756,6 +1796,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -1,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
         ]);
@@ -1802,6 +1843,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -2,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -1810,6 +1852,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -1,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
         ]);
@@ -1862,6 +1905,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -2,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -1870,6 +1914,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -1,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
         ]);
@@ -1898,6 +1943,7 @@ mod tests {
                 register: Register::FP,
                 offset1: -1,
                 offset2: 0,
+                inner_dereference: false,
             },
         )]);
         vm.segments.add(&mut vm.memory, None);
@@ -1934,6 +1980,7 @@ mod tests {
                 register: Register::FP,
                 offset1: -1,
                 offset2: 0,
+                inner_dereference: false,
             },
         )]);
         vm.segments.add(&mut vm.memory, None);
@@ -1973,6 +2020,7 @@ mod tests {
                 register: Register::FP,
                 offset1: -1,
                 offset2: 0,
+                inner_dereference: false,
             },
         )]);
         vm.segments.add(&mut vm.memory, None);
@@ -2015,6 +2063,7 @@ mod tests {
                 register: Register::FP,
                 offset1: -1,
                 offset2: 0,
+                inner_dereference: false,
             },
         )]);
         vm.segments.add(&mut vm.memory, None);
@@ -2054,6 +2103,7 @@ mod tests {
                 register: Register::FP,
                 offset1: -1,
                 offset2: 0,
+                inner_dereference: false,
             },
         )]);
         vm.segments.add(&mut vm.memory, None);
@@ -2095,6 +2145,7 @@ mod tests {
                 register: Register::FP,
                 offset1: -1,
                 offset2: 0,
+                inner_dereference: false,
             },
         )]);
         vm.segments.add(&mut vm.memory, None);
@@ -2151,6 +2202,7 @@ mod tests {
                 register: Register::FP,
                 offset1: -1,
                 offset2: 0,
+                inner_dereference: false,
             },
         )]);
         //Execute the hint
@@ -2190,6 +2242,7 @@ mod tests {
                 register: Register::FP,
                 offset1: -1,
                 offset2: 0,
+                inner_dereference: false,
             },
         )]);
         //Execute the hint
@@ -2252,6 +2305,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -4,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -2260,6 +2314,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -3,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -2268,6 +2323,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -2,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -2276,6 +2332,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -1,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
         ]);
@@ -2343,6 +2400,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -4,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -2351,6 +2409,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -3,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -2359,6 +2418,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -2,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -2367,6 +2427,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -1,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
         ]);
@@ -2414,6 +2475,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -2,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -2422,6 +2484,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -1,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
         ]);
@@ -2471,6 +2534,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -2,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -2479,6 +2543,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -1,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
         ]);
@@ -2531,6 +2596,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -2,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -2539,6 +2605,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -1,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
         ]);
@@ -2594,6 +2661,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -2,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -2602,6 +2670,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -1,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
         ]);

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -588,6 +588,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -2,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -596,6 +597,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -1,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
         ]);
@@ -642,6 +644,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -2,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -650,6 +653,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -1,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
         ]);
@@ -702,6 +706,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -2,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -710,6 +715,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -1,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
         ]);
@@ -765,6 +771,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -2,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -773,6 +780,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -1,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
         ]);
@@ -2719,6 +2727,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -2,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -2727,6 +2736,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -1,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
         ]);
@@ -2771,6 +2781,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -2,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -2779,6 +2790,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -1,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
         ]);
@@ -2830,6 +2842,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -2,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
             (
@@ -2838,6 +2851,7 @@ mod tests {
                     register: Register::FP,
                     offset1: -1,
                     offset2: 0,
+                    inner_dereference: false,
                 },
             ),
         ]);

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -41,19 +41,18 @@ fn compute_addr_from_reference(
                 relocatable.segment_index,
                 (relocatable.offset as i32 + hint_reference.offset1) as usize,
             ));
-            if let MaybeRelocatable::RelocatableValue(dereferenced_addr) =
-                vm.memory.get(&addr).unwrap()?
-            {
-                return Some(MaybeRelocatable::from((
-                    dereferenced_addr.segment_index,
-                    (dereferenced_addr.offset as i32 + hint_reference.offset2) as usize,
-                )));
+
+            match vm.memory.get(&addr) {
+                Ok(Some(&MaybeRelocatable::RelocatableValue(ref dereferenced_addr))) => {
+                    return Some(MaybeRelocatable::from((
+                        dereferenced_addr.segment_index,
+                        (dereferenced_addr.offset as i32 + hint_reference.offset2) as usize,
+                    )))
+                }
+
+                _none_or_error => return None,
             }
         }
-        // return Some(MaybeRelocatable::from((
-        //     relocatable.segment_index,
-        //     (relocatable.offset as i32 + hint_reference.offset1 + hint_reference.offset2) as usize,
-        // )));
     }
 
     None

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -402,8 +402,8 @@ pub fn assert_not_equal(
     };
     //Check that each reference id corresponds to a value in the reference manager
     let (a_addr, b_addr) = if let (Some(a_addr), Some(b_addr)) = (
-        get_address_from_reference(a_ref, &vm.references, &vm.run_context),
-        get_address_from_reference(b_ref, &vm.references, &vm.run_context),
+        get_address_from_reference(a_ref, &vm.references, &vm.run_context, vm),
+        get_address_from_reference(b_ref, &vm.references, &vm.run_context, vm),
     ) {
         (a_addr, b_addr)
     } else {
@@ -762,8 +762,8 @@ pub fn sqrt(
     };
     //Check that each reference id corresponds to a value in the reference manager
     let (value_addr, root_addr) = if let (Some(value_addr), Some(root_addr)) = (
-        get_address_from_reference(value_ref, &vm.references, &vm.run_context),
-        get_address_from_reference(root_ref, &vm.references, &vm.run_context),
+        get_address_from_reference(value_ref, &vm.references, &vm.run_context, vm),
+        get_address_from_reference(root_ref, &vm.references, &vm.run_context, vm),
     ) {
         (value_addr, root_addr)
     } else {

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -101,7 +101,7 @@ pub fn is_nn(
     };
     //Check that each reference id corresponds to a value in the reference manager
     let a_addr = if let Some(a_addr) =
-        get_address_from_reference(a_ref, &vm.references, &vm.run_context, &vm)
+        get_address_from_reference(a_ref, &vm.references, &vm.run_context, vm)
     {
         a_addr
     } else {
@@ -166,7 +166,7 @@ pub fn is_nn_out_of_range(
     };
     //Check that each reference id corresponds to a value in the reference manager
     let a_addr = if let Some(a_addr) =
-        get_address_from_reference(a_ref, &vm.references, &vm.run_context, &vm)
+        get_address_from_reference(a_ref, &vm.references, &vm.run_context, vm)
     {
         a_addr
     } else {
@@ -248,9 +248,9 @@ pub fn assert_le_felt(
     //Check that each reference id corresponds to a value in the reference manager
     let (a_addr, b_addr, small_inputs_addr) =
         if let (Some(a_addr), Some(b_addr), Some(small_inputs_addr)) = (
-            get_address_from_reference(a_ref, &vm.references, &vm.run_context, &vm),
-            get_address_from_reference(b_ref, &vm.references, &vm.run_context, &vm),
-            get_address_from_reference(small_inputs_ref, &vm.references, &vm.run_context, &vm),
+            get_address_from_reference(a_ref, &vm.references, &vm.run_context, vm),
+            get_address_from_reference(b_ref, &vm.references, &vm.run_context, vm),
+            get_address_from_reference(small_inputs_ref, &vm.references, &vm.run_context, vm),
         ) {
             (a_addr, b_addr, small_inputs_addr)
         } else {
@@ -329,8 +329,8 @@ pub fn is_le_felt(
     };
     //Check that each reference id corresponds to a value in the reference manager
     let (a_addr, b_addr) = if let (Some(a_addr), Some(b_addr)) = (
-        get_address_from_reference(a_ref, &vm.references, &vm.run_context, &vm),
-        get_address_from_reference(b_ref, &vm.references, &vm.run_context, &vm),
+        get_address_from_reference(a_ref, &vm.references, &vm.run_context, vm),
+        get_address_from_reference(b_ref, &vm.references, &vm.run_context, vm),
     ) {
         (a_addr, b_addr)
     } else {
@@ -463,7 +463,7 @@ pub fn assert_nn(
     };
     //Check that 'a' reference id corresponds to a value in the reference manager
     let a_addr = if let Some(a_addr) =
-        get_address_from_reference(a_ref, &vm.references, &vm.run_context, &vm)
+        get_address_from_reference(a_ref, &vm.references, &vm.run_context, vm)
     {
         a_addr
     } else {
@@ -526,7 +526,7 @@ pub fn assert_not_zero(
     };
     //Check that each reference id corresponds to a value in the reference manager
     let value_addr = if let Some(value_addr) =
-        get_address_from_reference(value_ref, &vm.references, &vm.run_context, &vm)
+        get_address_from_reference(value_ref, &vm.references, &vm.run_context, vm)
     {
         value_addr
     } else {
@@ -568,7 +568,7 @@ pub fn split_int_assert_range(
     };
     //Check that each reference id corresponds to a value in the reference manager
     let value_addr = if let Some(value_addr) =
-        get_address_from_reference(value_ref, &vm.references, &vm.run_context, &vm)
+        get_address_from_reference(value_ref, &vm.references, &vm.run_context, vm)
     {
         value_addr
     } else {
@@ -623,10 +623,10 @@ pub fn split_int(
     //Check that each reference id corresponds to a value in the reference manager
     let (output_addr, value_addr, base_addr, bound_addr) =
         if let (Some(output_addr), Some(value_addr), Some(base_addr), Some(bound_addr)) = (
-            get_address_from_reference(output_ref, &vm.references, &vm.run_context, &vm),
-            get_address_from_reference(value_ref, &vm.references, &vm.run_context, &vm),
-            get_address_from_reference(base_ref, &vm.references, &vm.run_context, &vm),
-            get_address_from_reference(bound_ref, &vm.references, &vm.run_context, &vm),
+            get_address_from_reference(output_ref, &vm.references, &vm.run_context, vm),
+            get_address_from_reference(value_ref, &vm.references, &vm.run_context, vm),
+            get_address_from_reference(base_ref, &vm.references, &vm.run_context, vm),
+            get_address_from_reference(bound_ref, &vm.references, &vm.run_context, vm),
         ) {
             (output_addr, value_addr, base_addr, bound_addr)
         } else {
@@ -688,8 +688,8 @@ pub fn is_positive(
     };
     //Check that each reference id corresponds to a value in the reference manager
     let (value_addr, is_positive_addr) = if let (Some(value_addr), Some(is_positive_addr)) = (
-        get_address_from_reference(value_ref, &vm.references, &vm.run_context, &vm),
-        get_address_from_reference(is_positive_ref, &vm.references, &vm.run_context, &vm),
+        get_address_from_reference(value_ref, &vm.references, &vm.run_context, vm),
+        get_address_from_reference(is_positive_ref, &vm.references, &vm.run_context, vm),
     ) {
         (value_addr, is_positive_addr)
     } else {

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -17,6 +17,7 @@ use std::ops::Shr;
 fn compute_addr_from_reference(
     hint_reference: &HintReference,
     run_context: &RunContext,
+    vm: &VirtualMachine,
 ) -> Option<MaybeRelocatable> {
     let register = match hint_reference.register {
         Register::FP => run_context.fp.clone(),
@@ -29,10 +30,30 @@ fn compute_addr_from_reference(
         {
             return None;
         }
-        return Some(MaybeRelocatable::from((
-            relocatable.segment_index,
-            (relocatable.offset as i32 + hint_reference.offset1 + hint_reference.offset2) as usize,
-        )));
+        if !hint_reference.inner_dereference {
+            return Some(MaybeRelocatable::from((
+                relocatable.segment_index,
+                (relocatable.offset as i32 + hint_reference.offset1 + hint_reference.offset2)
+                    as usize,
+            )));
+        } else {
+            let addr = MaybeRelocatable::from((
+                relocatable.segment_index,
+                (relocatable.offset as i32 + hint_reference.offset1) as usize,
+            ));
+            if let MaybeRelocatable::RelocatableValue(dereferenced_addr) =
+                vm.memory.get(&addr).unwrap()?
+            {
+                return Some(MaybeRelocatable::from((
+                    dereferenced_addr.segment_index,
+                    (dereferenced_addr.offset as i32 + hint_reference.offset2) as usize,
+                )));
+            }
+        }
+        // return Some(MaybeRelocatable::from((
+        //     relocatable.segment_index,
+        //     (relocatable.offset as i32 + hint_reference.offset1 + hint_reference.offset2) as usize,
+        // )));
     }
 
     None
@@ -43,11 +64,12 @@ fn get_address_from_reference(
     reference_id: &BigInt,
     references: &HashMap<usize, HintReference>,
     run_context: &RunContext,
+    vm: &VirtualMachine,
 ) -> Option<MaybeRelocatable> {
     if let Some(index) = reference_id.to_usize() {
         if index < references.len() {
             if let Some(hint_reference) = references.get(&index) {
-                return compute_addr_from_reference(hint_reference, run_context);
+                return compute_addr_from_reference(hint_reference, run_context, vm);
             }
         }
     }
@@ -79,12 +101,13 @@ pub fn is_nn(
         ));
     };
     //Check that each reference id corresponds to a value in the reference manager
-    let a_addr =
-        if let Some(a_addr) = get_address_from_reference(a_ref, &vm.references, &vm.run_context) {
-            a_addr
-        } else {
-            return Err(VirtualMachineError::FailedToGetReference(a_ref.clone()));
-        };
+    let a_addr = if let Some(a_addr) =
+        get_address_from_reference(a_ref, &vm.references, &vm.run_context, &vm)
+    {
+        a_addr
+    } else {
+        return Err(VirtualMachineError::FailedToGetReference(a_ref.clone()));
+    };
 
     //Check that the ids are in memory
     match vm.memory.get(&a_addr) {
@@ -143,12 +166,13 @@ pub fn is_nn_out_of_range(
         ));
     };
     //Check that each reference id corresponds to a value in the reference manager
-    let a_addr =
-        if let Some(a_addr) = get_address_from_reference(a_ref, &vm.references, &vm.run_context) {
-            a_addr
-        } else {
-            return Err(VirtualMachineError::FailedToGetReference(a_ref.clone()));
-        };
+    let a_addr = if let Some(a_addr) =
+        get_address_from_reference(a_ref, &vm.references, &vm.run_context, &vm)
+    {
+        a_addr
+    } else {
+        return Err(VirtualMachineError::FailedToGetReference(a_ref.clone()));
+    };
     //Check that the ids are in memory
     match vm.memory.get(&a_addr) {
         Ok(Some(maybe_rel_a)) => {
@@ -225,9 +249,9 @@ pub fn assert_le_felt(
     //Check that each reference id corresponds to a value in the reference manager
     let (a_addr, b_addr, small_inputs_addr) =
         if let (Some(a_addr), Some(b_addr), Some(small_inputs_addr)) = (
-            get_address_from_reference(a_ref, &vm.references, &vm.run_context),
-            get_address_from_reference(b_ref, &vm.references, &vm.run_context),
-            get_address_from_reference(small_inputs_ref, &vm.references, &vm.run_context),
+            get_address_from_reference(a_ref, &vm.references, &vm.run_context, &vm),
+            get_address_from_reference(b_ref, &vm.references, &vm.run_context, &vm),
+            get_address_from_reference(small_inputs_ref, &vm.references, &vm.run_context, &vm),
         ) {
             (a_addr, b_addr, small_inputs_addr)
         } else {
@@ -306,8 +330,8 @@ pub fn is_le_felt(
     };
     //Check that each reference id corresponds to a value in the reference manager
     let (a_addr, b_addr) = if let (Some(a_addr), Some(b_addr)) = (
-        get_address_from_reference(a_ref, &vm.references, &vm.run_context),
-        get_address_from_reference(b_ref, &vm.references, &vm.run_context),
+        get_address_from_reference(a_ref, &vm.references, &vm.run_context, &vm),
+        get_address_from_reference(b_ref, &vm.references, &vm.run_context, &vm),
     ) {
         (a_addr, b_addr)
     } else {
@@ -439,12 +463,13 @@ pub fn assert_nn(
         ));
     };
     //Check that 'a' reference id corresponds to a value in the reference manager
-    let a_addr =
-        if let Some(a_addr) = get_address_from_reference(a_ref, &vm.references, &vm.run_context) {
-            a_addr
-        } else {
-            return Err(VirtualMachineError::FailedToGetIds);
-        };
+    let a_addr = if let Some(a_addr) =
+        get_address_from_reference(a_ref, &vm.references, &vm.run_context, &vm)
+    {
+        a_addr
+    } else {
+        return Err(VirtualMachineError::FailedToGetIds);
+    };
 
     //Check that the 'a' id is in memory
     let maybe_rel_a = if let Ok(Some(maybe_rel_a)) = vm.memory.get(&a_addr) {
@@ -502,7 +527,7 @@ pub fn assert_not_zero(
     };
     //Check that each reference id corresponds to a value in the reference manager
     let value_addr = if let Some(value_addr) =
-        get_address_from_reference(value_ref, &vm.references, &vm.run_context)
+        get_address_from_reference(value_ref, &vm.references, &vm.run_context, &vm)
     {
         value_addr
     } else {
@@ -544,7 +569,7 @@ pub fn split_int_assert_range(
     };
     //Check that each reference id corresponds to a value in the reference manager
     let value_addr = if let Some(value_addr) =
-        get_address_from_reference(value_ref, &vm.references, &vm.run_context)
+        get_address_from_reference(value_ref, &vm.references, &vm.run_context, &vm)
     {
         value_addr
     } else {
@@ -599,10 +624,10 @@ pub fn split_int(
     //Check that each reference id corresponds to a value in the reference manager
     let (output_addr, value_addr, base_addr, bound_addr) =
         if let (Some(output_addr), Some(value_addr), Some(base_addr), Some(bound_addr)) = (
-            get_address_from_reference(output_ref, &vm.references, &vm.run_context),
-            get_address_from_reference(value_ref, &vm.references, &vm.run_context),
-            get_address_from_reference(base_ref, &vm.references, &vm.run_context),
-            get_address_from_reference(bound_ref, &vm.references, &vm.run_context),
+            get_address_from_reference(output_ref, &vm.references, &vm.run_context, &vm),
+            get_address_from_reference(value_ref, &vm.references, &vm.run_context, &vm),
+            get_address_from_reference(base_ref, &vm.references, &vm.run_context, &vm),
+            get_address_from_reference(bound_ref, &vm.references, &vm.run_context, &vm),
         ) {
             (output_addr, value_addr, base_addr, bound_addr)
         } else {
@@ -664,8 +689,8 @@ pub fn is_positive(
     };
     //Check that each reference id corresponds to a value in the reference manager
     let (value_addr, is_positive_addr) = if let (Some(value_addr), Some(is_positive_addr)) = (
-        get_address_from_reference(value_ref, &vm.references, &vm.run_context),
-        get_address_from_reference(is_positive_ref, &vm.references, &vm.run_context),
+        get_address_from_reference(value_ref, &vm.references, &vm.run_context, &vm),
+        get_address_from_reference(is_positive_ref, &vm.references, &vm.run_context, &vm),
     ) {
         (value_addr, is_positive_addr)
     } else {

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -234,6 +234,7 @@ impl CairoRunner {
                         register: register.clone(),
                         offset1: reference.value_address.offset1,
                         offset2: reference.value_address.offset2,
+                        inner_dereference: reference.value_address.inner_dereference,
                     },
                 );
             }


### PR DESCRIPTION
# Fix references deserialization bug

## Description
There was a case in the references deserialization that was not being contemplated, values in the format:

`[cast([reg + offset1], felt*)]`

For this fix, another field was added to the `ValueAddress` and `HintReference` structs: inner_dereference. The logic in the function `compute_addr_from_reference` was also modified to support the fix.

Currently, the `vm` struct is being passed as an argument to `get_address_from_reference` and `compute_addr_from_reference`. This makes the other arguments redundant, because `references` and `run_context` could be obtained directly from the `vm` argument, but I think this could be solved later.


## Checklist
- [x] Unit tests added
