### PR TITLE
Conditionally save accessed addresses

### DIFF
--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -50,7 +50,8 @@ pub struct VirtualMachine {
     pub _program_base: Option<MaybeRelocatable>,
     pub memory: Memory,
     //auto_deduction: HashMap<BigInt, Vec<(Rule, ())>>,
-    accessed_addresses: HashSet<MaybeRelocatable>,
+    //Some(accessed_addresses) == proof mode enabled
+    accessed_addresses: Option<HashSet<MaybeRelocatable>>,
     pub trace: Vec<TraceEntry>,
     current_step: usize,
     skip_instruction_execution: bool,
@@ -82,7 +83,7 @@ impl VirtualMachine {
             references: HashMap::<usize, HintReference>::new(),
             _program_base: None,
             memory: Memory::new(),
-            accessed_addresses: HashSet::<MaybeRelocatable>::new(),
+            accessed_addresses: None,
             trace: Vec::<TraceEntry>::new(),
             current_step: 0,
             skip_instruction_execution: false,
@@ -417,9 +418,10 @@ impl VirtualMachine {
             ap: self.run_context.ap.clone(),
             fp: self.run_context.fp.clone(),
         });
-        self.accessed_addresses
-            .extend(operands_mem_addresses.iter().map(Clone::clone));
-        self.accessed_addresses.insert(self.run_context.pc.clone());
+        if let Some(ref mut accessed_addresses) = self.accessed_addresses {
+            accessed_addresses.extend(operands_mem_addresses.iter().map(Clone::clone));
+            accessed_addresses.insert(self.run_context.pc.clone());
+        }
 
         self.update_registers(instruction, operands)?;
         self.current_step += 1;
@@ -569,15 +571,22 @@ impl VirtualMachine {
         }
 
         match (dst, op0, op1) {
-            (Some(unwrapped_dst), Some(unwrapped_op0), Some(unwrapped_op1)) => Ok((
-                Operands {
-                    dst: unwrapped_dst,
-                    op0: unwrapped_op0,
-                    op1: unwrapped_op1,
-                    res,
-                },
-                [dst_addr, op0_addr, op1_addr].to_vec(),
-            )),
+            (Some(unwrapped_dst), Some(unwrapped_op0), Some(unwrapped_op1)) => {
+                let accessed_addresses = if self.accessed_addresses.is_some() {
+                    vec![dst_addr, op0_addr, op1_addr]
+                } else {
+                    vec![]
+                };
+                Ok((
+                    Operands {
+                        dst: unwrapped_dst,
+                        op0: unwrapped_op0,
+                        op1: unwrapped_op1,
+                        res,
+                    },
+                    accessed_addresses,
+                ))
+            }
             _ => Err(VirtualMachineError::InvalidInstructionEncoding),
         }
     }
@@ -2060,6 +2069,7 @@ mod tests {
         };
 
         let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
+        vm.accessed_addresses = Some(HashSet::new());
         vm.memory.data.push(Vec::new());
         let dst_addr = MaybeRelocatable::from((0, 0));
         let dst_addr_value = MaybeRelocatable::Int(bigint!(5));
@@ -2102,6 +2112,7 @@ mod tests {
             opcode: Opcode::NOp,
         };
         let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
+        vm.accessed_addresses = Some(HashSet::new());
         vm.memory.data.push(Vec::new());
         let dst_addr = MaybeRelocatable::from((0, 0));
         let dst_addr_value = MaybeRelocatable::from(bigint!(6));
@@ -2156,6 +2167,7 @@ mod tests {
         ];
 
         let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
+        vm.accessed_addresses = Some(HashSet::new());
         vm.memory = memory_from(mem_arr.clone(), 2).unwrap();
 
         let expected_operands = Operands {
@@ -2369,7 +2381,7 @@ mod tests {
             hints: HashMap::<MaybeRelocatable, Vec<HintData>>::new(),
             references: HashMap::<usize, HintReference>::new(),
             memory: Memory::new(),
-            accessed_addresses: HashSet::<MaybeRelocatable>::new(),
+            accessed_addresses: Some(HashSet::<MaybeRelocatable>::new()),
             trace: Vec::<TraceEntry>::new(),
             current_step: 1,
             skip_instruction_execution: false,
@@ -2409,6 +2421,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
         );
+        vm.accessed_addresses = Some(HashSet::new());
         for _ in 0..4 {
             vm.memory.data.push(Vec::new());
         }
@@ -2445,15 +2458,10 @@ mod tests {
         assert_eq!(vm.run_context.pc, MaybeRelocatable::from((3, 0)));
         assert_eq!(vm.run_context.ap, MaybeRelocatable::from((1, 2)));
         assert_eq!(vm.run_context.fp, MaybeRelocatable::from((2, 0)));
-        assert!(vm
-            .accessed_addresses
-            .contains(&MaybeRelocatable::from((1, 0))));
-        assert!(vm
-            .accessed_addresses
-            .contains(&MaybeRelocatable::from((1, 1))));
-        assert!(vm
-            .accessed_addresses
-            .contains(&MaybeRelocatable::from((0, 0))));
+        let accessed_addresses = vm.accessed_addresses.as_ref().unwrap();
+        assert!(accessed_addresses.contains(&MaybeRelocatable::from((1, 0))));
+        assert!(accessed_addresses.contains(&MaybeRelocatable::from((1, 1))));
+        assert!(accessed_addresses.contains(&MaybeRelocatable::from((0, 0))));
     }
 
     #[test]
@@ -2492,6 +2500,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
         );
+        vm.accessed_addresses = Some(HashSet::new());
         for _ in 0..4 {
             vm.memory.data.push(Vec::new());
         }
@@ -2622,51 +2631,23 @@ mod tests {
         //Check accessed_addresses
         //Order will differ from python vm execution, (due to python version using set's update() method)
         //We will instead check that all elements are contained and not duplicated
-        assert_eq!(vm.accessed_addresses.len(), 14);
-        assert_eq!(vm.accessed_addresses.len(), 14);
+        let accessed_addresses = vm.accessed_addresses.as_ref().unwrap();
+        assert_eq!(accessed_addresses.len(), 14);
         //Check each element individually
-        assert!(vm
-            .accessed_addresses
-            .contains(&MaybeRelocatable::from((0, 1))));
-        assert!(vm
-            .accessed_addresses
-            .contains(&MaybeRelocatable::from((0, 7))));
-        assert!(vm
-            .accessed_addresses
-            .contains(&MaybeRelocatable::from((1, 2))));
-        assert!(vm
-            .accessed_addresses
-            .contains(&MaybeRelocatable::from((0, 4))));
-        assert!(vm
-            .accessed_addresses
-            .contains(&MaybeRelocatable::from((0, 0))));
-        assert!(vm
-            .accessed_addresses
-            .contains(&MaybeRelocatable::from((1, 5))));
-        assert!(vm
-            .accessed_addresses
-            .contains(&MaybeRelocatable::from((1, 1))));
-        assert!(vm
-            .accessed_addresses
-            .contains(&MaybeRelocatable::from((0, 3))));
-        assert!(vm
-            .accessed_addresses
-            .contains(&MaybeRelocatable::from((1, 4))));
-        assert!(vm
-            .accessed_addresses
-            .contains(&MaybeRelocatable::from((0, 6))));
-        assert!(vm
-            .accessed_addresses
-            .contains(&MaybeRelocatable::from((0, 2))));
-        assert!(vm
-            .accessed_addresses
-            .contains(&MaybeRelocatable::from((0, 5))));
-        assert!(vm
-            .accessed_addresses
-            .contains(&MaybeRelocatable::from((1, 0))));
-        assert!(vm
-            .accessed_addresses
-            .contains(&MaybeRelocatable::from((1, 3))));
+        assert!(accessed_addresses.contains(&MaybeRelocatable::from((0, 1))));
+        assert!(accessed_addresses.contains(&MaybeRelocatable::from((0, 7))));
+        assert!(accessed_addresses.contains(&MaybeRelocatable::from((1, 2))));
+        assert!(accessed_addresses.contains(&MaybeRelocatable::from((0, 4))));
+        assert!(accessed_addresses.contains(&MaybeRelocatable::from((0, 0))));
+        assert!(accessed_addresses.contains(&MaybeRelocatable::from((1, 5))));
+        assert!(accessed_addresses.contains(&MaybeRelocatable::from((1, 1))));
+        assert!(accessed_addresses.contains(&MaybeRelocatable::from((0, 3))));
+        assert!(accessed_addresses.contains(&MaybeRelocatable::from((1, 4))));
+        assert!(accessed_addresses.contains(&MaybeRelocatable::from((0, 6))));
+        assert!(accessed_addresses.contains(&MaybeRelocatable::from((0, 2))));
+        assert!(accessed_addresses.contains(&MaybeRelocatable::from((0, 5))));
+        assert!(accessed_addresses.contains(&MaybeRelocatable::from((1, 0))));
+        assert!(accessed_addresses.contains(&MaybeRelocatable::from((1, 3))));
     }
 
     #[test]
@@ -2869,6 +2850,7 @@ mod tests {
         let mut builtin = HashBuiltinRunner::new(true, 8);
         builtin.base = Some(relocatable!(3, 0));
         let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
+        vm.accessed_addresses = Some(HashSet::new());
         vm.builtin_runners
             .push((String::from("pedersen"), Box::new(builtin)));
         vm.run_context.ap = MaybeRelocatable::from((1, 13));
@@ -3065,6 +3047,7 @@ mod tests {
         let mut builtin = BitwiseBuiltinRunner::new(true, 256);
         builtin.base = Some(relocatable!(2, 0));
         let mut vm = VirtualMachine::new(bigint!(127), Vec::new());
+        vm.accessed_addresses = Some(HashSet::new());
         vm.builtin_runners
             .push((String::from("bitwise"), Box::new(builtin)));
         vm.run_context.ap = MaybeRelocatable::from((1, 9));


### PR DESCRIPTION
# Avoid many `HashSet` operations

## Description

Updating the accessed_addresses set is taking significant time from
benchmarks, between 15% and 25%.
This is only used for proof mode which, while an important use case, is
not always on and currently not supported.
The patch conditions whether we produce the addresses and update the set
to existence of the set in the VirtualMachine instance, using itself as
flag.
Because the feature is not yet implemented, the constructor just sets it
to None for simplicity, with tests explicitly overriding this value.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
