### PR TITLE
[HINTS] Add implementation for first two hints on Uint256.cairo

### DIFF
--- a/cairo_programs/uint256.cairo
+++ b/cairo_programs/uint256.cairo
@@ -1,6 +1,6 @@
 %builtins range_check
 
-from starkware.cairo.common.uint256 import (uint256_add, Uint256)
+from starkware.cairo.common.uint256 import (Uint256, uint256_add, split_64)
 
 func main{range_check_ptr: felt}():
     let x :Uint256 = Uint256(5,2)
@@ -9,5 +9,9 @@ func main{range_check_ptr: felt}():
     assert res.low = 8
     assert res.high = 9
     assert carry_high = 0
+
+    let (low, high) = split_64(850981239023189021389081239089023)
+    assert low = 7249717543555297151
+    assert high = 46131785404667
     return()
 end

--- a/cairo_programs/uint256.cairo
+++ b/cairo_programs/uint256.cairo
@@ -1,0 +1,13 @@
+%builtins range_check
+
+from starkware.cairo.common.uint256 import (uint256_add, Uint256)
+
+func main{range_check_ptr: felt}():
+    let x :Uint256 = Uint256(5,2)
+    let y = Uint256(3,7)
+    let (res, carry_high) = uint256_add(x,y)
+    assert res.low = 8
+    assert res.high = 9
+    assert carry_high = 0
+    return()
+end

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -18,6 +18,13 @@ macro_rules! bigint64 {
 }
 
 #[macro_export]
+macro_rules! bigint_u64 {
+    ($val : expr) => {
+        BigInt::from_u64($val).unwrap()
+    };
+}
+
+#[macro_export]
 macro_rules! bigintusize {
     ($val : expr) => {
         BigInt::from_usize($val).unwrap()

--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -38,6 +38,7 @@ pub enum VirtualMachineError {
     IncorrectIds(Vec<String>, Vec<String>),
     MemoryGet(MaybeRelocatable),
     ExpectedInteger(MaybeRelocatable),
+    ExpectedRelocatable(MaybeRelocatable),
     FailedToGetIds,
     NonLeFelt(BigInt, BigInt),
     OutOfValidRange(BigInt, BigInt),
@@ -144,6 +145,9 @@ impl fmt::Display for VirtualMachineError {
             },
             VirtualMachineError::ExpectedInteger(addr) => {
                 write!(f, "Expected integer at address {:?}", addr)
+            },
+            VirtualMachineError::ExpectedRelocatable(mayberelocatable) => {
+                write!(f, "Expected address to be a Relocatable, got {:?}", mayberelocatable)
             },
             VirtualMachineError::FailedToGetIds => {
                 write!(f, "Failed to get ids from memory")

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -15,7 +15,7 @@ use crate::vm::hints::hint_utils::{
     split_int_assert_range, sqrt, unsigned_div_rem,
 };
 use crate::vm::hints::pow_utils::pow;
-use crate::vm::hints::uint256_utils::uint256_add;
+use crate::vm::hints::uint256_utils::{split_64, uint256_add};
 use crate::vm::vm_core::VirtualMachine;
 
 #[derive(Debug, PartialEq, Clone)]
@@ -79,6 +79,7 @@ pub fn execute_hint(
         ) => dict_update(vm, ids, None),
         Ok("sum_low = ids.a.low + ids.b.low\nids.carry_low = 1 if sum_low >= ids.SHIFT else 0\nsum_high = ids.a.high + ids.b.high + ids.carry_low\nids.carry_high = 1 if sum_high >= ids.SHIFT else 0"
         ) => uint256_add(vm, ids, Some(ap_tracking)),
+        Ok("ids.low = ids.a & ((1<<64) - 1)\nids.high = ids.a >> 64") => split_64(vm, ids, None),
         Ok(hint_code) => Err(VirtualMachineError::UnknownHint(String::from(hint_code))),
         Err(_) => Err(VirtualMachineError::InvalidHintEncoding(
             vm.run_context.pc.clone(),

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -15,6 +15,7 @@ use crate::vm::hints::hint_utils::{
     split_int_assert_range, sqrt, unsigned_div_rem,
 };
 use crate::vm::hints::pow_utils::pow;
+use crate::vm::hints::uint256_utils::uint256_add;
 use crate::vm::vm_core::VirtualMachine;
 
 #[derive(Debug, PartialEq, Clone)]
@@ -76,6 +77,8 @@ pub fn execute_hint(
         ) => default_dict_new(vm, ids, None),
         Ok("# Verify dict pointer and prev value.\ndict_tracker = __dict_manager.get_tracker(ids.dict_ptr)\ncurrent_value = dict_tracker.data[ids.key]\nassert current_value == ids.prev_value, \\\n    f'Wrong previous value in dict. Got {ids.prev_value}, expected {current_value}.'\n\n# Update value.\ndict_tracker.data[ids.key] = ids.new_value\ndict_tracker.current_ptr += ids.DictAccess.SIZE"
         ) => dict_update(vm, ids, None),
+        Ok("sum_low = ids.a.low + ids.b.low\nids.carry_low = 1 if sum_low >= ids.SHIFT else 0\nsum_high = ids.a.high + ids.b.high + ids.carry_low\nids.carry_high = 1 if sum_high >= ids.SHIFT else 0"
+        ) => uint256_add(vm, ids, Some(ap_tracking)),
         Ok(hint_code) => Err(VirtualMachineError::UnknownHint(String::from(hint_code))),
         Err(_) => Err(VirtualMachineError::InvalidHintEncoding(
             vm.run_context.pc.clone(),

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -78,7 +78,7 @@ pub fn execute_hint(
         Ok("# Verify dict pointer and prev value.\ndict_tracker = __dict_manager.get_tracker(ids.dict_ptr)\ncurrent_value = dict_tracker.data[ids.key]\nassert current_value == ids.prev_value, \\\n    f'Wrong previous value in dict. Got {ids.prev_value}, expected {current_value}.'\n\n# Update value.\ndict_tracker.data[ids.key] = ids.new_value\ndict_tracker.current_ptr += ids.DictAccess.SIZE"
         ) => dict_update(vm, ids, None),
         Ok("sum_low = ids.a.low + ids.b.low\nids.carry_low = 1 if sum_low >= ids.SHIFT else 0\nsum_high = ids.a.high + ids.b.high + ids.carry_low\nids.carry_high = 1 if sum_high >= ids.SHIFT else 0"
-        ) => uint256_add(vm, ids, Some(ap_tracking)),
+        ) => uint256_add(vm, ids, None),
         Ok("ids.low = ids.a & ((1<<64) - 1)\nids.high = ids.a >> 64") => split_64(vm, ids, None),
         Ok(hint_code) => Err(VirtualMachineError::UnknownHint(String::from(hint_code))),
         Err(_) => Err(VirtualMachineError::InvalidHintEncoding(

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -148,12 +148,12 @@ pub fn get_address_from_var_name(
 //else raises Err
 pub fn get_relocatable_from_var_name(
     var_name: &str,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     vm: &VirtualMachine,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<Relocatable, VirtualMachineError> {
     if let MaybeRelocatable::RelocatableValue(relocatable) =
-        get_address_from_var_name(var_name, ids, vm, hint_ap_tracking)?
+        get_address_from_var_name(var_name, ids.clone(), vm, hint_ap_tracking)?
     {
         Ok(relocatable)
     } else {
@@ -166,7 +166,7 @@ pub fn get_relocatable_from_var_name(
 //else raises Err
 pub fn get_integer_from_var_name<'a>(
     var_name: &str,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     vm: &'a VirtualMachine,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<&'a BigInt, VirtualMachineError> {
@@ -1660,7 +1660,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            get_integer_from_var_name(var_name, ids, &vm, None),
+            get_integer_from_var_name(var_name, &ids, &vm, None),
             Ok(&bigint!(10))
         );
     }
@@ -1705,7 +1705,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            get_integer_from_var_name(var_name, ids, &vm, None),
+            get_integer_from_var_name(var_name, &ids, &vm, None),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((0, 0))
             ))

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -189,12 +189,9 @@ pub fn get_relocatable_from_var_name(
     vm: &VirtualMachine,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<Relocatable, VirtualMachineError> {
-    if let MaybeRelocatable::RelocatableValue(relocatable) =
-        get_address_from_var_name(var_name, ids, vm, hint_ap_tracking)?
-    {
-        Ok(relocatable)
-    } else {
-        Err(VirtualMachineError::FailedToGetIds)
+    match get_address_from_var_name(var_name, ids, vm, hint_ap_tracking)? {
+        MaybeRelocatable::RelocatableValue(relocatable) => Ok(relocatable),
+        address => Err(VirtualMachineError::ExpectedRelocatable(address)),
     }
 }
 

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -161,7 +161,7 @@ pub fn get_integer_from_var_name<'a>(
 // Gets the value of the address + offset
 //If the value is an MaybeRelocatable::Int(Bigint) return &Bigint
 //else raises Err
-pub fn get_integer_from_address_with_offset<'a>(
+pub fn get_integer_from_address_plus_offset<'a>(
     address: &MaybeRelocatable,
     field_offset: usize,
     vm: &'a VirtualMachine,
@@ -1704,7 +1704,7 @@ mod tests {
     }
 
     #[test]
-    fn get_integer_from_address_with_offset_valid() {
+    fn get_integer_from_address_plus_offset_valid() {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -1722,13 +1722,13 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            get_integer_from_address_with_offset(&MaybeRelocatable::from((0, 0)), 1, &vm),
+            get_integer_from_address_plus_offset(&MaybeRelocatable::from((0, 0)), 1, &vm),
             Ok(&bigint!(10))
         );
     }
 
     #[test]
-    fn get_integer_from_address_with_offset_invalid_expectected_integer() {
+    fn get_integer_from_address_plus_offset_invalid_expectected_integer() {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -1738,7 +1738,7 @@ mod tests {
         vm.segments.add(&mut vm.memory, None);
 
         assert_eq!(
-            get_integer_from_address_with_offset(&MaybeRelocatable::from((0, 0)), 1, &vm),
+            get_integer_from_address_plus_offset(&MaybeRelocatable::from((0, 0)), 1, &vm),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((0, 1))
             ))

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -190,7 +190,7 @@ pub fn get_relocatable_from_var_name(
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<Relocatable, VirtualMachineError> {
     if let MaybeRelocatable::RelocatableValue(relocatable) =
-        get_address_from_var_name(var_name, ids.clone(), vm, hint_ap_tracking)?
+        get_address_from_var_name(var_name, ids, vm, hint_ap_tracking)?
     {
         Ok(relocatable)
     } else {

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -144,6 +144,9 @@ pub fn get_address_from_var_name(
     .ok_or(VirtualMachineError::FailedToGetIds)
 }
 
+//Gets the value of a variable name.
+//If the value is an MaybeRelocatable::Int(Bigint) return &Bigint
+//else raises Err
 pub fn get_integer_from_var_name<'a>(
     var_name: &str,
     ids: HashMap<String, BigInt>,
@@ -1596,5 +1599,104 @@ pub fn assert_lt_felt(
         }
 
         _ => Err(VirtualMachineError::FailedToGetIds),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use num_bigint::Sign;
+
+    use super::*;
+
+    #[test]
+    fn get_integer_from_var_name_valid() {
+        let mut vm = VirtualMachine::new(
+            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            Vec::new(),
+            false,
+        );
+        // initialize memory segments
+        vm.segments.add(&mut vm.memory, None);
+
+        // initialize fp
+        vm.run_context.fp = MaybeRelocatable::from((0, 2));
+
+        //Create references
+        vm.references = HashMap::from([(
+            0,
+            HintReference {
+                register: Register::FP,
+                offset1: -2,
+                offset2: 0,
+                inner_dereference: false,
+                ap_tracking_data: None,
+            },
+        )]);
+
+        let var_name: &str = "variable";
+
+        //Create ids
+        let mut ids = HashMap::<String, BigInt>::new();
+        ids.insert(String::from("variable"), bigint!(0));
+
+        //Insert ids.prev_locs.exp into memory
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((0, 0)),
+                &MaybeRelocatable::from(bigint!(10)),
+            )
+            .unwrap();
+
+        assert_eq!(
+            get_integer_from_var_name(var_name, ids, &vm, None),
+            Ok(&bigint!(10))
+        );
+    }
+
+    #[test]
+    fn get_integer_from_var_name_invalid_expected_integer() {
+        let mut vm = VirtualMachine::new(
+            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            Vec::new(),
+            false,
+        );
+        // initialize memory segments
+        vm.segments.add(&mut vm.memory, None);
+
+        // initialize fp
+        vm.run_context.fp = MaybeRelocatable::from((0, 2));
+
+        //Create references
+        vm.references = HashMap::from([(
+            0,
+            HintReference {
+                register: Register::FP,
+                offset1: -2,
+                offset2: 0,
+                inner_dereference: false,
+                ap_tracking_data: None,
+            },
+        )]);
+
+        let var_name: &str = "variable";
+
+        //Create ids
+        let mut ids = HashMap::<String, BigInt>::new();
+        ids.insert(String::from("variable"), bigint!(0));
+
+        //Insert ids.variable into memory as a RelocatableValue
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((0, 0)),
+                &MaybeRelocatable::from((0, 1)),
+            )
+            .unwrap();
+
+        assert_eq!(
+            get_integer_from_var_name(var_name, ids, &vm, None),
+            Err(VirtualMachineError::ExpectedInteger(
+                MaybeRelocatable::from((0, 0))
+            ))
+        );
     }
 }

--- a/src/vm/hints/mod.rs
+++ b/src/vm/hints/mod.rs
@@ -3,3 +3,4 @@ pub mod dict_manager;
 pub mod execute_hint;
 pub mod hint_utils;
 pub mod pow_utils;
+pub mod uint256_utils;

--- a/src/vm/hints/uint256_utils.rs
+++ b/src/vm/hints/uint256_utils.rs
@@ -94,3 +94,249 @@ pub fn split_64(
         (Err(error), _) | (_, Err(error)) => Err(VirtualMachineError::MemoryError(error)),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::instruction::Register;
+    use crate::types::relocatable::MaybeRelocatable;
+    use crate::vm::errors::memory_errors::MemoryError;
+    use crate::vm::hints::execute_hint::{execute_hint, HintReference};
+    use crate::{bigint, vm::runners::builtin_runner::RangeCheckBuiltinRunner};
+    use num_bigint::{BigInt, Sign};
+    use num_traits::FromPrimitive;
+
+    #[test]
+    fn run_uint256_add_ok() {
+        let hint_code = "sum_low = ids.a.low + ids.b.low\nids.carry_low = 1 if sum_low >= ids.SHIFT else 0\nsum_high = ids.a.high + ids.b.high + ids.carry_low\nids.carry_high = 1 if sum_high >= ids.SHIFT else 0".as_bytes();
+        let mut vm = VirtualMachine::new(
+            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            vec![(
+                "range_check".to_string(),
+                Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
+            )],
+            false,
+        );
+        for _ in 0..3 {
+            vm.segments.add(&mut vm.memory, None);
+        }
+
+        //Initialize fp
+        vm.run_context.fp = MaybeRelocatable::from((1, 10));
+
+        //Create ids
+        let mut ids = HashMap::<String, BigInt>::new();
+        ids.insert(String::from("a"), bigint!(0));
+        ids.insert(String::from("b"), bigint!(1));
+        ids.insert(String::from("carry_high"), bigint!(2));
+        ids.insert(String::from("carry_low"), bigint!(3));
+
+        //Create references
+        vm.references = HashMap::from([
+            (
+                0,
+                HintReference {
+                    register: Register::FP,
+                    offset1: -6,
+                    offset2: 0,
+                    inner_dereference: false,
+                    ap_tracking_data: None,
+                },
+            ),
+            (
+                1,
+                HintReference {
+                    register: Register::FP,
+                    offset1: -4,
+                    offset2: 0,
+                    inner_dereference: false,
+                    ap_tracking_data: None,
+                },
+            ),
+            (
+                2,
+                HintReference {
+                    register: Register::FP,
+                    offset1: 3,
+                    offset2: 0,
+                    inner_dereference: false,
+                    ap_tracking_data: None,
+                },
+            ),
+            (
+                3,
+                HintReference {
+                    register: Register::FP,
+                    offset1: 2,
+                    offset2: 0,
+                    inner_dereference: false,
+                    ap_tracking_data: None,
+                },
+            ),
+        ]);
+
+        //Insert ids.a.low into memory
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((1, 4)),
+                &MaybeRelocatable::from(bigint!(2)),
+            )
+            .unwrap();
+        //Insert ids.b.high into memory
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((1, 5)),
+                &MaybeRelocatable::from(bigint!(3)),
+            )
+            .unwrap();
+        //Insert ids.b.low into memory
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((1, 6)),
+                &MaybeRelocatable::from(bigint!(4)),
+            )
+            .unwrap();
+        //Insert ids.b.high into memory
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((1, 7)),
+                &MaybeRelocatable::from(bigint!(2).pow(128)),
+            )
+            .unwrap();
+
+        //Execute the hint
+        assert_eq!(
+            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            Ok(())
+        );
+
+        //Check hint memory inserts
+        assert_eq!(
+            vm.memory.get(&MaybeRelocatable::from((1, 12))),
+            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
+        );
+        assert_eq!(
+            vm.memory.get(&MaybeRelocatable::from((1, 13))),
+            Ok(Some(&MaybeRelocatable::from(bigint!(1))))
+        );
+    }
+
+    #[test]
+    fn run_uint256_add_fail_inserts() {
+        let hint_code = "sum_low = ids.a.low + ids.b.low\nids.carry_low = 1 if sum_low >= ids.SHIFT else 0\nsum_high = ids.a.high + ids.b.high + ids.carry_low\nids.carry_high = 1 if sum_high >= ids.SHIFT else 0".as_bytes();
+        let mut vm = VirtualMachine::new(
+            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            vec![(
+                "range_check".to_string(),
+                Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
+            )],
+            false,
+        );
+        for _ in 0..3 {
+            vm.segments.add(&mut vm.memory, None);
+        }
+
+        //Initialize fp
+        vm.run_context.fp = MaybeRelocatable::from((1, 10));
+
+        //Create ids
+        let mut ids = HashMap::<String, BigInt>::new();
+        ids.insert(String::from("a"), bigint!(0));
+        ids.insert(String::from("b"), bigint!(1));
+        ids.insert(String::from("carry_high"), bigint!(2));
+        ids.insert(String::from("carry_low"), bigint!(3));
+
+        //Create references
+        vm.references = HashMap::from([
+            (
+                0,
+                HintReference {
+                    register: Register::FP,
+                    offset1: -6,
+                    offset2: 0,
+                    inner_dereference: false,
+                    ap_tracking_data: None,
+                },
+            ),
+            (
+                1,
+                HintReference {
+                    register: Register::FP,
+                    offset1: -4,
+                    offset2: 0,
+                    inner_dereference: false,
+                    ap_tracking_data: None,
+                },
+            ),
+            (
+                2,
+                HintReference {
+                    register: Register::FP,
+                    offset1: 3,
+                    offset2: 0,
+                    inner_dereference: false,
+                    ap_tracking_data: None,
+                },
+            ),
+            (
+                3,
+                HintReference {
+                    register: Register::FP,
+                    offset1: 2,
+                    offset2: 0,
+                    inner_dereference: false,
+                    ap_tracking_data: None,
+                },
+            ),
+        ]);
+
+        //Insert ids.a.low into memory
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((1, 4)),
+                &MaybeRelocatable::from(bigint!(2)),
+            )
+            .unwrap();
+        //Insert ids.b.high into memory
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((1, 5)),
+                &MaybeRelocatable::from(bigint!(3)),
+            )
+            .unwrap();
+        //Insert ids.b.low into memory
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((1, 6)),
+                &MaybeRelocatable::from(bigint!(4)),
+            )
+            .unwrap();
+        //Insert ids.b.high into memory
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((1, 7)),
+                &MaybeRelocatable::from(bigint!(2)),
+            )
+            .unwrap();
+
+        //Insert a value in the ids.carry_low address, so the hint insertion fails
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((1, 12)),
+                &MaybeRelocatable::from(bigint!(2)),
+            )
+            .unwrap();
+
+        //Execute the hint
+        assert_eq!(
+            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            Err(VirtualMachineError::MemoryError(
+                MemoryError::InconsistentMemory(
+                    MaybeRelocatable::from((1, 12)),
+                    MaybeRelocatable::from(bigint!(2)),
+                    MaybeRelocatable::from(bigint!(0))
+                )
+            ))
+        );
+    }
+}

--- a/src/vm/hints/uint256_utils.rs
+++ b/src/vm/hints/uint256_utils.rs
@@ -2,7 +2,8 @@ use crate::serde::deserialize_program::ApTracking;
 use crate::types::relocatable::MaybeRelocatable;
 use crate::vm::errors::vm_errors::VirtualMachineError;
 use crate::vm::hints::hint_utils::{
-    get_address_from_var_name, get_integer_from_address_plus_offset, get_integer_from_var_name,
+    get_address_from_var_name, get_integer_from_relocatable_plus_offset, get_integer_from_var_name,
+    get_relocatable_from_var_name,
 };
 use crate::vm::vm_core::VirtualMachine;
 use crate::{bigint, bigint_u64};
@@ -26,16 +27,16 @@ pub fn uint256_add(
 ) -> Result<(), VirtualMachineError> {
     let shift: BigInt = bigint!(2).pow(128);
 
-    let a_addr = get_address_from_var_name("a", ids.clone(), vm, hint_ap_tracking)?;
-    let b_addr = get_address_from_var_name("b", ids.clone(), vm, hint_ap_tracking)?;
+    let a_maybe_rel = get_relocatable_from_var_name("a", ids.clone(), vm, hint_ap_tracking)?;
+    let b_maybe_rel = get_relocatable_from_var_name("b", ids.clone(), vm, hint_ap_tracking)?;
     let carry_high_addr =
         get_address_from_var_name("carry_high", ids.clone(), vm, hint_ap_tracking)?;
     let carry_low_addr = get_address_from_var_name("carry_low", ids, vm, hint_ap_tracking)?;
 
-    let a_low = get_integer_from_address_plus_offset(&a_addr, 0, vm)?;
-    let a_high = get_integer_from_address_plus_offset(&a_addr, 1, vm)?;
-    let b_low = get_integer_from_address_plus_offset(&b_addr, 0, vm)?;
-    let b_high = get_integer_from_address_plus_offset(&b_addr, 1, vm)?;
+    let a_low = get_integer_from_relocatable_plus_offset(&a_maybe_rel, 0, vm)?;
+    let a_high = get_integer_from_relocatable_plus_offset(&a_maybe_rel, 1, vm)?;
+    let b_low = get_integer_from_relocatable_plus_offset(&b_maybe_rel, 0, vm)?;
+    let b_high = get_integer_from_relocatable_plus_offset(&b_maybe_rel, 1, vm)?;
 
     // Hint main logic
     // sum_low = ids.a.low + ids.b.low

--- a/src/vm/hints/uint256_utils.rs
+++ b/src/vm/hints/uint256_utils.rs
@@ -50,7 +50,7 @@ pub fn uint256_add(
         bigint!(0)
     };
 
-    let carry_high = if a_high + b_high + carry_low.clone() >= shift {
+    let carry_high = if a_high + b_high + &carry_low >= shift {
         bigint!(1)
     } else {
         bigint!(0)

--- a/src/vm/hints/uint256_utils.rs
+++ b/src/vm/hints/uint256_utils.rs
@@ -56,15 +56,13 @@ pub fn uint256_add(
         bigint!(0)
     };
 
-    match (
-        vm.memory
-            .insert(&carry_high_addr, &MaybeRelocatable::from(carry_high)),
-        vm.memory
-            .insert(&carry_low_addr, &MaybeRelocatable::from(carry_low)),
-    ) {
-        (Ok(_), Ok(_)) => Ok(()),
-        (Err(error), _) | (_, Err(error)) => Err(VirtualMachineError::MemoryError(error)),
-    }
+    vm.memory
+        .insert(&carry_high_addr, &MaybeRelocatable::from(carry_high))
+        .map_err(VirtualMachineError::MemoryError)?;
+
+    vm.memory
+        .insert(&carry_low_addr, &MaybeRelocatable::from(carry_low))
+        .map_err(VirtualMachineError::MemoryError)
 }
 
 /*
@@ -86,13 +84,12 @@ pub fn split_64(
     let low: BigInt = a & (bigint!(1).shl(64_usize) - 1);
     let high: BigInt = a.shr(64_usize);
 
-    match (
-        vm.memory.insert(&low_addr, &MaybeRelocatable::from(low)),
-        vm.memory.insert(&high_addr, &MaybeRelocatable::from(high)),
-    ) {
-        (Ok(_), Ok(_)) => Ok(()),
-        (Err(error), _) | (_, Err(error)) => Err(VirtualMachineError::MemoryError(error)),
-    }
+    vm.memory
+        .insert(&low_addr, &MaybeRelocatable::from(low))
+        .map_err(VirtualMachineError::MemoryError)?;
+    vm.memory
+        .insert(&high_addr, &MaybeRelocatable::from(high))
+        .map_err(VirtualMachineError::MemoryError)
 }
 
 #[cfg(test)]

--- a/src/vm/hints/uint256_utils.rs
+++ b/src/vm/hints/uint256_utils.rs
@@ -3,7 +3,7 @@ use crate::serde::deserialize_program::ApTracking;
 use crate::types::relocatable::MaybeRelocatable;
 use crate::vm::errors::vm_errors::VirtualMachineError;
 use crate::vm::hints::hint_utils::{
-    get_address_from_var_name, get_integer_from_var_name, get_struct_field_from_struct_address,
+    get_address_from_var_name, get_integer_from_address_with_offset, get_integer_from_var_name,
 };
 use crate::vm::vm_core::VirtualMachine;
 use num_bigint::BigInt;
@@ -33,10 +33,10 @@ pub fn uint256_add(
         get_address_from_var_name("carry_high", ids.clone(), vm, hint_ap_tracking)?;
     let carry_low_addr = get_address_from_var_name("carry_low", ids, vm, hint_ap_tracking)?;
 
-    let a_low = get_struct_field_from_struct_address(&a_addr, 0, vm)?;
-    let a_high = get_struct_field_from_struct_address(&a_addr, 1, vm)?;
-    let b_low = get_struct_field_from_struct_address(&b_addr, 0, vm)?;
-    let b_high = get_struct_field_from_struct_address(&b_addr, 1, vm)?;
+    let a_low = get_integer_from_address_with_offset(&a_addr, 0, vm)?;
+    let a_high = get_integer_from_address_with_offset(&a_addr, 1, vm)?;
+    let b_low = get_integer_from_address_with_offset(&b_addr, 0, vm)?;
+    let b_high = get_integer_from_address_with_offset(&b_addr, 1, vm)?;
 
     // Hint main logic
     // sum_low = ids.a.low + ids.b.low

--- a/src/vm/hints/uint256_utils.rs
+++ b/src/vm/hints/uint256_utils.rs
@@ -3,7 +3,7 @@ use crate::serde::deserialize_program::ApTracking;
 use crate::types::relocatable::MaybeRelocatable;
 use crate::vm::errors::vm_errors::VirtualMachineError;
 use crate::vm::hints::hint_utils::{
-    get_address_from_var_name, get_integer_from_address_with_offset, get_integer_from_var_name,
+    get_address_from_var_name, get_integer_from_address_plus_offset, get_integer_from_var_name,
 };
 use crate::vm::vm_core::VirtualMachine;
 use num_bigint::BigInt;
@@ -33,10 +33,10 @@ pub fn uint256_add(
         get_address_from_var_name("carry_high", ids.clone(), vm, hint_ap_tracking)?;
     let carry_low_addr = get_address_from_var_name("carry_low", ids, vm, hint_ap_tracking)?;
 
-    let a_low = get_integer_from_address_with_offset(&a_addr, 0, vm)?;
-    let a_high = get_integer_from_address_with_offset(&a_addr, 1, vm)?;
-    let b_low = get_integer_from_address_with_offset(&b_addr, 0, vm)?;
-    let b_high = get_integer_from_address_with_offset(&b_addr, 1, vm)?;
+    let a_low = get_integer_from_address_plus_offset(&a_addr, 0, vm)?;
+    let a_high = get_integer_from_address_plus_offset(&a_addr, 1, vm)?;
+    let b_low = get_integer_from_address_plus_offset(&b_addr, 0, vm)?;
+    let b_high = get_integer_from_address_plus_offset(&b_addr, 1, vm)?;
 
     // Hint main logic
     // sum_low = ids.a.low + ids.b.low

--- a/src/vm/hints/uint256_utils.rs
+++ b/src/vm/hints/uint256_utils.rs
@@ -27,8 +27,8 @@ pub fn uint256_add(
 ) -> Result<(), VirtualMachineError> {
     let shift: BigInt = bigint!(2).pow(128);
 
-    let a_maybe_rel = get_relocatable_from_var_name("a", ids.clone(), vm, hint_ap_tracking)?;
-    let b_maybe_rel = get_relocatable_from_var_name("b", ids.clone(), vm, hint_ap_tracking)?;
+    let a_maybe_rel = get_relocatable_from_var_name("a", &ids, vm, hint_ap_tracking)?;
+    let b_maybe_rel = get_relocatable_from_var_name("b", &ids, vm, hint_ap_tracking)?;
     let carry_high_addr =
         get_address_from_var_name("carry_high", ids.clone(), vm, hint_ap_tracking)?;
     let carry_low_addr = get_address_from_var_name("carry_low", ids, vm, hint_ap_tracking)?;
@@ -77,7 +77,7 @@ pub fn split_64(
     ids: HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
-    let a = get_integer_from_var_name("a", ids.clone(), vm, hint_ap_tracking)?;
+    let a = get_integer_from_var_name("a", &ids, vm, hint_ap_tracking)?;
     let high_addr = get_address_from_var_name("high", ids.clone(), vm, hint_ap_tracking)?;
     let low_addr = get_address_from_var_name("low", ids, vm, hint_ap_tracking)?;
 

--- a/src/vm/hints/uint256_utils.rs
+++ b/src/vm/hints/uint256_utils.rs
@@ -27,16 +27,15 @@ pub fn uint256_add(
 ) -> Result<(), VirtualMachineError> {
     let shift: BigInt = bigint!(2).pow(128);
 
-    let a_maybe_rel = get_relocatable_from_var_name("a", &ids, vm, hint_ap_tracking)?;
-    let b_maybe_rel = get_relocatable_from_var_name("b", &ids, vm, hint_ap_tracking)?;
-    let carry_high_addr =
-        get_address_from_var_name("carry_high", ids.clone(), vm, hint_ap_tracking)?;
-    let carry_low_addr = get_address_from_var_name("carry_low", ids, vm, hint_ap_tracking)?;
+    let a_relocatable = get_relocatable_from_var_name("a", &ids, vm, hint_ap_tracking)?;
+    let b_relocatable = get_relocatable_from_var_name("b", &ids, vm, hint_ap_tracking)?;
+    let carry_high_addr = get_address_from_var_name("carry_high", &ids, vm, hint_ap_tracking)?;
+    let carry_low_addr = get_address_from_var_name("carry_low", &ids, vm, hint_ap_tracking)?;
 
-    let a_low = get_integer_from_relocatable_plus_offset(&a_maybe_rel, 0, vm)?;
-    let a_high = get_integer_from_relocatable_plus_offset(&a_maybe_rel, 1, vm)?;
-    let b_low = get_integer_from_relocatable_plus_offset(&b_maybe_rel, 0, vm)?;
-    let b_high = get_integer_from_relocatable_plus_offset(&b_maybe_rel, 1, vm)?;
+    let a_low = get_integer_from_relocatable_plus_offset(&a_relocatable, 0, vm)?;
+    let a_high = get_integer_from_relocatable_plus_offset(&a_relocatable, 1, vm)?;
+    let b_low = get_integer_from_relocatable_plus_offset(&b_relocatable, 0, vm)?;
+    let b_high = get_integer_from_relocatable_plus_offset(&b_relocatable, 1, vm)?;
 
     // Hint main logic
     // sum_low = ids.a.low + ids.b.low
@@ -78,8 +77,8 @@ pub fn split_64(
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let a = get_integer_from_var_name("a", &ids, vm, hint_ap_tracking)?;
-    let high_addr = get_address_from_var_name("high", ids.clone(), vm, hint_ap_tracking)?;
-    let low_addr = get_address_from_var_name("low", ids, vm, hint_ap_tracking)?;
+    let high_addr = get_address_from_var_name("high", &ids, vm, hint_ap_tracking)?;
+    let low_addr = get_address_from_var_name("low", &ids, vm, hint_ap_tracking)?;
 
     let mut digits = a.iter_u64_digits();
     let low = digits.next().unwrap_or(0u64);

--- a/src/vm/hints/uint256_utils.rs
+++ b/src/vm/hints/uint256_utils.rs
@@ -1,4 +1,3 @@
-use crate::bigint;
 use crate::serde::deserialize_program::ApTracking;
 use crate::types::relocatable::MaybeRelocatable;
 use crate::vm::errors::vm_errors::VirtualMachineError;
@@ -6,10 +5,10 @@ use crate::vm::hints::hint_utils::{
     get_address_from_var_name, get_integer_from_address_plus_offset, get_integer_from_var_name,
 };
 use crate::vm::vm_core::VirtualMachine;
+use crate::{bigint, bigint_u64};
 use num_bigint::BigInt;
 use num_traits::FromPrimitive;
 use std::collections::HashMap;
-use std::ops::{Shl, Shr};
 
 /*
 Implements hint:
@@ -81,14 +80,15 @@ pub fn split_64(
     let high_addr = get_address_from_var_name("high", ids.clone(), vm, hint_ap_tracking)?;
     let low_addr = get_address_from_var_name("low", ids, vm, hint_ap_tracking)?;
 
-    let low: BigInt = a & (bigint!(1).shl(64_usize) - 1);
-    let high: BigInt = a.shr(64_usize);
+    let mut digits = a.iter_u64_digits();
+    let low = digits.next().unwrap_or(0u64);
+    let high = digits.next().unwrap_or(0u64);
 
     vm.memory
-        .insert(&low_addr, &MaybeRelocatable::from(low))
+        .insert(&low_addr, &MaybeRelocatable::from(bigint_u64!(low)))
         .map_err(VirtualMachineError::MemoryError)?;
     vm.memory
-        .insert(&high_addr, &MaybeRelocatable::from(high))
+        .insert(&high_addr, &MaybeRelocatable::from(bigint_u64!(high)))
         .map_err(VirtualMachineError::MemoryError)
 }
 

--- a/src/vm/hints/uint256_utils.rs
+++ b/src/vm/hints/uint256_utils.rs
@@ -1,0 +1,67 @@
+use crate::bigint;
+use crate::serde::deserialize_program::ApTracking;
+use crate::types::relocatable::MaybeRelocatable;
+use crate::vm::errors::vm_errors::VirtualMachineError;
+use crate::vm::hints::hint_utils::{
+    get_address_from_var_name, get_struct_field_from_struct_address,
+};
+use crate::vm::vm_core::VirtualMachine;
+use num_bigint::BigInt;
+use num_traits::FromPrimitive;
+use std::collections::HashMap;
+
+/*
+Implements hint:
+%{
+    sum_low = ids.a.low + ids.b.low
+    ids.carry_low = 1 if sum_low >= ids.SHIFT else 0
+    sum_high = ids.a.high + ids.b.high + ids.carry_low
+    ids.carry_high = 1 if sum_high >= ids.SHIFT else 0
+%}
+*/
+pub fn uint256_add(
+    vm: &mut VirtualMachine,
+    ids: HashMap<String, BigInt>,
+    hint_ap_tracking: Option<&ApTracking>,
+) -> Result<(), VirtualMachineError> {
+    let shift: BigInt = bigint!(2).pow(128);
+
+    let a_addr = get_address_from_var_name("a", ids.clone(), vm, hint_ap_tracking)?;
+    let b_addr = get_address_from_var_name("b", ids.clone(), vm, hint_ap_tracking)?;
+    let carry_high_addr =
+        get_address_from_var_name("carry_high", ids.clone(), vm, hint_ap_tracking)?;
+    let carry_low_addr = get_address_from_var_name("carry_low", ids, vm, hint_ap_tracking)?;
+
+    let a_low = get_struct_field_from_struct_address(&a_addr, 0, vm)?;
+    let a_high = get_struct_field_from_struct_address(&a_addr, 1, vm)?;
+    let b_low = get_struct_field_from_struct_address(&b_addr, 0, vm)?;
+    let b_high = get_struct_field_from_struct_address(&b_addr, 1, vm)?;
+
+    // Hint main logic
+    // sum_low = ids.a.low + ids.b.low
+    // ids.carry_low = 1 if sum_low >= ids.SHIFT else 0
+    // sum_high = ids.a.high + ids.b.high + ids.carry_low
+    // ids.carry_high = 1 if sum_high >= ids.SHIFT else 0
+
+    let carry_low = if a_low + b_low >= shift {
+        bigint!(1)
+    } else {
+        bigint!(0)
+    };
+
+    let carry_high = if a_high + b_high + carry_low.clone() >= shift {
+        bigint!(1)
+    } else {
+        bigint!(0)
+    };
+
+    match (
+        vm.memory
+            .insert(&carry_high_addr, &MaybeRelocatable::from(carry_high)),
+        vm.memory
+            .insert(&carry_low_addr, &MaybeRelocatable::from(carry_low)),
+    ) {
+        (Ok(_), Ok(_)) => Ok(()),
+        (Err(error), _) | (_, Err(error)) => Err(VirtualMachineError::MemoryError(error)),
+    }
+}

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -1,7 +1,9 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::vm::errors::memory_errors::MemoryError;
+use crate::vm::errors::vm_errors::VirtualMachineError;
 use crate::{types::relocatable::MaybeRelocatable, utils::from_relocatable_to_indexes};
+use num_bigint::BigInt;
 
 pub struct ValidationRule(
     pub Box<dyn Fn(&Memory, &MaybeRelocatable) -> Result<MaybeRelocatable, MemoryError>>,
@@ -81,6 +83,13 @@ impl Memory {
             Ok(None)
         } else {
             Err(MemoryError::AddressNotRelocatable)
+        }
+    }
+
+    pub fn get_integer(&self, key: &MaybeRelocatable) -> Result<&BigInt, VirtualMachineError> {
+        match self.get(key) {
+            Ok(Some(MaybeRelocatable::Int(int))) => Ok(int),
+            _ => Err(VirtualMachineError::ExpectedInteger(key.clone())),
         }
     }
 

--- a/tests/cairo_run_test.rs
+++ b/tests/cairo_run_test.rs
@@ -171,6 +171,12 @@ fn cairo_run_dict_update() {
 }
 
 #[test]
+fn cairo_run_uint256() {
+    cairo_run::cairo_run(Path::new("cairo_programs/uint256.json"), false)
+        .expect("Couldn't run program");
+}
+
+#[test]
 fn cairo_run_dict_write_bad() {
     assert!(cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/bad_dict_new.json"),


### PR DESCRIPTION
# Add implementation for first two hints on Uint256.cairo
[Description of the pull request changes and motivation.](https://github.com/starkware-libs/cairo-lang/blob/167b28bcd940fd25ea3816204fa882a0b0a49603/src/starkware/cairo/common/uint256.cairo)

## Description

Add 3 functions to avoid boilerplate code:
  * `HintUtils::get_integer_from_var_name`
  * `HintUtils::get_integer_from_relocatable_plus_offset`
  * `HintUtils::get_relocatable_from_var_name`
  * `Memory::get_integer`
  
Add hint implementations:
```
%{
    sum_low = ids.a.low + ids.b.low
    ids.carry_low = 1 if sum_low >= ids.SHIFT else 0
    sum_high = ids.a.high + ids.b.high + ids.carry_low
    ids.carry_high = 1 if sum_high >= ids.SHIFT else 0
%}
```

```
%{
    ids.low = ids.a & ((1<<64) - 1)
    ids.high = ids.a >> 64
%}

```
## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [x] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
