### PR TITLE
Add fixme in ValueAddress deserialization

### DIFF
--- a/src/serde/deserialize_utils.rs
+++ b/src/serde/deserialize_utils.rs
@@ -62,6 +62,12 @@ pub fn parse_dereference(value: &str) -> Result<ValueAddress, ReferenceParseErro
         1 => parse_dereference_no_offsets(&splitted),
         2 => parse_dereference_with_one_offset(&splitted),
         3 => parse_dereference_with_two_offsets(&splitted),
+
+        // FIXME this match arm is handled like this just to avoid unnecesary deserialization errors.
+        // For the moment, the ValueAddress structs returned in ths arm are not used in hints, so they are not important.
+        // issue: https://github.com/lambdaclass/cleopatra_cairo/issues/280
+
+        // _ => Err(ReferenceParseError::InvalidStringError(String::from(value))),
         _ => Ok(ValueAddress {
             register: Some(Register::FP),
             offset1: 0,
@@ -145,12 +151,18 @@ pub fn parse_reference(value: &str) -> Result<ValueAddress, ReferenceParseError>
         1 => parse_reference_no_offsets(&splitted),
         2 => parse_reference_with_one_offset(&splitted),
         3 => parse_reference_with_two_offsets(&splitted),
+
+        // FIXME this match arm is handled like this just to avoid unnecesary deserialization errors.
+        // For the moment, the ValueAddress structs returned in ths arm are not used in hints, so they are not important.
+        // issue: https://github.com/lambdaclass/cleopatra_cairo/issues/280
+
+        // _ => Err(ReferenceParseError::InvalidStringError(String::from(value))),
         _ => Ok(ValueAddress {
             register: Some(Register::FP),
             offset1: 0,
             offset2: 0,
             immediate: None,
-            dereference: true,
+            dereference: false,
             inner_dereference: false,
         }),
     }


### PR DESCRIPTION
# Add fixme in ValueAddress deserialization

## Description
Just adding a minor fix to avoid unnecessary deserialization errors that are not important ATM.
Issue #280 for handling this in the future was created

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
