### PR TITLE
Reduce one clone in instruction decoder

### DIFF
--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -453,7 +453,7 @@ impl VirtualMachine {
 
     fn decode_current_instruction(&self) -> Result<Instruction, VirtualMachineError> {
         let (instruction_ref, imm) = self.get_instruction_encoding()?;
-        match instruction_ref.clone().to_i64() {
+        match instruction_ref.to_i64() {
             Some(instruction) => {
                 if let Some(MaybeRelocatable::Int(imm_ref)) = imm {
                     let decoded_instruction =


### PR DESCRIPTION
# Deletes a clone

## Description

Ditto. 1-3% improvement in benchmarks, turns out it was a sizable part of instruction decoding.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
