### PR TITLE
Compile benchmarks in GH Action

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -23,8 +23,12 @@ jobs:
           override: true
           components: rustfmt, clippy
     - uses: actions/checkout@v3
-    - name: Build
-      run: make build
+    - name: Python3 Build
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+    - name: Install test dependencies
+      run: pip install ecdsa fastecdsa sympy cairo-lang
     - name: Run benchmark
       run: make benchmark-action
     - name: Store benchmark result

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Build
       run: make build
     - name: Run benchmark
-      run: cargo +nightly bench --bench criterion_benchmark -- --output-format bencher |sed 1d | tee output.txt
+      run: make benchmark-action
     - name: Store benchmark result
       uses: benchmark-action/github-action-benchmark@v1
       with:

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,9 @@ benchmark: $(COMPILED_BENCHES)
 	cargo criterion --bench criterion_benchmark
 	@echo 'Report: target/criterion/reports/index.html'
 
+benchmark-action: $(COMPILED_BENCHES)
+	cargo +nightly bench --bench criterion_benchmark -- --output-format bencher |sed 1d | tee output.txt
+
 flamegraph:
 	cargo flamegraph --root --bench criterion_benchmark -- --bench
 


### PR DESCRIPTION
Benchmarks were failing due to missing compiled programs.
Turned the benchmark step into a make target depending on those.