### PR TITLE
Properly compare runs with Hyperfine

### DIFF
--- a/bench/run_benchmarks.sh
+++ b/bench/run_benchmarks.sh
@@ -2,28 +2,14 @@
 tests_path="../cairo_programs/benchmarks"
 
 set -e
-echo "Cleaning old results"
-rm -f results
 
 for file in $(ls $tests_path | grep .cairo | sed -E 's/\.cairo//'); do
     echo "Running $file benchmark"
-    echo "\n*** $file.cairo times ***" >> results
 
     export PATH="$(pyenv root)/shims:$PATH"
 
-    echo "\nOriginal Cairo VM:"
-    pyenv local 3.7.12
-    hyperfine "cairo-run --layout all --program $tests_path/$file.json"
-
-    echo "\nPyPy Cairo VM:"
-    pyenv local pypy3.7-7.3.9
-    hyperfine "cairo-run --layout all --program $tests_path/$file.json"
-
-    echo "\nRust Cleopatra VM:"
-    hyperfine "../target/release/cleopatra-run $tests_path/$file.json"
+    hyperfine \
+	    -n "Cairo VM (CPython)" "PYENV_VERSION=3.7.12 cairo-run --layout all --program $tests_path/$file.json" \
+	    -n "Cairo VM (PyPy)" "PYENV_VERSION=pypy3.7-7.3.9 cairo-run --layout all --program $tests_path/$file.json" \
+	    -n "Cleopatra VM (Rust)" "../target/release/cleopatra-run $tests_path/$file.json"
 done
-
-cat results
-
-echo "Cleaning results"
-rm -f results


### PR DESCRIPTION
## Description

Modifies `run_benchmarks.sh` script to let Hyperfine know we're comparing benchmarks (invoke it with multiple commands, each with its own name). This helps it make a summary comparing the results of each command it ran.