### PR TITLE
[HINTS] Add implementation for hint on assert_lt_felt (math.cairo) 

### DIFF
--- a/cairo_programs/assert_lt_felt.cairo
+++ b/cairo_programs/assert_lt_felt.cairo
@@ -1,0 +1,49 @@
+%builtins range_check
+
+from starkware.cairo.common.math import assert_lt
+from starkware.cairo.common.math import split_felt
+from starkware.cairo.common.math import assert_lt_felt
+
+func assert_lt_felt_manual_implementation{range_check_ptr}(a, b):
+    %{
+        from starkware.cairo.common.math_utils import assert_integer
+        assert_integer(ids.a)
+        assert_integer(ids.b)
+        assert (ids.a % PRIME) < (ids.b % PRIME), \
+            f'a = {ids.a % PRIME} is not less than b = {ids.b % PRIME}.'
+    %}
+    alloc_locals
+    let (local a_high, local a_low) = split_felt(a)
+    let (b_high, b_low) = split_felt(b)
+
+    if a_high == b_high:
+        assert_lt(a_low, b_low)
+        return ()
+    end
+    assert_lt(a_high, b_high)
+    return ()
+end
+
+func main{range_check_ptr: felt}():
+    let x = 5
+    let y = 6 
+
+    tempvar m = 7
+    tempvar n = 7 * 7
+
+    assert_lt_felt(1,2)
+    assert_lt_felt(-2,-1)
+    assert_lt_felt(1,-1)
+    assert_lt_felt(0,1)
+    assert_lt_felt(x,y)
+    assert_lt_felt(m,n)
+
+    assert_lt_felt_manual_implementation(1,2)
+    assert_lt_felt_manual_implementation(-2,-1)
+    assert_lt_felt_manual_implementation(1,-1)
+    assert_lt_felt_manual_implementation(0,1)
+    assert_lt_felt_manual_implementation(x,y)
+    assert_lt_felt_manual_implementation(m,n)
+
+    return ()
+end

--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -52,6 +52,7 @@ pub enum VirtualMachineError {
     SqrtNegative(BigInt),
     FailedToGetSqrt(BigInt),
     AssertNotZero(BigInt, BigInt),
+    AssertLtFelt(BigInt, BigInt),
 }
 
 impl fmt::Display for VirtualMachineError {
@@ -148,6 +149,10 @@ impl fmt::Display for VirtualMachineError {
             VirtualMachineError::FailedToGetSqrt(value) => write!(f, "Failed to calculate the square root of: {:?})", value),
             VirtualMachineError::AssertNotZero(value, prime) => {
                 write!(f, "Assertion failed, {} % {} is equal to 0", value, prime)
+            },
+            VirtualMachineError::AssertLtFelt(a, b) => {
+                write!(f, "Assertion failed, a = {} % PRIME is not less than b = {} % PRIME", a, b)
+
             },
         }
     }

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -5,7 +5,7 @@ use num_bigint::BigInt;
 use crate::types::instruction::Register;
 use crate::vm::errors::vm_errors::VirtualMachineError;
 use crate::vm::hints::hint_utils::{
-    add_segment, assert_250_bit, assert_le_felt, assert_nn, assert_not_equal, assert_not_zero,
+    add_segment, assert_250_bit, assert_le_felt, assert_lt_felt, assert_nn, assert_not_equal, assert_not_zero,
     is_le_felt, is_nn, is_nn_out_of_range, is_positive, split_felt, split_int,
     split_int_assert_range, sqrt, unsigned_div_rem,
 };
@@ -52,6 +52,7 @@ pub fn execute_hint(
         Ok("from starkware.cairo.common.math_utils import assert_integer\nassert ids.MAX_HIGH < 2**128 and ids.MAX_LOW < 2**128\nassert PRIME - 1 == ids.MAX_HIGH * 2**128 + ids.MAX_LOW\nassert_integer(ids.value)\nids.low = ids.value & ((1 << 128) - 1)\nids.high = ids.value >> 128"
         ) => split_felt(vm, ids),
         Ok("from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\nids.q, ids.r = divmod(ids.value, ids.div)") => unsigned_div_rem(vm, ids),
+        Ok("from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\nassert (ids.a % PRIME) < (ids.b % PRIME), \\\n    f'a = {ids.a % PRIME} is not less than b = {ids.b % PRIME}.'") => assert_lt_felt(vm, ids),
         Ok(hint_code) => Err(VirtualMachineError::UnknownHint(String::from(hint_code))),
         Err(_) => Err(VirtualMachineError::InvalidHintEncoding(
             vm.run_context.pc.clone(),

--- a/tests/cairo_run_test.rs
+++ b/tests/cairo_run_test.rs
@@ -121,3 +121,9 @@ fn cairo_run_unsigned_div_rem() {
     cairo_run::cairo_run(Path::new("cairo_programs/unsigned_div_rem.json"))
         .expect("Couldn't run program");
 }
+
+#[test]
+fn cairo_run_assert_lt_felt() {
+    cairo_run::cairo_run(Path::new("cairo_programs/assert_lt_felt.json"))
+        .expect("Couldn't run program");
+}


### PR DESCRIPTION
# Add implementation for hint on assert_lt_felt (math.cairo) 
https://github.com/starkware-libs/cairo-lang/blob/167b28bcd940fd25ea3816204fa882a0b0a49603/src/starkware/cairo/common/math.cairo#L187

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [x] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
