### PR TITLE
Add support for ap tracking

### DIFF
--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -50,6 +50,12 @@ impl ApTracking {
     }
 }
 
+impl Default for ApTracking {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Deserialize, Debug)]
 pub struct Identifier {
     pub pc: Option<usize>,

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -41,6 +41,15 @@ pub struct ApTracking {
     pub offset: usize,
 }
 
+impl ApTracking {
+    pub fn new() -> ApTracking {
+        ApTracking {
+            group: 0,
+            offset: 0,
+        }
+    }
+}
+
 #[derive(Deserialize, Debug)]
 pub struct Identifier {
     pub pc: Option<usize>,

--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -53,6 +53,9 @@ pub enum VirtualMachineError {
     FailedToGetSqrt(BigInt),
     AssertNotZero(BigInt, BigInt),
     AssertLtFelt(BigInt, BigInt),
+    NoneApTrackingData,
+    InvalidTrackingGroup(usize, usize),
+    InvalidApValue(MaybeRelocatable),
 }
 
 impl fmt::Display for VirtualMachineError {
@@ -153,6 +156,15 @@ impl fmt::Display for VirtualMachineError {
             VirtualMachineError::AssertLtFelt(a, b) => {
                 write!(f, "Assertion failed, a = {} % PRIME is not less than b = {} % PRIME", a, b)
 
+            },
+            VirtualMachineError::NoneApTrackingData => {
+                write!(f, "AP tracking data is None; could not apply correction to address")
+            },
+            VirtualMachineError::InvalidTrackingGroup(group1, group2) => {
+                write!(f, "Tracking groups should be the same, got {} and {}", group1, group2)
+            },
+            VirtualMachineError::InvalidApValue(addr) => {
+                write!(f, "Expected relocatable for ap, got {:?}", addr)
             },
         }
     }

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -25,7 +25,7 @@ pub fn execute_hint(
     vm: &mut VirtualMachine,
     hint_code: &[u8],
     ids: HashMap<String, BigInt>,
-    _ap_tracking: &ApTracking,
+    ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
     match std::str::from_utf8(hint_code) {
         Ok("memory[ap] = segments.add()") => add_segment(vm),
@@ -39,7 +39,7 @@ pub fn execute_hint(
         Ok("from starkware.cairo.common.math_utils import as_int\n\n# Correctness check.\nvalue = as_int(ids.value, PRIME) % PRIME\nassert value < ids.UPPER_BOUND, f'{value} is outside of the range [0, 2**250).'\n\n# Calculation for the assertion.\nids.high, ids.low = divmod(ids.value, ids.SHIFT)",
         ) => assert_250_bit(vm, ids, None),
         Ok("from starkware.cairo.common.math_utils import is_positive\nids.is_positive = 1 if is_positive(\n    value=ids.value, prime=PRIME, rc_bound=range_check_builtin.bound) else 0"
-        ) => is_positive(vm, ids, None),
+        ) => is_positive(vm, ids, Some(ap_tracking)),
         Ok("assert ids.value == 0, 'split_int(): value is out of range.'"
         ) => split_int_assert_range(vm, ids, None),
         Ok("memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base\nassert res < ids.bound, f'split_int(): Limb {res} is out of range.'"

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -1,6 +1,7 @@
 use crate::bigint;
 use crate::math_utils::as_int;
 use crate::math_utils::isqrt;
+use crate::serde::deserialize_program::ApTracking;
 use crate::types::{instruction::Register, relocatable::MaybeRelocatable};
 use crate::vm::{
     context::run_context::RunContext, errors::vm_errors::VirtualMachineError,
@@ -13,29 +14,64 @@ use num_traits::{FromPrimitive, Signed, ToPrimitive, Zero};
 use std::collections::HashMap;
 use std::ops::{Neg, Shl, Shr};
 
+fn apply_ap_tracking_correction(
+    ap: MaybeRelocatable,
+    ref_ap_tracking: Option<&ApTracking>,
+    hint_ap_tracking: Option<&ApTracking>,
+) -> Result<MaybeRelocatable, VirtualMachineError> {
+    if let (Some(ref_tracking_data), Some(hint_tracking_data)) = (ref_ap_tracking, hint_ap_tracking)
+    {
+        // check that both groups are the same
+        if ref_tracking_data.group != hint_tracking_data.group {
+            return Err(VirtualMachineError::InvalidTrackingGroup(
+                ref_tracking_data.group,
+                hint_tracking_data.group,
+            ));
+        }
+        if let MaybeRelocatable::RelocatableValue(relocatable) = ap {
+            let ap_diff = hint_tracking_data.group - ref_tracking_data.group;
+
+            return Ok(MaybeRelocatable::from((
+                relocatable.segment_index,
+                relocatable.offset - ap_diff,
+            )));
+        } else {
+            return Err(VirtualMachineError::InvalidApValue(ap));
+        }
+    } else {
+        return Err(VirtualMachineError::NoneApTrackingData);
+    }
+}
+
 ///Computes the memory address indicated by the HintReference
 fn compute_addr_from_reference(
     hint_reference: &HintReference,
     run_context: &RunContext,
     vm: &VirtualMachine,
-) -> Option<MaybeRelocatable> {
-    let register = match hint_reference.register {
+    hint_ap_tracking: Option<&ApTracking>,
+) -> Result<Option<MaybeRelocatable>, VirtualMachineError> {
+    let base_addr = match hint_reference.register {
         Register::FP => run_context.fp.clone(),
-        Register::AP => run_context.ap.clone(),
+        // Register::AP => run_context.ap.clone(),
+        Register::AP => apply_ap_tracking_correction(
+            run_context.ap.clone(),
+            hint_reference.ap_tracking_data.as_ref(),
+            hint_ap_tracking,
+        )?,
     };
 
-    if let MaybeRelocatable::RelocatableValue(relocatable) = register {
+    if let MaybeRelocatable::RelocatableValue(relocatable) = base_addr {
         if hint_reference.offset1.is_negative()
             && relocatable.offset < hint_reference.offset1.abs() as usize
         {
-            return None;
+            return Ok(None);
         }
         if !hint_reference.inner_dereference {
-            return Some(MaybeRelocatable::from((
+            return Ok(Some(MaybeRelocatable::from((
                 relocatable.segment_index,
                 (relocatable.offset as i32 + hint_reference.offset1 + hint_reference.offset2)
                     as usize,
-            )));
+            ))));
         } else {
             let addr = MaybeRelocatable::from((
                 relocatable.segment_index,
@@ -44,18 +80,18 @@ fn compute_addr_from_reference(
 
             match vm.memory.get(&addr) {
                 Ok(Some(&MaybeRelocatable::RelocatableValue(ref dereferenced_addr))) => {
-                    return Some(MaybeRelocatable::from((
+                    return Ok(Some(MaybeRelocatable::from((
                         dereferenced_addr.segment_index,
                         (dereferenced_addr.offset as i32 + hint_reference.offset2) as usize,
-                    )))
+                    ))))
                 }
 
-                _none_or_error => return None,
+                _none_or_error => return Ok(None),
             }
         }
     }
 
-    None
+    Ok(None)
 }
 
 ///Computes the memory address given by the reference id
@@ -64,15 +100,21 @@ fn get_address_from_reference(
     references: &HashMap<usize, HintReference>,
     run_context: &RunContext,
     vm: &VirtualMachine,
-) -> Option<MaybeRelocatable> {
+    hint_ap_tracking: Option<&ApTracking>,
+) -> Result<Option<MaybeRelocatable>, VirtualMachineError> {
     if let Some(index) = reference_id.to_usize() {
         if index < references.len() {
             if let Some(hint_reference) = references.get(&index) {
-                return compute_addr_from_reference(hint_reference, run_context, vm);
+                return compute_addr_from_reference(
+                    hint_reference,
+                    run_context,
+                    vm,
+                    hint_ap_tracking,
+                );
             }
         }
     }
-    None
+    Ok(None)
 }
 
 ///Implements hint: memory[ap] = segments.add()
@@ -89,6 +131,7 @@ pub fn add_segment(vm: &mut VirtualMachine) -> Result<(), VirtualMachineError> {
 pub fn is_nn(
     vm: &mut VirtualMachine,
     ids: HashMap<String, BigInt>,
+    hint_ap_tracking: Option<ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
     let a_ref = if let Some(a_ref) = ids.get(&String::from("a")) {
@@ -100,9 +143,13 @@ pub fn is_nn(
         ));
     };
     //Check that each reference id corresponds to a value in the reference manager
-    let a_addr = if let Some(a_addr) =
-        get_address_from_reference(a_ref, &vm.references, &vm.run_context, vm)
-    {
+    let a_addr = if let Ok(Some(a_addr)) = get_address_from_reference(
+        a_ref,
+        &vm.references,
+        &vm.run_context,
+        vm,
+        hint_ap_tracking.as_ref(),
+    ) {
         a_addr
     } else {
         return Err(VirtualMachineError::FailedToGetReference(a_ref.clone()));
@@ -154,6 +201,7 @@ pub fn is_nn(
 pub fn is_nn_out_of_range(
     vm: &mut VirtualMachine,
     ids: HashMap<String, BigInt>,
+    hint_ap_tracking: Option<ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
     let a_ref = if let Some(a_ref) = ids.get(&String::from("a")) {
@@ -165,9 +213,13 @@ pub fn is_nn_out_of_range(
         ));
     };
     //Check that each reference id corresponds to a value in the reference manager
-    let a_addr = if let Some(a_addr) =
-        get_address_from_reference(a_ref, &vm.references, &vm.run_context, vm)
-    {
+    let a_addr = if let Ok(Some(a_addr)) = get_address_from_reference(
+        a_ref,
+        &vm.references,
+        &vm.run_context,
+        vm,
+        hint_ap_tracking.as_ref(),
+    ) {
         a_addr
     } else {
         return Err(VirtualMachineError::FailedToGetReference(a_ref.clone()));
@@ -226,6 +278,7 @@ pub fn is_nn_out_of_range(
 pub fn assert_le_felt(
     vm: &mut VirtualMachine,
     ids: HashMap<String, BigInt>,
+    hint_ap_tracking: Option<ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
     let (a_ref, b_ref, small_inputs_ref) =
@@ -247,10 +300,28 @@ pub fn assert_le_felt(
         };
     //Check that each reference id corresponds to a value in the reference manager
     let (a_addr, b_addr, small_inputs_addr) =
-        if let (Some(a_addr), Some(b_addr), Some(small_inputs_addr)) = (
-            get_address_from_reference(a_ref, &vm.references, &vm.run_context, vm),
-            get_address_from_reference(b_ref, &vm.references, &vm.run_context, vm),
-            get_address_from_reference(small_inputs_ref, &vm.references, &vm.run_context, vm),
+        if let (Ok(Some(a_addr)), Ok(Some(b_addr)), Ok(Some(small_inputs_addr))) = (
+            get_address_from_reference(
+                a_ref,
+                &vm.references,
+                &vm.run_context,
+                vm,
+                hint_ap_tracking.as_ref(),
+            ),
+            get_address_from_reference(
+                b_ref,
+                &vm.references,
+                &vm.run_context,
+                vm,
+                hint_ap_tracking.as_ref(),
+            ),
+            get_address_from_reference(
+                small_inputs_ref,
+                &vm.references,
+                &vm.run_context,
+                vm,
+                hint_ap_tracking.as_ref(),
+            ),
         ) {
             (a_addr, b_addr, small_inputs_addr)
         } else {
@@ -315,6 +386,7 @@ pub fn assert_le_felt(
 pub fn is_le_felt(
     vm: &mut VirtualMachine,
     ids: HashMap<String, BigInt>,
+    hint_ap_tracking: Option<ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
     let (a_ref, b_ref) = if let (Some(a_ref), Some(b_ref)) =
@@ -328,9 +400,21 @@ pub fn is_le_felt(
         ));
     };
     //Check that each reference id corresponds to a value in the reference manager
-    let (a_addr, b_addr) = if let (Some(a_addr), Some(b_addr)) = (
-        get_address_from_reference(a_ref, &vm.references, &vm.run_context, vm),
-        get_address_from_reference(b_ref, &vm.references, &vm.run_context, vm),
+    let (a_addr, b_addr) = if let (Ok(Some(a_addr)), Ok(Some(b_addr))) = (
+        get_address_from_reference(
+            a_ref,
+            &vm.references,
+            &vm.run_context,
+            vm,
+            hint_ap_tracking.as_ref(),
+        ),
+        get_address_from_reference(
+            b_ref,
+            &vm.references,
+            &vm.run_context,
+            vm,
+            hint_ap_tracking.as_ref(),
+        ),
     ) {
         (a_addr, b_addr)
     } else {
@@ -388,6 +472,7 @@ pub fn is_le_felt(
 pub fn assert_not_equal(
     vm: &mut VirtualMachine,
     ids: HashMap<String, BigInt>,
+    hint_ap_tracking: Option<ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
     let (a_ref, b_ref) = if let (Some(a_ref), Some(b_ref)) =
@@ -401,9 +486,21 @@ pub fn assert_not_equal(
         ));
     };
     //Check that each reference id corresponds to a value in the reference manager
-    let (a_addr, b_addr) = if let (Some(a_addr), Some(b_addr)) = (
-        get_address_from_reference(a_ref, &vm.references, &vm.run_context, vm),
-        get_address_from_reference(b_ref, &vm.references, &vm.run_context, vm),
+    let (a_addr, b_addr) = if let (Ok(Some(a_addr)), Ok(Some(b_addr))) = (
+        get_address_from_reference(
+            a_ref,
+            &vm.references,
+            &vm.run_context,
+            vm,
+            hint_ap_tracking.as_ref(),
+        ),
+        get_address_from_reference(
+            b_ref,
+            &vm.references,
+            &vm.run_context,
+            vm,
+            hint_ap_tracking.as_ref(),
+        ),
     ) {
         (a_addr, b_addr)
     } else {
@@ -451,6 +548,7 @@ pub fn assert_not_equal(
 pub fn assert_nn(
     vm: &mut VirtualMachine,
     ids: HashMap<String, BigInt>,
+    hint_ap_tracking: Option<ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for 'a' variable used by the hint
     let a_ref = if let Some(a_ref) = ids.get(&String::from("a")) {
@@ -462,9 +560,13 @@ pub fn assert_nn(
         ));
     };
     //Check that 'a' reference id corresponds to a value in the reference manager
-    let a_addr = if let Some(a_addr) =
-        get_address_from_reference(a_ref, &vm.references, &vm.run_context, vm)
-    {
+    let a_addr = if let Ok(Some(a_addr)) = get_address_from_reference(
+        a_ref,
+        &vm.references,
+        &vm.run_context,
+        vm,
+        hint_ap_tracking.as_ref(),
+    ) {
         a_addr
     } else {
         return Err(VirtualMachineError::FailedToGetIds);
@@ -515,6 +617,7 @@ pub fn assert_nn(
 pub fn assert_not_zero(
     vm: &mut VirtualMachine,
     ids: HashMap<String, BigInt>,
+    hint_ap_tracking: Option<ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let value_ref = if let Some(value_ref) = ids.get(&String::from("value")) {
         value_ref
@@ -525,9 +628,13 @@ pub fn assert_not_zero(
         ));
     };
     //Check that each reference id corresponds to a value in the reference manager
-    let value_addr = if let Some(value_addr) =
-        get_address_from_reference(value_ref, &vm.references, &vm.run_context, vm)
-    {
+    let value_addr = if let Ok(Some(value_addr)) = get_address_from_reference(
+        value_ref,
+        &vm.references,
+        &vm.run_context,
+        vm,
+        hint_ap_tracking.as_ref(),
+    ) {
         value_addr
     } else {
         return Err(VirtualMachineError::FailedToGetReference(value_ref.clone()));
@@ -556,6 +663,7 @@ pub fn assert_not_zero(
 pub fn split_int_assert_range(
     vm: &mut VirtualMachine,
     ids: HashMap<String, BigInt>,
+    hint_ap_tracking: Option<ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
     let value_ref = if let Some(value_ref) = ids.get(&String::from("value")) {
@@ -567,9 +675,13 @@ pub fn split_int_assert_range(
         ));
     };
     //Check that each reference id corresponds to a value in the reference manager
-    let value_addr = if let Some(value_addr) =
-        get_address_from_reference(value_ref, &vm.references, &vm.run_context, vm)
-    {
+    let value_addr = if let Ok(Some(value_addr)) = get_address_from_reference(
+        value_ref,
+        &vm.references,
+        &vm.run_context,
+        vm,
+        hint_ap_tracking.as_ref(),
+    ) {
         value_addr
     } else {
         return Err(VirtualMachineError::FailedToGetReference(value_ref.clone()));
@@ -599,6 +711,7 @@ pub fn split_int_assert_range(
 pub fn split_int(
     vm: &mut VirtualMachine,
     ids: HashMap<String, BigInt>,
+    hint_ap_tracking: Option<ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
     let (output_ref, value_ref, base_ref, bound_ref) =
@@ -622,17 +735,45 @@ pub fn split_int(
         };
     //Check that the ids are in memory (except for small_inputs which is local, and should contain None)
     //small_inputs needs to be None, as we cant change it value otherwise
-    let (output_addr, value_addr, base_addr, bound_addr) =
-        if let (Some(output_addr), Some(value_addr), Some(base_addr), Some(bound_addr)) = (
-            get_address_from_reference(output_ref, &vm.references, &vm.run_context, vm),
-            get_address_from_reference(value_ref, &vm.references, &vm.run_context, vm),
-            get_address_from_reference(base_ref, &vm.references, &vm.run_context, vm),
-            get_address_from_reference(bound_ref, &vm.references, &vm.run_context, vm),
-        ) {
-            (output_addr, value_addr, base_addr, bound_addr)
-        } else {
-            return Err(VirtualMachineError::FailedToGetIds);
-        };
+    let (output_addr, value_addr, base_addr, bound_addr) = if let (
+        Ok(Some(output_addr)),
+        Ok(Some(value_addr)),
+        Ok(Some(base_addr)),
+        Ok(Some(bound_addr)),
+    ) = (
+        get_address_from_reference(
+            output_ref,
+            &vm.references,
+            &vm.run_context,
+            vm,
+            hint_ap_tracking.as_ref(),
+        ),
+        get_address_from_reference(
+            value_ref,
+            &vm.references,
+            &vm.run_context,
+            vm,
+            hint_ap_tracking.as_ref(),
+        ),
+        get_address_from_reference(
+            base_ref,
+            &vm.references,
+            &vm.run_context,
+            vm,
+            hint_ap_tracking.as_ref(),
+        ),
+        get_address_from_reference(
+            bound_ref,
+            &vm.references,
+            &vm.run_context,
+            vm,
+            hint_ap_tracking.as_ref(),
+        ),
+    ) {
+        (output_addr, value_addr, base_addr, bound_addr)
+    } else {
+        return Err(VirtualMachineError::FailedToGetIds);
+    };
     //Check that the ids are in memory
     let (mr_output, mr_value, mr_base, mr_bound) =
         if let (Ok(Some(mr_output)), Ok(Some(mr_value)), Ok(Some(mr_base)), Ok(Some(mr_bound))) = (
@@ -674,6 +815,7 @@ pub fn split_int(
 pub fn is_positive(
     vm: &mut VirtualMachine,
     ids: HashMap<String, BigInt>,
+    hint_ap_tracking: Option<ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
     let (value_ref, is_positive_ref) = if let (Some(value_ref), Some(is_positive_ref)) = (
@@ -688,9 +830,21 @@ pub fn is_positive(
         ));
     };
     //Check that each reference id corresponds to a value in the reference manager
-    let (value_addr, is_positive_addr) = if let (Some(value_addr), Some(is_positive_addr)) = (
-        get_address_from_reference(value_ref, &vm.references, &vm.run_context, vm),
-        get_address_from_reference(is_positive_ref, &vm.references, &vm.run_context, vm),
+    let (value_addr, is_positive_addr) = if let (Ok(Some(value_addr)), Ok(Some(is_positive_addr))) = (
+        get_address_from_reference(
+            value_ref,
+            &vm.references,
+            &vm.run_context,
+            vm,
+            hint_ap_tracking.as_ref(),
+        ),
+        get_address_from_reference(
+            is_positive_ref,
+            &vm.references,
+            &vm.run_context,
+            vm,
+            hint_ap_tracking.as_ref(),
+        ),
     ) {
         (value_addr, is_positive_addr)
     } else {
@@ -752,6 +906,7 @@ pub fn is_positive(
 pub fn split_felt(
     vm: &mut VirtualMachine,
     ids: HashMap<String, BigInt>,
+    hint_ap_tracking: Option<ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for the variables used by the hint
     let (high_ref, low_ref, value_ref) = if let (Some(high_ref), Some(low_ref), Some(value_ref)) = (
@@ -773,10 +928,28 @@ pub fn split_felt(
 
     // Get the addresses of the variables used in the hints
     let (high_addr, low_addr, value_addr) =
-        if let (Some(high_addr), Some(low_addr), Some(value_addr)) = (
-            get_address_from_reference(high_ref, &vm.references, &vm.run_context, vm),
-            get_address_from_reference(low_ref, &vm.references, &vm.run_context, vm),
-            get_address_from_reference(value_ref, &vm.references, &vm.run_context, vm),
+        if let (Ok(Some(high_addr)), Ok(Some(low_addr)), Ok(Some(value_addr))) = (
+            get_address_from_reference(
+                high_ref,
+                &vm.references,
+                &vm.run_context,
+                vm,
+                hint_ap_tracking.as_ref(),
+            ),
+            get_address_from_reference(
+                low_ref,
+                &vm.references,
+                &vm.run_context,
+                vm,
+                hint_ap_tracking.as_ref(),
+            ),
+            get_address_from_reference(
+                value_ref,
+                &vm.references,
+                &vm.run_context,
+                vm,
+                hint_ap_tracking.as_ref(),
+            ),
         ) {
             (high_addr, low_addr, value_addr)
         } else {
@@ -815,6 +988,7 @@ pub fn split_felt(
 pub fn sqrt(
     vm: &mut VirtualMachine,
     ids: HashMap<String, BigInt>,
+    hint_ap_tracking: Option<ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
     let (value_ref, root_ref) = if let (Some(value_ref), Some(root_ref)) = (
@@ -829,9 +1003,21 @@ pub fn sqrt(
         ));
     };
     //Check that each reference id corresponds to a value in the reference manager
-    let (value_addr, root_addr) = if let (Some(value_addr), Some(root_addr)) = (
-        get_address_from_reference(value_ref, &vm.references, &vm.run_context, vm),
-        get_address_from_reference(root_ref, &vm.references, &vm.run_context, vm),
+    let (value_addr, root_addr) = if let (Ok(Some(value_addr)), Ok(Some(root_addr))) = (
+        get_address_from_reference(
+            value_ref,
+            &vm.references,
+            &vm.run_context,
+            vm,
+            hint_ap_tracking.as_ref(),
+        ),
+        get_address_from_reference(
+            root_ref,
+            &vm.references,
+            &vm.run_context,
+            vm,
+            hint_ap_tracking.as_ref(),
+        ),
     ) {
         (value_addr, root_addr)
     } else {
@@ -863,6 +1049,7 @@ pub fn sqrt(
 pub fn signed_div_rem(
     vm: &mut VirtualMachine,
     ids: HashMap<String, BigInt>,
+    hint_ap_tracking: Option<ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
     let (r_ref, biased_q_ref, range_check_ptr_ref, div_ref, value_ref, bound_ref) = if let (
@@ -903,19 +1090,55 @@ pub fn signed_div_rem(
     };
     //Check that each reference id corresponds to a value in the reference manager
     let (r_addr, biased_q_addr, range_check_ptr_addr, div_addr, value_addr, bound_addr) = if let (
-        Some(r_addr),
-        Some(biased_q_addr),
-        Some(range_check_ptr_addr),
-        Some(div_addr),
-        Some(value_addr),
-        Some(bound_addr),
+        Ok(Some(r_addr)),
+        Ok(Some(biased_q_addr)),
+        Ok(Some(range_check_ptr_addr)),
+        Ok(Some(div_addr)),
+        Ok(Some(value_addr)),
+        Ok(Some(bound_addr)),
     ) = (
-        get_address_from_reference(r_ref, &vm.references, &vm.run_context, vm),
-        get_address_from_reference(biased_q_ref, &vm.references, &vm.run_context, vm),
-        get_address_from_reference(range_check_ptr_ref, &vm.references, &vm.run_context, vm),
-        get_address_from_reference(div_ref, &vm.references, &vm.run_context, vm),
-        get_address_from_reference(value_ref, &vm.references, &vm.run_context, vm),
-        get_address_from_reference(bound_ref, &vm.references, &vm.run_context, vm),
+        get_address_from_reference(
+            r_ref,
+            &vm.references,
+            &vm.run_context,
+            vm,
+            hint_ap_tracking.as_ref(),
+        ),
+        get_address_from_reference(
+            biased_q_ref,
+            &vm.references,
+            &vm.run_context,
+            vm,
+            hint_ap_tracking.as_ref(),
+        ),
+        get_address_from_reference(
+            range_check_ptr_ref,
+            &vm.references,
+            &vm.run_context,
+            vm,
+            hint_ap_tracking.as_ref(),
+        ),
+        get_address_from_reference(
+            div_ref,
+            &vm.references,
+            &vm.run_context,
+            vm,
+            hint_ap_tracking.as_ref(),
+        ),
+        get_address_from_reference(
+            value_ref,
+            &vm.references,
+            &vm.run_context,
+            vm,
+            hint_ap_tracking.as_ref(),
+        ),
+        get_address_from_reference(
+            bound_ref,
+            &vm.references,
+            &vm.run_context,
+            vm,
+            hint_ap_tracking.as_ref(),
+        ),
     ) {
         (
             r_addr,
@@ -1033,6 +1256,7 @@ ids.q, ids.r = divmod(ids.value, ids.div)
 pub fn unsigned_div_rem(
     vm: &mut VirtualMachine,
     ids: HashMap<String, BigInt>,
+    hint_ap_tracking: Option<ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
     let (r_ref, q_ref, div_ref, value_ref) =
@@ -1056,11 +1280,35 @@ pub fn unsigned_div_rem(
         };
     //Check that each reference id corresponds to a value in the reference manager
     let (r_addr, q_addr, div_addr, value_addr) =
-        if let (Some(r_addr), Some(q_addr), Some(div_addr), Some(value_addr)) = (
-            get_address_from_reference(r_ref, &vm.references, &vm.run_context, vm),
-            get_address_from_reference(q_ref, &vm.references, &vm.run_context, vm),
-            get_address_from_reference(div_ref, &vm.references, &vm.run_context, vm),
-            get_address_from_reference(value_ref, &vm.references, &vm.run_context, vm),
+        if let (Ok(Some(r_addr)), Ok(Some(q_addr)), Ok(Some(div_addr)), Ok(Some(value_addr))) = (
+            get_address_from_reference(
+                r_ref,
+                &vm.references,
+                &vm.run_context,
+                vm,
+                hint_ap_tracking.as_ref(),
+            ),
+            get_address_from_reference(
+                q_ref,
+                &vm.references,
+                &vm.run_context,
+                vm,
+                hint_ap_tracking.as_ref(),
+            ),
+            get_address_from_reference(
+                div_ref,
+                &vm.references,
+                &vm.run_context,
+                vm,
+                hint_ap_tracking.as_ref(),
+            ),
+            get_address_from_reference(
+                value_ref,
+                &vm.references,
+                &vm.run_context,
+                vm,
+                hint_ap_tracking.as_ref(),
+            ),
         ) {
             (r_addr, q_addr, div_addr, value_addr)
         } else {
@@ -1129,6 +1377,7 @@ pub fn unsigned_div_rem(
 pub fn assert_250_bit(
     vm: &mut VirtualMachine,
     ids: HashMap<String, BigInt>,
+    hint_ap_tracking: Option<ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Declare constant values
     let upper_bound = bigint!(1).shl(250_i32);
@@ -1152,10 +1401,28 @@ pub fn assert_250_bit(
     };
     //Check that each reference id corresponds to a value in the reference manager
     let (value_addr, high_addr, low_addr) =
-        if let (Some(value_addr), Some(high_addr), Some(low_addr)) = (
-            get_address_from_reference(value_ref, &vm.references, &vm.run_context, vm),
-            get_address_from_reference(high_ref, &vm.references, &vm.run_context, vm),
-            get_address_from_reference(low_ref, &vm.references, &vm.run_context, vm),
+        if let (Ok(Some(value_addr)), Ok(Some(high_addr)), Ok(Some(low_addr))) = (
+            get_address_from_reference(
+                value_ref,
+                &vm.references,
+                &vm.run_context,
+                vm,
+                hint_ap_tracking.as_ref(),
+            ),
+            get_address_from_reference(
+                high_ref,
+                &vm.references,
+                &vm.run_context,
+                vm,
+                hint_ap_tracking.as_ref(),
+            ),
+            get_address_from_reference(
+                low_ref,
+                &vm.references,
+                &vm.run_context,
+                vm,
+                hint_ap_tracking.as_ref(),
+            ),
         ) {
             (value_addr, high_addr, low_addr)
         } else {
@@ -1204,6 +1471,7 @@ Implements hint:
 pub fn assert_lt_felt(
     vm: &mut VirtualMachine,
     ids: HashMap<String, BigInt>,
+    hint_ap_tracking: Option<ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
     let (a_ref, b_ref) = if let (Some(a_ref), Some(b_ref)) =
@@ -1217,9 +1485,21 @@ pub fn assert_lt_felt(
         ));
     };
     //Check that each reference id corresponds to a value in the reference manager
-    let (a_addr, b_addr) = if let (Some(a_addr), Some(b_addr)) = (
-        get_address_from_reference(a_ref, &vm.references, &vm.run_context, vm),
-        get_address_from_reference(b_ref, &vm.references, &vm.run_context, vm),
+    let (a_addr, b_addr) = if let (Ok(Some(a_addr)), Ok(Some(b_addr))) = (
+        get_address_from_reference(
+            a_ref,
+            &vm.references,
+            &vm.run_context,
+            vm,
+            hint_ap_tracking.as_ref(),
+        ),
+        get_address_from_reference(
+            b_ref,
+            &vm.references,
+            &vm.run_context,
+            vm,
+            hint_ap_tracking.as_ref(),
+        ),
     ) {
         (a_addr, b_addr)
     } else {

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -29,7 +29,7 @@ fn apply_ap_tracking_correction(
             ));
         }
         if let MaybeRelocatable::RelocatableValue(relocatable) = ap {
-            let ap_diff = hint_tracking_data.group - ref_tracking_data.group;
+            let ap_diff = hint_tracking_data.offset - ref_tracking_data.offset;
 
             Ok(MaybeRelocatable::from((
                 relocatable.segment_index,

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -1,4 +1,5 @@
 use crate::bigint;
+use crate::types::instruction::Register;
 use crate::types::program::Program;
 use crate::types::relocatable::{relocate_value, MaybeRelocatable, Relocatable};
 use crate::utils::{is_subsequence, to_field_element};
@@ -235,6 +236,12 @@ impl CairoRunner {
                         offset1: reference.value_address.offset1,
                         offset2: reference.value_address.offset2,
                         inner_dereference: reference.value_address.inner_dereference,
+                        // only store `ap` tracking data if the reference is referred to it
+                        ap_tracking_data: if register == &Register::FP {
+                            None
+                        } else {
+                            Some(reference.ap_tracking_data.clone())
+                        },
                     },
                 );
             }
@@ -254,6 +261,7 @@ impl CairoRunner {
                     hint_list.push(HintData::new(
                         hint_data.code.clone(),
                         hint_data.flow_tracking_data.reference_ids.clone(),
+                        hint_data.flow_tracking_data.ap_tracking.clone(),
                     ));
                 } else {
                     //Insert the first hint at a given pc
@@ -264,6 +272,7 @@ impl CairoRunner {
                             CairoRunner::remove_path_from_reference_ids(
                                 &hint_data.flow_tracking_data.reference_ids,
                             )?,
+                            hint_data.flow_tracking_data.ap_tracking.clone(),
                         )],
                     );
                 }

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -1,4 +1,5 @@
 use crate::bigint;
+use crate::serde::deserialize_program::ApTracking;
 use crate::types::exec_scope::ExecutionScopes;
 use crate::types::instruction::{ApUpdate, FpUpdate, Instruction, Opcode, PcUpdate, Res};
 use crate::types::relocatable::MaybeRelocatable;
@@ -33,6 +34,7 @@ pub struct HintData {
     pub hint_code: Vec<u8>,
     //Maps the name of the variable to its reference id
     pub ids: HashMap<String, BigInt>,
+    pub ap_tracking_data: ApTracking,
 }
 pub struct VirtualMachine {
     pub run_context: RunContext,
@@ -62,8 +64,16 @@ pub struct VirtualMachine {
 }
 
 impl HintData {
-    pub fn new(hint_code: Vec<u8>, ids: HashMap<String, BigInt>) -> HintData {
-        HintData { hint_code, ids }
+    pub fn new(
+        hint_code: Vec<u8>,
+        ids: HashMap<String, BigInt>,
+        ap_tracking_data: ApTracking,
+    ) -> HintData {
+        HintData {
+            hint_code,
+            ids,
+            ap_tracking_data,
+        }
     }
 }
 
@@ -470,7 +480,12 @@ impl VirtualMachine {
     pub fn step(&mut self) -> Result<(), VirtualMachineError> {
         if let Some(hint_list) = self.hints.get(&self.run_context.pc) {
             for hint_data in hint_list.clone().iter() {
-                execute_hint(self, &hint_data.hint_code, hint_data.ids.clone())?
+                execute_hint(
+                    self,
+                    &hint_data.hint_code,
+                    hint_data.ids.clone(),
+                    &hint_data.ap_tracking_data,
+                )?
             }
         }
         self.skip_instruction_execution = false;
@@ -3511,6 +3526,7 @@ mod tests {
             vec![HintData::new(
                 "memory[ap] = segments.add()".as_bytes().to_vec(),
                 HashMap::new(),
+                ApTracking::new(),
             )],
         );
 


### PR DESCRIPTION
# Add support for ap tracking

## Description

Some references are referenced respect to `ap`, which can change while the program is executing. AP tracking data from the compiled program json is used for adjusting the value of the reference. This PR adds support for these cases.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
