### PR TITLE
Ignore artifacts, except manually compiled programs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 **/target
 **/.DS_Store
-/flamegraph.svg
+**/*.svg
+**/*.json
+!cairo_programs/manually_compiled/*.json
+**/*.trace
+**/*.memory
+**/*.swp
+bench/results


### PR DESCRIPTION
# More thoroughly ignore artifacts

## Description

After running tests, benchmarks and generating flamegraphs or during edition with Vim we would observe (often many) irrelevant files polluting our `git status` output.
I added more aggressive filters to `.gitignore`, essentially ignoring all traces, flamegraph files and compiled cairo programs, with the exception of manually compiled ones we need in our repo.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
- [ ] Documentation has been added/updated.
