### PR TITLE
[HINTS] Add implementation for memset on pow (memset.cairo)

### DIFF
--- a/cairo_programs/memset.cairo
+++ b/cairo_programs/memset.cairo
@@ -1,0 +1,15 @@
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.memset import memset
+
+func main():
+    alloc_locals
+    let (local string1 : felt*) = alloc()
+    memset(string1,'I dont know why',20)
+    let (local string2 : felt*) = alloc()
+    memset(string2,'Do you know why',20)
+
+    assert string1[19] = 'I dont know why'
+    assert string2[1] = 'Do you know why'
+
+return ()
+end

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -14,6 +14,7 @@ use crate::vm::hints::hint_utils::{
     memcpy_continue_copying, memcpy_enter_scope, signed_div_rem, split_felt, split_int,
     split_int_assert_range, sqrt, unsigned_div_rem,
 };
+use crate::vm::hints::memset_utils::{memset_continue_loop, memset_enter_scope};
 use crate::vm::vm_core::VirtualMachine;
 
 #[derive(Debug, PartialEq, Clone)]
@@ -58,7 +59,9 @@ pub fn execute_hint(
         ) => assert_not_zero(vm, ids, None),
         Ok("vm_exit_scope()") => exit_scope(vm),
         Ok("vm_enter_scope({'n': ids.len})") => memcpy_enter_scope(vm, ids, Some(ap_tracking)),
+        Ok("vm_enter_scope({'n': ids.n})") => memset_enter_scope(vm, ids, Some(ap_tracking)),
         Ok("n -= 1\nids.continue_copying = 1 if n > 0 else 0") => memcpy_continue_copying(vm, ids, Some(ap_tracking)),
+        Ok("n -= 1\nids.continue_loop = 1 if n > 0 else 0") => memset_continue_loop(vm, ids, Some(ap_tracking)),
         Ok("from starkware.cairo.common.math_utils import assert_integer\nassert ids.MAX_HIGH < 2**128 and ids.MAX_LOW < 2**128\nassert PRIME - 1 == ids.MAX_HIGH * 2**128 + ids.MAX_LOW\nassert_integer(ids.value)\nids.low = ids.value & ((1 << 128) - 1)\nids.high = ids.value >> 128"
         ) => split_felt(vm, ids, None),
         Ok("from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\nids.q, ids.r = divmod(ids.value, ids.div)") => unsigned_div_rem(vm, ids, None),

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -123,7 +123,7 @@ pub fn get_address_from_reference(
     Ok(None)
 }
 
-fn get_address_from_var_name(
+pub fn get_address_from_var_name(
     var_name: &str,
     ids: HashMap<String, BigInt>,
     vm: &VirtualMachine,

--- a/src/vm/hints/mod.rs
+++ b/src/vm/hints/mod.rs
@@ -2,3 +2,4 @@ pub mod dict_hint_utils;
 pub mod dict_manager;
 pub mod execute_hint;
 pub mod hint_utils;
+pub mod memset_utils;

--- a/tests/cairo_run_test.rs
+++ b/tests/cairo_run_test.rs
@@ -153,6 +153,12 @@ fn cairo_run_memcpy() {
 }
 
 #[test]
+fn cairo_run_memset() {
+    cairo_run::cairo_run(Path::new("cairo_programs/memset.json"), false)
+        .expect("Couldn't run program");
+}
+
+#[test]
 fn cairo_run_dict() {
     cairo_run::cairo_run(Path::new("cairo_programs/dict.json"), false)
         .expect("Couldn't run program");


### PR DESCRIPTION
# Add implementation for memset on pow (memset.cairo)

## Description

https://github.com/starkware-libs/cairo-lang/blob/167b28bcd940fd25ea3816204fa882a0b0a49603/src/starkware/cairo/common/memset.cairo

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
