### PR TITLE
Add get_output helper

### DIFF
--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -1,5 +1,5 @@
 use crate::types::program::Program;
-use crate::vm::errors::cairo_run_errors::CairoRunError;
+use crate::vm::errors::{cairo_run_errors::CairoRunError, runner_errors::RunnerError};
 use crate::vm::runners::cairo_runner::CairoRunner;
 use crate::vm::trace::trace_entry::RelocatedTraceEntry;
 use num_bigint::BigInt;
@@ -41,10 +41,12 @@ pub fn cairo_run(path: &Path, trace_enabled: bool) -> Result<CairoRunner, CairoR
 }
 
 pub fn write_output(cairo_runner: &mut CairoRunner) -> Result<(), CairoRunError> {
-    if let Err(error) = cairo_runner.write_output(&mut io::stdout()) {
-        return Err(CairoRunError::Runner(error));
-    }
-    Ok(())
+    let stdout = &mut io::stdout();
+    writeln!(stdout, "Program Output: ")
+        .map_err(|_| CairoRunError::Runner(RunnerError::WriteFail))?;
+    cairo_runner
+        .write_output(stdout)
+        .map_err(CairoRunError::Runner)
 }
 
 /// Writes a trace as a binary file. Bincode encodes to little endian by default and each trace

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -360,6 +360,13 @@ impl CairoRunner {
         Ok(())
     }
 
+    pub fn get_output(&mut self) -> Result<Option<String>, RunnerError> {
+        let mut output = Vec::<u8>::new();
+        self.write_output(&mut output)?;
+        let output = String::from_utf8(output).map_err(|_| RunnerError::FailedStringConversion)?;
+        Ok(Some(output))
+    }
+
     ///Writes the values hosted in the output builtin's segment
     /// Does nothing if the output builtin is not present in the program
     pub fn write_output(&mut self, stdout: &mut dyn io::Write) -> Result<(), RunnerError> {
@@ -372,11 +379,6 @@ impl CairoRunner {
                 Some(base) => base,
                 None => return Err(RunnerError::UninitializedBase),
             };
-
-            let write_result = writeln!(stdout, "Program Output: ");
-            if write_result.is_err() {
-                return Err(RunnerError::WriteFail);
-            }
 
             // After this if block,
             // segment_used_sizes is always Some(_)
@@ -2940,10 +2942,7 @@ mod tests {
         cairo_runner.vm.segments.segment_used_sizes = Some(vec![0, 0, 2]);
         let mut stdout = Vec::<u8>::new();
         cairo_runner.write_output(&mut stdout).unwrap();
-        assert_eq!(
-            String::from_utf8(stdout),
-            Ok(String::from("Program Output: \n1\n2\n"))
-        );
+        assert_eq!(String::from_utf8(stdout), Ok(String::from("1\n2\n")));
     }
 
     #[test]
@@ -2996,10 +2995,7 @@ mod tests {
         assert_eq!(cairo_runner.run_until_pc(end), Ok(()));
         let mut stdout = Vec::<u8>::new();
         cairo_runner.write_output(&mut stdout).unwrap();
-        assert_eq!(
-            String::from_utf8(stdout),
-            Ok(String::from("Program Output: \n1\n17\n"))
-        );
+        assert_eq!(String::from_utf8(stdout), Ok(String::from("1\n17\n")));
     }
 
     #[test]
@@ -3038,7 +3034,9 @@ mod tests {
         cairo_runner.write_output(&mut stdout).unwrap();
         assert_eq!(
             String::from_utf8(stdout),
-            Ok(String::from("Program Output: \n-347635731488942605882605540010235804344383682379185578591125677225688681570\n"))
+            Ok(String::from(
+                "-347635731488942605882605540010235804344383682379185578591125677225688681570\n"
+            ))
         );
     }
 


### PR DESCRIPTION
## Description

Refactor `write_output` to separate the 'Program output:' line and introduce a `get_output` function returning a string calling `write_output`. Requested by and based on PR by @tdelabro.

Co-authored-by: @tdelabro 

Should supersede #215 