### PR TITLE
Convert TraceEntry fields to Relocatable

### DIFF
--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -333,9 +333,9 @@ impl CairoRunner {
         let mut relocated_trace = Vec::<RelocatedTraceEntry>::with_capacity(trace.len());
         for entry in trace {
             relocated_trace.push(RelocatedTraceEntry {
-                pc: relocate_trace_register(entry.pc.clone(), relocation_table)?,
-                ap: relocate_trace_register(entry.ap.clone(), relocation_table)?,
-                fp: relocate_trace_register(entry.fp.clone(), relocation_table)?,
+                pc: relocate_trace_register(&entry.pc, relocation_table)?,
+                ap: relocate_trace_register(&entry.ap, relocation_table)?,
+                fp: relocate_trace_register(&entry.fp, relocation_table)?,
             })
         }
         self.relocated_trace = Some(relocated_trace);
@@ -1690,41 +1690,86 @@ mod tests {
         assert_eq!(
             trace[0],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 3)),
-                ap: MaybeRelocatable::from((1, 2)),
-                fp: MaybeRelocatable::from((1, 2)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 3
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 2
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 2
+                },
             }
         );
         assert_eq!(
             trace[1],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 5)),
-                ap: MaybeRelocatable::from((1, 3)),
-                fp: MaybeRelocatable::from((1, 2)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 5
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 3
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 2
+                },
             }
         );
         assert_eq!(
             trace[2],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 0)),
-                ap: MaybeRelocatable::from((1, 5)),
-                fp: MaybeRelocatable::from((1, 5)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 0
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 5
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 5
+                },
             }
         );
         assert_eq!(
             trace[3],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 2)),
-                ap: MaybeRelocatable::from((1, 6)),
-                fp: MaybeRelocatable::from((1, 5)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 2
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 6
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 5
+                },
             }
         );
         assert_eq!(
             trace[4],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 7)),
-                ap: MaybeRelocatable::from((1, 6)),
-                fp: MaybeRelocatable::from((1, 2)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 7
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 6
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 2
+                },
             }
         );
     }
@@ -1812,81 +1857,171 @@ mod tests {
         assert_eq!(
             trace[0],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 8)),
-                ap: MaybeRelocatable::from((1, 3)),
-                fp: MaybeRelocatable::from((1, 3)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 8
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 3
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 3
+                },
             }
         );
         assert_eq!(
             trace[1],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 9)),
-                ap: MaybeRelocatable::from((1, 4)),
-                fp: MaybeRelocatable::from((1, 3)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 9
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 4
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 3
+                },
             }
         );
         assert_eq!(
             trace[2],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 11)),
-                ap: MaybeRelocatable::from((1, 5)),
-                fp: MaybeRelocatable::from((1, 3)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 11
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 5
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 3
+                },
             }
         );
         assert_eq!(
             trace[3],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 0)),
-                ap: MaybeRelocatable::from((1, 7)),
-                fp: MaybeRelocatable::from((1, 7)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 0
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 7
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 7
+                },
             }
         );
         assert_eq!(
             trace[4],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 1)),
-                ap: MaybeRelocatable::from((1, 7)),
-                fp: MaybeRelocatable::from((1, 7)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 1
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 7
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 7
+                },
             }
         );
         assert_eq!(
             trace[5],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 3)),
-                ap: MaybeRelocatable::from((1, 8)),
-                fp: MaybeRelocatable::from((1, 7)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 3
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 8
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 7
+                },
             }
         );
         assert_eq!(
             trace[6],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 4)),
-                ap: MaybeRelocatable::from((1, 9)),
-                fp: MaybeRelocatable::from((1, 7)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 4
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 9
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 7
+                },
             }
         );
         assert_eq!(
             trace[7],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 5)),
-                ap: MaybeRelocatable::from((1, 9)),
-                fp: MaybeRelocatable::from((1, 7)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 5
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 9
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 7
+                },
             }
         );
         assert_eq!(
             trace[8],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 7)),
-                ap: MaybeRelocatable::from((1, 10)),
-                fp: MaybeRelocatable::from((1, 7)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 7
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 10
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 7
+                },
             }
         );
         assert_eq!(
             trace[9],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 13)),
-                ap: MaybeRelocatable::from((1, 10)),
-                fp: MaybeRelocatable::from((1, 3)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 13
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 10
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 3
+                },
             }
         );
         //Check the range_check builtin segment
@@ -2016,97 +2151,205 @@ mod tests {
         assert_eq!(
             trace[0],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 4)),
-                ap: MaybeRelocatable::from((1, 3)),
-                fp: MaybeRelocatable::from((1, 3)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 4
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 3
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 3
+                },
             }
         );
         assert_eq!(
             trace[1],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 5)),
-                ap: MaybeRelocatable::from((1, 4)),
-                fp: MaybeRelocatable::from((1, 3)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 5
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 4
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 3
+                },
             }
         );
         assert_eq!(
             trace[2],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 7)),
-                ap: MaybeRelocatable::from((1, 5)),
-                fp: MaybeRelocatable::from((1, 3)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 7
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 5
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 3
+                },
             }
         );
         assert_eq!(
             trace[3],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 0)),
-                ap: MaybeRelocatable::from((1, 7)),
-                fp: MaybeRelocatable::from((1, 7)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 0
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 7
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 7
+                },
             }
         );
         assert_eq!(
             trace[4],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 1)),
-                ap: MaybeRelocatable::from((1, 7)),
-                fp: MaybeRelocatable::from((1, 7)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 1
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 7
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 7
+                },
             }
         );
         assert_eq!(
             trace[5],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 3)),
-                ap: MaybeRelocatable::from((1, 8)),
-                fp: MaybeRelocatable::from((1, 7)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 3
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 8
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 7
+                },
             }
         );
         assert_eq!(
             trace[6],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 9)),
-                ap: MaybeRelocatable::from((1, 8)),
-                fp: MaybeRelocatable::from((1, 3)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 9
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 8
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 3
+                },
             }
         );
         assert_eq!(
             trace[7],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 11)),
-                ap: MaybeRelocatable::from((1, 9)),
-                fp: MaybeRelocatable::from((1, 3)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 11
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 9
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 3
+                },
             }
         );
         assert_eq!(
             trace[8],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 0)),
-                ap: MaybeRelocatable::from((1, 11)),
-                fp: MaybeRelocatable::from((1, 11)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 0
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 11
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 11
+                },
             }
         );
         assert_eq!(
             trace[9],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 1)),
-                ap: MaybeRelocatable::from((1, 11)),
-                fp: MaybeRelocatable::from((1, 11)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 1
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 11
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 11
+                },
             }
         );
         assert_eq!(
             trace[10],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 3)),
-                ap: MaybeRelocatable::from((1, 12)),
-                fp: MaybeRelocatable::from((1, 11)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 3
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 12
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 11
+                },
             }
         );
         assert_eq!(
             trace[11],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 13)),
-                ap: MaybeRelocatable::from((1, 12)),
-                fp: MaybeRelocatable::from((1, 3)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 13
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 12
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 3
+                },
             }
         );
         //Check that the output to be printed is correct
@@ -2259,145 +2502,307 @@ mod tests {
         assert_eq!(
             trace[0],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 13)),
-                ap: MaybeRelocatable::from((1, 4)),
-                fp: MaybeRelocatable::from((1, 4)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 13
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 4
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 4
+                },
             }
         );
         assert_eq!(
             trace[1],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 14)),
-                ap: MaybeRelocatable::from((1, 5)),
-                fp: MaybeRelocatable::from((1, 4)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 14
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 5
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 4
+                },
             }
         );
         assert_eq!(
             trace[2],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 16)),
-                ap: MaybeRelocatable::from((1, 6)),
-                fp: MaybeRelocatable::from((1, 4)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 16
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 6
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 4
+                },
             }
         );
         assert_eq!(
             trace[3],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 4)),
-                ap: MaybeRelocatable::from((1, 8)),
-                fp: MaybeRelocatable::from((1, 8)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 4
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 8
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 8
+                },
             }
         );
         assert_eq!(
             trace[4],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 5)),
-                ap: MaybeRelocatable::from((1, 8)),
-                fp: MaybeRelocatable::from((1, 8)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 5
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 8
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 8
+                },
             }
         );
         assert_eq!(
             trace[5],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 7)),
-                ap: MaybeRelocatable::from((1, 9)),
-                fp: MaybeRelocatable::from((1, 8)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 7
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 9
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 8
+                },
             }
         );
         assert_eq!(
             trace[6],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 8)),
-                ap: MaybeRelocatable::from((1, 10)),
-                fp: MaybeRelocatable::from((1, 8)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 8
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 10
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 8
+                },
             }
         );
         assert_eq!(
             trace[7],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 9)),
-                ap: MaybeRelocatable::from((1, 10)),
-                fp: MaybeRelocatable::from((1, 8)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 9
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 10
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 8
+                },
             }
         );
         assert_eq!(
             trace[8],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 11)),
-                ap: MaybeRelocatable::from((1, 11)),
-                fp: MaybeRelocatable::from((1, 8)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 11
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 11
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 8
+                },
             }
         );
         assert_eq!(
             trace[9],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 12)),
-                ap: MaybeRelocatable::from((1, 12)),
-                fp: MaybeRelocatable::from((1, 8)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 12
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 12
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 8
+                },
             }
         );
         assert_eq!(
             trace[10],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 18)),
-                ap: MaybeRelocatable::from((1, 12)),
-                fp: MaybeRelocatable::from((1, 4)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 18
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 12
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 4
+                },
             }
         );
         assert_eq!(
             trace[11],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 19)),
-                ap: MaybeRelocatable::from((1, 13)),
-                fp: MaybeRelocatable::from((1, 4)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 19
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 13
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 4
+                },
             }
         );
         assert_eq!(
             trace[12],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 20)),
-                ap: MaybeRelocatable::from((1, 14)),
-                fp: MaybeRelocatable::from((1, 4)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 20
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 14
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 4
+                },
             }
         );
         assert_eq!(
             trace[13],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 0)),
-                ap: MaybeRelocatable::from((1, 16)),
-                fp: MaybeRelocatable::from((1, 16)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 0
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 16
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 16
+                },
             }
         );
         assert_eq!(
             trace[14],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 1)),
-                ap: MaybeRelocatable::from((1, 16)),
-                fp: MaybeRelocatable::from((1, 16)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 1
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 16
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 16
+                },
             }
         );
         assert_eq!(
             trace[15],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 3)),
-                ap: MaybeRelocatable::from((1, 17)),
-                fp: MaybeRelocatable::from((1, 16)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 3
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 17
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 16
+                },
             }
         );
         assert_eq!(
             trace[16],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 22)),
-                ap: MaybeRelocatable::from((1, 17)),
-                fp: MaybeRelocatable::from((1, 4)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 22
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 17
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 4
+                },
             }
         );
         assert_eq!(
             trace[17],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 23)),
-                ap: MaybeRelocatable::from((1, 18)),
-                fp: MaybeRelocatable::from((1, 4)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 23
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 18
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 4
+                },
             }
         );
         //Check the range_check builtin segment

--- a/src/vm/trace/trace_entry.rs
+++ b/src/vm/trace/trace_entry.rs
@@ -1,14 +1,14 @@
 ///A trace entry for every instruction that was executed.
 ///Holds the register values before the instruction was executed.
-use crate::types::relocatable::MaybeRelocatable;
+use crate::types::relocatable::Relocatable;
 use crate::vm::errors::trace_errors::TraceError;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq)]
 pub struct TraceEntry {
-    pub pc: MaybeRelocatable,
-    pub ap: MaybeRelocatable,
-    pub fp: MaybeRelocatable,
+    pub pc: Relocatable,
+    pub ap: Relocatable,
+    pub fp: Relocatable,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -19,54 +19,40 @@ pub struct RelocatedTraceEntry {
 }
 
 pub fn relocate_trace_register(
-    value: MaybeRelocatable,
+    value: &Relocatable,
     relocation_table: &Vec<usize>,
 ) -> Result<usize, TraceError> {
-    match value {
-        MaybeRelocatable::Int(_num) => Err(TraceError::RegNotRelocatable),
-        MaybeRelocatable::RelocatableValue(relocatable) => {
-            if relocation_table.len() <= relocatable.segment_index {
-                return Err(TraceError::NoRelocationFound);
-            }
-            Ok(relocation_table[relocatable.segment_index] + relocatable.offset)
-        }
+    if relocation_table.len() <= value.segment_index {
+        return Err(TraceError::NoRelocationFound);
     }
+    Ok(relocation_table[value.segment_index] + value.offset)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bigint;
-    use num_bigint::BigInt;
-    use num_traits::FromPrimitive;
 
     #[test]
     fn relocate_relocatable_value() {
-        let value = MaybeRelocatable::from((2, 7));
+        let value = Relocatable {
+            segment_index: 2,
+            offset: 7,
+        };
         let relocation_table = vec![1, 2, 5];
         assert_eq!(
-            relocate_trace_register(value, &relocation_table).unwrap(),
+            relocate_trace_register(&value, &relocation_table).unwrap(),
             12
         );
     }
 
     #[test]
-    fn relocate_int_value() {
-        let value = MaybeRelocatable::from(bigint!(7));
-        let relocation_table = vec![1, 2, 5];
-        let error = relocate_trace_register(value, &relocation_table);
-        assert_eq!(error, Err(TraceError::RegNotRelocatable));
-        assert_eq!(
-            error.unwrap_err().to_string(),
-            "Trace register must be relocatable"
-        );
-    }
-
-    #[test]
     fn relocate_relocatable_value_no_relocation() {
-        let value = MaybeRelocatable::from((2, 7));
+        let value = Relocatable {
+            segment_index: 2,
+            offset: 7,
+        };
         let relocation_table = vec![1, 2];
-        let error = relocate_trace_register(value, &relocation_table);
+        let error = relocate_trace_register(&value, &relocation_table);
         assert_eq!(error, Err(TraceError::NoRelocationFound));
         assert_eq!(
             error.unwrap_err().to_string(),

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -2,6 +2,7 @@ use crate::bigint;
 use crate::types::exec_scope::ExecutionScopes;
 use crate::types::instruction::{ApUpdate, FpUpdate, Instruction, Opcode, PcUpdate, Res};
 use crate::types::relocatable::MaybeRelocatable;
+use crate::types::relocatable::MaybeRelocatable::RelocatableValue;
 use crate::vm::context::run_context::RunContext;
 use crate::vm::decoding::decoder::decode_instruction;
 use crate::vm::errors::runner_errors::RunnerError;
@@ -427,11 +428,17 @@ impl VirtualMachine {
         self.opcode_assertions(&instruction, &operands)?;
 
         if let Some(ref mut trace) = &mut self.trace {
-            trace.push(TraceEntry {
-                pc: self.run_context.pc.clone(),
-                ap: self.run_context.ap.clone(),
-                fp: self.run_context.fp.clone(),
-            });
+            if let (RelocatableValue(ref pc), RelocatableValue(ref ap), RelocatableValue(ref fp)) = (
+                &self.run_context.pc,
+                &self.run_context.ap,
+                &self.run_context.fp,
+            ) {
+                trace.push(TraceEntry {
+                    pc: pc.clone(),
+                    ap: ap.clone(),
+                    fp: fp.clone(),
+                });
+            }
         }
 
         if let Some(ref mut accessed_addresses) = self.accessed_addresses {
@@ -2488,9 +2495,18 @@ mod tests {
         assert_eq!(
             trace[0],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 0)),
-                fp: MaybeRelocatable::from((1, 2)),
-                ap: MaybeRelocatable::from((1, 2))
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 0
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 2
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 2
+                }
             }
         );
         assert_eq!(vm.run_context.pc, MaybeRelocatable::from((3, 0)));
@@ -2631,41 +2647,86 @@ mod tests {
         assert_eq!(
             trace[0],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 3)),
-                ap: MaybeRelocatable::from((1, 2)),
-                fp: MaybeRelocatable::from((1, 2)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 3
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 2
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 2
+                },
             }
         );
         assert_eq!(
             trace[1],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 5)),
-                ap: MaybeRelocatable::from((1, 3)),
-                fp: MaybeRelocatable::from((1, 2)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 5
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 3
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 2
+                },
             }
         );
         assert_eq!(
             trace[2],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 0)),
-                ap: MaybeRelocatable::from((1, 5)),
-                fp: MaybeRelocatable::from((1, 5)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 0
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 5
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 5
+                },
             }
         );
         assert_eq!(
             trace[3],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 2)),
-                ap: MaybeRelocatable::from((1, 6)),
-                fp: MaybeRelocatable::from((1, 5)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 2
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 6
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 5
+                },
             }
         );
         assert_eq!(
             trace[4],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 7)),
-                ap: MaybeRelocatable::from((1, 6)),
-                fp: MaybeRelocatable::from((1, 2)),
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 7
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 6
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 2
+                },
             }
         );
         //Check accessed_addresses
@@ -3601,49 +3662,103 @@ mod tests {
         assert_eq!(
             trace[0],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 3)),
-                fp: MaybeRelocatable::from((1, 2)),
-                ap: MaybeRelocatable::from((1, 2))
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 3
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 2
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 2
+                }
             }
         );
         assert_eq!(
             trace[1],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 0)),
-                fp: MaybeRelocatable::from((1, 4)),
-                ap: MaybeRelocatable::from((1, 4))
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 0
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 4
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 4
+                }
             }
         );
         assert_eq!(
             trace[2],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 2)),
-                fp: MaybeRelocatable::from((1, 4)),
-                ap: MaybeRelocatable::from((1, 5))
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 2
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 4
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 5
+                }
             }
         );
         assert_eq!(
             trace[3],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 5)),
-                fp: MaybeRelocatable::from((1, 2)),
-                ap: MaybeRelocatable::from((1, 5))
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 5
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 2
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 5
+                }
             }
         );
         assert_eq!(
             trace[4],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 7)),
-                fp: MaybeRelocatable::from((1, 2)),
-                ap: MaybeRelocatable::from((1, 6))
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 7
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 2
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 6
+                }
             }
         );
         assert_eq!(
             trace[5],
             TraceEntry {
-                pc: MaybeRelocatable::from((0, 8)),
-                fp: MaybeRelocatable::from((1, 2)),
-                ap: MaybeRelocatable::from((1, 6))
+                pc: Relocatable {
+                    segment_index: 0,
+                    offset: 8
+                },
+                fp: Relocatable {
+                    segment_index: 1,
+                    offset: 2
+                },
+                ap: Relocatable {
+                    segment_index: 1,
+                    offset: 6
+                }
             }
         );
 


### PR DESCRIPTION
## Description

First, some background. In Cairo:
- Registers are always pointers.
- Pointers are always `Relocatable` values.
- `Relocatable` values are simply a pair of machine integers (currently `usize`).
- `MaybeRelocatable` values need to be able to fit either of `Relocatable` or `Int` values (currently `num-bigint::BigInt`, a vector and a sign).
- Traces store the registers only.
- We currently store them as `MaybeRelocatable`.

This means we can cut memory for traces in half by just using `Relocatable` directly.
Benchmarks with trace enabled improve 2-3% in run time.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
