### PR TITLE
Add support for execution scopes management

### DIFF
--- a/src/types/exec_scope.rs
+++ b/src/types/exec_scope.rs
@@ -99,14 +99,20 @@ mod tests {
 
         let mut scopes = ExecutionScopes {
             exec_scopes: vec![HashMap::from([(
-                String::from("a"),
+                String::from("b"),
                 PyValueType::BigInt(bigint!(1)),
             )])],
         };
 
-        assert_eq!(scopes.get_local_variables().unwrap(), &HashMap::new());
+        assert_eq!(
+            scopes.get_local_variables().unwrap(),
+            &HashMap::from([(String::from("b"), PyValueType::BigInt(bigint!(1)))])
+        );
 
         scopes.enter_scope(new_scope);
+
+        // check that variable `b` can't be accessed now
+        assert!(scopes.get_local_variables().unwrap().get("b").is_none());
 
         assert_eq!(
             scopes.get_local_variables().unwrap(),

--- a/src/types/exec_scope.rs
+++ b/src/types/exec_scope.rs
@@ -4,11 +4,11 @@ use std::collections::HashMap;
 
 #[derive(Eq, PartialEq, Debug)]
 pub struct ExecutionScopes {
-    exec_scopes: Vec<HashMap<String, PythonDictValueType>>,
+    exec_scopes: Vec<HashMap<String, PyValueType>>,
 }
 
 #[derive(Eq, Hash, PartialEq, Debug)]
-pub enum PythonDictValueType {
+pub enum PyValueType {
     BigInt(BigInt),
 }
 
@@ -19,7 +19,7 @@ impl ExecutionScopes {
         }
     }
 
-    pub fn enter_scope(&mut self, new_scope_locals: HashMap<String, PythonDictValueType>) {
+    pub fn enter_scope(&mut self, new_scope_locals: HashMap<String, PyValueType>) {
         self.exec_scopes.push(new_scope_locals);
     }
 
@@ -32,11 +32,11 @@ impl ExecutionScopes {
         Ok(())
     }
 
-    pub fn get_local_variables(&mut self) -> Option<&mut HashMap<String, PythonDictValueType>> {
+    pub fn get_local_variables(&mut self) -> Option<&mut HashMap<String, PyValueType>> {
         self.exec_scopes.last_mut()
     }
 
-    pub fn assign_or_update_variable(&mut self, var_name: String, var_value: PythonDictValueType) {
+    pub fn assign_or_update_variable(&mut self, var_name: String, var_value: PyValueType) {
         if let Some(local_variables) = self.get_local_variables() {
             local_variables.insert(var_name, var_value);
         }
@@ -76,7 +76,7 @@ mod tests {
     #[test]
     fn get_local_variables_test() {
         let var_name = String::from("a");
-        let var_value = PythonDictValueType::BigInt(bigint!(2));
+        let var_value = PyValueType::BigInt(bigint!(2));
 
         let scope = HashMap::from([(var_name, var_value)]);
 
@@ -86,14 +86,14 @@ mod tests {
 
         assert_eq!(
             scopes.get_local_variables().unwrap(),
-            &HashMap::from([(String::from("a"), PythonDictValueType::BigInt(bigint!(2)))])
+            &HashMap::from([(String::from("a"), PyValueType::BigInt(bigint!(2)))])
         );
     }
 
     #[test]
     fn enter_new_scope_test() {
         let var_name = String::from("a");
-        let var_value = PythonDictValueType::BigInt(bigint!(2));
+        let var_value = PyValueType::BigInt(bigint!(2));
 
         let new_scope = HashMap::from([(var_name, var_value)]);
 
@@ -105,14 +105,14 @@ mod tests {
 
         assert_eq!(
             scopes.get_local_variables().unwrap(),
-            &HashMap::from([(String::from("a"), PythonDictValueType::BigInt(bigint!(2)))])
+            &HashMap::from([(String::from("a"), PyValueType::BigInt(bigint!(2)))])
         );
     }
 
     #[test]
     fn exit_scope_test() {
         let var_name = String::from("a");
-        let var_value = PythonDictValueType::BigInt(bigint!(2));
+        let var_value = PyValueType::BigInt(bigint!(2));
 
         let new_scope = HashMap::from([(var_name, var_value)]);
 
@@ -124,7 +124,7 @@ mod tests {
 
         assert_eq!(
             scopes.get_local_variables().unwrap(),
-            &HashMap::from([(String::from("a"), PythonDictValueType::BigInt(bigint!(2)))])
+            &HashMap::from([(String::from("a"), PyValueType::BigInt(bigint!(2)))])
         );
 
         // exit the current scope
@@ -139,7 +139,7 @@ mod tests {
     #[test]
     fn assign_local_variable_test() {
         let var_name = String::from("a");
-        let var_value = PythonDictValueType::BigInt(bigint!(2));
+        let var_value = PyValueType::BigInt(bigint!(2));
 
         let mut scopes = ExecutionScopes::new();
 
@@ -147,14 +147,14 @@ mod tests {
 
         assert_eq!(
             scopes.get_local_variables().unwrap().get("a").unwrap(),
-            &PythonDictValueType::BigInt(bigint!(2))
+            &PyValueType::BigInt(bigint!(2))
         );
     }
 
     #[test]
     fn re_assign_local_variable_test() {
         let var_name = String::from("a");
-        let var_value = PythonDictValueType::BigInt(bigint!(2));
+        let var_value = PyValueType::BigInt(bigint!(2));
 
         let scope = HashMap::from([(var_name, var_value)]);
 
@@ -162,19 +162,18 @@ mod tests {
             exec_scopes: vec![scope],
         };
 
-        scopes
-            .assign_or_update_variable(String::from("a"), PythonDictValueType::BigInt(bigint!(3)));
+        scopes.assign_or_update_variable(String::from("a"), PyValueType::BigInt(bigint!(3)));
 
         assert_eq!(
             scopes.get_local_variables().unwrap().get("a").unwrap(),
-            &PythonDictValueType::BigInt(bigint!(3))
+            &PyValueType::BigInt(bigint!(3))
         );
     }
 
     #[test]
     fn delete_local_variable_test() {
         let var_name = String::from("a");
-        let var_value = PythonDictValueType::BigInt(bigint!(2));
+        let var_value = PyValueType::BigInt(bigint!(2));
 
         let scope = HashMap::from([(var_name, var_value)]);
 

--- a/src/types/exec_scope.rs
+++ b/src/types/exec_scope.rs
@@ -1,0 +1,197 @@
+use crate::vm::errors::exec_scope_errors::ExecScopeError;
+use num_bigint::BigInt;
+use std::collections::HashMap;
+
+#[derive(Eq, PartialEq, Debug)]
+pub struct ExecutionScopes {
+    exec_scopes: Vec<HashMap<String, PythonDictValueType>>,
+}
+
+#[derive(Eq, Hash, PartialEq, Debug)]
+pub enum PythonDictValueType {
+    BigInt(BigInt),
+}
+
+impl ExecutionScopes {
+    pub fn new() -> ExecutionScopes {
+        ExecutionScopes {
+            exec_scopes: vec![HashMap::new()],
+        }
+    }
+
+    pub fn enter_scope(&mut self, new_scope_locals: HashMap<String, PythonDictValueType>) {
+        self.exec_scopes.push(new_scope_locals);
+    }
+
+    pub fn exit_scope(&mut self) -> Result<(), ExecScopeError> {
+        if self.exec_scopes.len() == 1 {
+            return Err(ExecScopeError::ExitMainScopeError);
+        }
+        self.exec_scopes.pop();
+
+        Ok(())
+    }
+
+    pub fn get_local_variables(&mut self) -> Option<&mut HashMap<String, PythonDictValueType>> {
+        self.exec_scopes.last_mut()
+    }
+
+    pub fn assign_or_update_variable(&mut self, var_name: String, var_value: PythonDictValueType) {
+        if let Some(local_variables) = self.get_local_variables() {
+            local_variables.insert(var_name, var_value);
+        }
+    }
+
+    pub fn delete_variable(&mut self, var_name: String) {
+        if let Some(local_variables) = self.get_local_variables() {
+            local_variables.remove(&var_name);
+        }
+    }
+}
+
+impl Default for ExecutionScopes {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bigint;
+    use num_traits::FromPrimitive;
+
+    #[test]
+    fn initialize_execution_scopes() {
+        let scopes = ExecutionScopes::new();
+
+        assert_eq!(
+            scopes,
+            ExecutionScopes {
+                exec_scopes: vec![HashMap::new()]
+            }
+        );
+    }
+
+    #[test]
+    fn get_local_variables_test() {
+        let var_name = String::from("a");
+        let var_value = PythonDictValueType::BigInt(bigint!(2));
+
+        let scope = HashMap::from([(var_name, var_value)]);
+
+        let mut scopes = ExecutionScopes {
+            exec_scopes: vec![scope],
+        };
+
+        assert_eq!(
+            scopes.get_local_variables().unwrap(),
+            &HashMap::from([(String::from("a"), PythonDictValueType::BigInt(bigint!(2)))])
+        );
+    }
+
+    #[test]
+    fn enter_new_scope_test() {
+        let var_name = String::from("a");
+        let var_value = PythonDictValueType::BigInt(bigint!(2));
+
+        let new_scope = HashMap::from([(var_name, var_value)]);
+
+        let mut scopes = ExecutionScopes::new();
+
+        assert_eq!(scopes.get_local_variables().unwrap(), &HashMap::new());
+
+        scopes.enter_scope(new_scope);
+
+        assert_eq!(
+            scopes.get_local_variables().unwrap(),
+            &HashMap::from([(String::from("a"), PythonDictValueType::BigInt(bigint!(2)))])
+        );
+    }
+
+    #[test]
+    fn exit_scope_test() {
+        let var_name = String::from("a");
+        let var_value = PythonDictValueType::BigInt(bigint!(2));
+
+        let new_scope = HashMap::from([(var_name, var_value)]);
+
+        // this initializes an empty main scope
+        let mut scopes = ExecutionScopes::new();
+
+        // enter one extra scope
+        scopes.enter_scope(new_scope);
+
+        assert_eq!(
+            scopes.get_local_variables().unwrap(),
+            &HashMap::from([(String::from("a"), PythonDictValueType::BigInt(bigint!(2)))])
+        );
+
+        // exit the current scope
+        let exit_scope_result = scopes.exit_scope();
+
+        assert!(exit_scope_result.is_ok());
+
+        // assert that we recovered the older scope
+        assert_eq!(scopes.get_local_variables().unwrap(), &HashMap::new());
+    }
+
+    #[test]
+    fn assign_local_variable_test() {
+        let var_name = String::from("a");
+        let var_value = PythonDictValueType::BigInt(bigint!(2));
+
+        let mut scopes = ExecutionScopes::new();
+
+        scopes.assign_or_update_variable(var_name, var_value);
+
+        assert_eq!(
+            scopes.get_local_variables().unwrap().get("a").unwrap(),
+            &PythonDictValueType::BigInt(bigint!(2))
+        );
+    }
+
+    #[test]
+    fn re_assign_local_variable_test() {
+        let var_name = String::from("a");
+        let var_value = PythonDictValueType::BigInt(bigint!(2));
+
+        let scope = HashMap::from([(var_name, var_value)]);
+
+        let mut scopes = ExecutionScopes {
+            exec_scopes: vec![scope],
+        };
+
+        scopes
+            .assign_or_update_variable(String::from("a"), PythonDictValueType::BigInt(bigint!(3)));
+
+        assert_eq!(
+            scopes.get_local_variables().unwrap().get("a").unwrap(),
+            &PythonDictValueType::BigInt(bigint!(3))
+        );
+    }
+
+    #[test]
+    fn delete_local_variable_test() {
+        let var_name = String::from("a");
+        let var_value = PythonDictValueType::BigInt(bigint!(2));
+
+        let scope = HashMap::from([(var_name, var_value)]);
+
+        let mut scopes = ExecutionScopes {
+            exec_scopes: vec![scope],
+        };
+
+        assert!(scopes
+            .get_local_variables()
+            .unwrap()
+            .contains_key(&String::from("a")));
+
+        scopes.delete_variable(String::from("a"));
+
+        assert!(!scopes
+            .get_local_variables()
+            .unwrap()
+            .contains_key(&String::from("a")));
+    }
+}

--- a/src/types/exec_scope.rs
+++ b/src/types/exec_scope.rs
@@ -143,6 +143,9 @@ mod tests {
 
         assert!(exit_scope_result.is_ok());
 
+        // assert that variable `a` is no longer available
+        assert!(scopes.get_local_variables().unwrap().get("a").is_none());
+
         // assert that we recovered the older scope
         assert_eq!(scopes.get_local_variables().unwrap(), &HashMap::new());
     }

--- a/src/types/exec_scope.rs
+++ b/src/types/exec_scope.rs
@@ -36,15 +36,15 @@ impl ExecutionScopes {
         self.exec_scopes.last_mut()
     }
 
-    pub fn assign_or_update_variable(&mut self, var_name: String, var_value: PyValueType) {
+    pub fn assign_or_update_variable(&mut self, var_name: &str, var_value: PyValueType) {
         if let Some(local_variables) = self.get_local_variables() {
-            local_variables.insert(var_name, var_value);
+            local_variables.insert(var_name.to_string(), var_value);
         }
     }
 
-    pub fn delete_variable(&mut self, var_name: String) {
+    pub fn delete_variable(&mut self, var_name: &str) {
         if let Some(local_variables) = self.get_local_variables() {
-            local_variables.remove(&var_name);
+            local_variables.remove(&var_name.to_string());
         }
     }
 }
@@ -97,7 +97,12 @@ mod tests {
 
         let new_scope = HashMap::from([(var_name, var_value)]);
 
-        let mut scopes = ExecutionScopes::new();
+        let mut scopes = ExecutionScopes {
+            exec_scopes: vec![HashMap::from([(
+                String::from("a"),
+                PyValueType::BigInt(bigint!(1)),
+            )])],
+        };
 
         assert_eq!(scopes.get_local_variables().unwrap(), &HashMap::new());
 
@@ -138,12 +143,11 @@ mod tests {
 
     #[test]
     fn assign_local_variable_test() {
-        let var_name = String::from("a");
         let var_value = PyValueType::BigInt(bigint!(2));
 
         let mut scopes = ExecutionScopes::new();
 
-        scopes.assign_or_update_variable(var_name, var_value);
+        scopes.assign_or_update_variable("a", var_value);
 
         assert_eq!(
             scopes.get_local_variables().unwrap().get("a").unwrap(),
@@ -162,7 +166,7 @@ mod tests {
             exec_scopes: vec![scope],
         };
 
-        scopes.assign_or_update_variable(String::from("a"), PyValueType::BigInt(bigint!(3)));
+        scopes.assign_or_update_variable("a", PyValueType::BigInt(bigint!(3)));
 
         assert_eq!(
             scopes.get_local_variables().unwrap().get("a").unwrap(),
@@ -186,7 +190,7 @@ mod tests {
             .unwrap()
             .contains_key(&String::from("a")));
 
-        scopes.delete_variable(String::from("a"));
+        scopes.delete_variable("a");
 
         assert!(!scopes
             .get_local_variables()

--- a/src/types/exec_scope.rs
+++ b/src/types/exec_scope.rs
@@ -206,4 +206,11 @@ mod tests {
             .unwrap()
             .contains_key(&String::from("a")));
     }
+
+    #[test]
+    fn exit_main_scope_gives_error_test() {
+        let mut scopes = ExecutionScopes::new();
+
+        assert!(scopes.exit_scope().is_err());
+    }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,4 +1,5 @@
 pub mod errors;
+pub mod exec_scope;
 pub mod instruction;
 pub mod program;
 pub mod relocatable;

--- a/src/vm/errors/exec_scope_errors.rs
+++ b/src/vm/errors/exec_scope_errors.rs
@@ -1,0 +1,16 @@
+use std::fmt;
+
+#[derive(Eq, Hash, PartialEq, Debug)]
+pub enum ExecScopeError {
+    ExitMainScopeError,
+}
+
+impl fmt::Display for ExecScopeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ExecScopeError::ExitMainScopeError => {
+                write!(f, "Cannot exit main scope.")
+            }
+        }
+    }
+}

--- a/src/vm/errors/mod.rs
+++ b/src/vm/errors/mod.rs
@@ -1,4 +1,5 @@
 pub mod cairo_run_errors;
+pub mod exec_scope_errors;
 pub mod memory_errors;
 pub mod runner_errors;
 pub mod trace_errors;

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -1,4 +1,5 @@
 use crate::bigint;
+use crate::types::exec_scope::ExecutionScopes;
 use crate::types::instruction::{ApUpdate, FpUpdate, Instruction, Opcode, PcUpdate, Res};
 use crate::types::relocatable::MaybeRelocatable;
 use crate::vm::context::run_context::RunContext;
@@ -36,7 +37,7 @@ pub struct VirtualMachine {
     pub prime: BigInt,
     pub builtin_runners: Vec<(String, Box<dyn BuiltinRunner>)>,
     pub segments: MemorySegmentManager,
-    //exec_scopes: Vec<HashMap<..., ...>>,
+    pub exec_scopes: ExecutionScopes,
     //enter_scope:
     pub hints: HashMap<MaybeRelocatable, Vec<HintData>>,
     pub references: HashMap<usize, HintReference>,
@@ -87,6 +88,7 @@ impl VirtualMachine {
             current_step: 0,
             skip_instruction_execution: false,
             segments: MemorySegmentManager::new(),
+            exec_scopes: ExecutionScopes::new(),
         }
     }
     ///Returns the encoded instruction (the value at pc) and the immediate value (the value at pc + 1, if it exists in the memory).

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -2376,6 +2376,7 @@ mod tests {
             current_step: 1,
             skip_instruction_execution: false,
             segments: MemorySegmentManager::new(),
+            exec_scopes: ExecutionScopes::new(),
         };
 
         let error = vm.opcode_assertions(&instruction, &operands);


### PR DESCRIPTION
# VM execution scopes

## Description
This PR adds basic functionality for hints that need to create scopes in the VM. A new stack-like struct, `ExecutionScopes` is created with the following methods:
* `new`: To create a new instance of ExecutionScopes
* `enter_scope`: To create a new scope in the VM, with a dictionary representing the variables available in the new scope.
* `exit_scope`: To exit the current scope and return to the previous one.
* `get_local_variables`: To return and use the variables in the current scope.
* `assign_or_update_variable`: To assign or update a variable in the current scope, depending if it exists or not.
* `delete_variable`: To delete a variable in the current scope. (Used in a lot of hints)

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
