### PR TITLE
[HINTS] Add implementation of unsafe_keccak hint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
 dependencies = [
  "ark-std",
- "digest",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -99,6 +99,15 @@ name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
  "generic-array",
 ]
@@ -217,6 +226,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "sha3",
  "starknet-crypto",
 ]
 
@@ -323,6 +333,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +392,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer 0.10.2",
+ "crypto-common",
 ]
 
 [[package]]
@@ -468,7 +498,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac",
- "digest",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -510,6 +540,12 @@ checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "keccak"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 
 [[package]]
 name = "lazy_static"
@@ -943,11 +979,21 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "881bf8156c87b6301fc5ca6b27f11eeb2761224c7081e69b409d5a1951a70c86"
+dependencies = [
+ "digest 0.10.3",
+ "keccak",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ hex = "0.4.3"
 bincode = "1.2.1"
 starknet-crypto = "0.1.0"
 clap = { version = "3.2.5", features = ["derive"] }
+sha3 = "0.10.1"
 
 [dev-dependencies.rusty-hook]
 version = "0.11"

--- a/cairo_programs/keccak_example.cairo
+++ b/cairo_programs/keccak_example.cairo
@@ -1,0 +1,23 @@
+%builtins output
+
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.serialize import serialize_word
+from starkware.cairo.common.keccak import unsafe_keccak
+
+func main{output_ptr: felt*}():
+    alloc_locals
+
+    let (data : felt*) = alloc()
+
+    assert data[0] = 0
+    assert data[1] = 0
+    assert data[2] = 0
+
+    let (low : felt, high : felt) = unsafe_keccak(data, 3)
+
+    serialize_word(low)
+    serialize_word(high)
+
+    return ()
+end
+    

--- a/cairo_programs/unsafe_keccak.cairo
+++ b/cairo_programs/unsafe_keccak.cairo
@@ -9,11 +9,17 @@ func main{output_ptr: felt*}():
 
     let (data : felt*) = alloc()
 
-    assert data[0] = 0
-    assert data[1] = 0
-    assert data[2] = 0
+    assert data[0] = 500 
+    assert data[1] = 2
+    assert data[2] = 3
+    assert data[3] = 6
+    assert data[4] = 1
+    assert data[5] = 4444
 
-    let (low : felt, high : felt) = unsafe_keccak(data, 3)
+    let (low : felt, high : felt) = unsafe_keccak(data, 6)
+
+    assert low = 182565855334575837944615807286777833262
+    assert high = 90044356407795786957420814893241941221
 
     serialize_word(low)
     serialize_word(high)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -25,6 +25,13 @@ macro_rules! bigint_u64 {
 }
 
 #[macro_export]
+macro_rules! bigint_u128 {
+    ($val : expr) => {
+        BigInt::from_u128($val).unwrap()
+    };
+}
+
+#[macro_export]
 macro_rules! bigintusize {
     ($val : expr) => {
         BigInt::from_usize($val).unwrap()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -46,13 +46,6 @@ macro_rules! bigint_i128 {
 }
 
 #[macro_export]
-macro_rules! bigint_u128 {
-    ($val : expr) => {
-        BigInt::from_u128($val).unwrap()
-    };
-}
-
-#[macro_export]
 macro_rules! bigint_str {
     ($val: expr) => {
         //BigInt::from_bytes_be(Sign::Plus, $val.chars().map(|c| c.to_digit(10).unwrap()).collect())

--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -87,6 +87,9 @@ pub enum VirtualMachineError {
     InvalidSetRange(MaybeRelocatable, MaybeRelocatable),
     AssertionFailed(String),
     MismatchedDictPtr(Relocatable, Relocatable),
+    KeccakMaxSize(BigInt, BigInt),
+    InvalidWordSize(BigInt),
+    InvalidKeccakInputLength(BigInt),
 }
 
 impl fmt::Display for VirtualMachineError {
@@ -264,6 +267,9 @@ impl fmt::Display for VirtualMachineError {
             VirtualMachineError::KeyNotFound => write!(f, "Found Key is None"),
             VirtualMachineError::AssertionFailed(error_msg) => write!(f, "{}",error_msg),
             VirtualMachineError::MismatchedDictPtr(current_ptr, dict_ptr) => write!(f, "Wrong dict pointer supplied. Got {:?}, expected {:?}.", dict_ptr, current_ptr),
+            VirtualMachineError::KeccakMaxSize(length, keccak_max_size) => write!(f, "unsafe_keccak() can only be used with length<={:?}. Got: length={:?}", keccak_max_size, length),
+            VirtualMachineError::InvalidWordSize(word) => write!(f, "Invalid word size: {:?}", word),
+            VirtualMachineError::InvalidKeccakInputLength(length) => write!(f, "Invalid input length, Got: length={:?}", length),
         }
     }
 }

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -139,6 +139,7 @@ mod tests {
     use std::ops::Shl;
 
     use crate::bigint_str;
+    use crate::bigint_u128;
     use crate::math_utils::as_int;
     use crate::relocatable;
     use crate::types::exec_scope::PyValueType;
@@ -5774,5 +5775,484 @@ mod tests {
         //Check exec_scopes
         let expected_scope = vec![HashMap::new(), HashMap::new()];
         assert_eq!(vm.exec_scopes.data, expected_scope)
+    }
+
+    #[test]
+    fn unsafe_keccak_valid() {
+        let hint_code = "from eth_hash.auto import keccak\n\ndata, length = ids.data, ids.length\n\nif '__keccak_max_size' in globals():\n    assert length <= __keccak_max_size, \\\n        f'unsafe_keccak() can only be used with length<={__keccak_max_size}. ' \\\n        f'Got: length={length}.'\n\nkeccak_input = bytearray()\nfor word_i, byte_i in enumerate(range(0, length, 16)):\n    word = memory[data + word_i]\n    n_bytes = min(16, length - byte_i)\n    assert 0 <= word < 2 ** (8 * n_bytes)\n    keccak_input += word.to_bytes(n_bytes, 'big')\n\nhashed = keccak(keccak_input)\nids.high = int.from_bytes(hashed[:16], 'big')\nids.low = int.from_bytes(hashed[16:32], 'big')".as_bytes();
+        let mut vm = VirtualMachine::new(
+            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            Vec::new(),
+            false,
+        );
+
+        // initialize memory segments
+        vm.segments.add(&mut vm.memory, None);
+        vm.segments.add(&mut vm.memory, None);
+
+        // initialize fp
+        vm.run_context.fp = MaybeRelocatable::from((0, 4));
+
+        // insert ids.len into memory
+        vm.memory
+            // length
+            .insert(
+                &MaybeRelocatable::from((0, 1)),
+                &MaybeRelocatable::from(bigint!(3)),
+            )
+            .unwrap();
+
+        vm.memory
+            // data
+            .insert(
+                &MaybeRelocatable::from((1, 0)),
+                &MaybeRelocatable::from(bigint!(1)),
+            )
+            .unwrap();
+
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((1, 1)),
+                &MaybeRelocatable::from(bigint!(1)),
+            )
+            .unwrap();
+
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((1, 2)),
+                &MaybeRelocatable::from(bigint!(1)),
+            )
+            .unwrap();
+
+        vm.memory
+            // pointer to data
+            .insert(
+                &MaybeRelocatable::from((0, 2)),
+                &MaybeRelocatable::from((1, 0)),
+            )
+            .unwrap();
+
+        vm.memory
+            // we create a memory gap in (0, 3) and (0, 4)
+            .insert(
+                &MaybeRelocatable::from((0, 5)),
+                &MaybeRelocatable::from(bigint!(0)),
+            )
+            .unwrap();
+
+        let mut ids = HashMap::<String, BigInt>::new();
+        ids.insert(String::from("length"), bigint!(0));
+        ids.insert(String::from("data"), bigint!(1));
+        ids.insert(String::from("high"), bigint!(2));
+        ids.insert(String::from("low"), bigint!(3));
+
+        vm.exec_scopes
+            .assign_or_update_variable("__keccak_max_size", PyValueType::BigInt(bigint!(500)));
+
+        //Create references
+        vm.references = HashMap::from([
+            (
+                0,
+                HintReference {
+                    register: Register::FP,
+                    offset1: -3,
+                    offset2: 0,
+                    inner_dereference: false,
+                    ap_tracking_data: None,
+                },
+            ),
+            (
+                1,
+                HintReference {
+                    register: Register::FP,
+                    offset1: -2,
+                    offset2: 0,
+                    inner_dereference: false,
+                    ap_tracking_data: None,
+                },
+            ),
+            (
+                2,
+                HintReference {
+                    register: Register::FP,
+                    offset1: -1,
+                    offset2: 0,
+                    inner_dereference: false,
+                    ap_tracking_data: None,
+                },
+            ),
+            (
+                3,
+                HintReference {
+                    register: Register::FP,
+                    offset1: 0,
+                    offset2: 0,
+                    inner_dereference: false,
+                    ap_tracking_data: None,
+                },
+            ),
+        ]);
+
+        assert!(execute_hint(&mut vm, hint_code, ids, &ApTracking::new()).is_ok());
+    }
+
+    #[test]
+    fn unsafe_keccak_max_size() {
+        let hint_code = "from eth_hash.auto import keccak\n\ndata, length = ids.data, ids.length\n\nif '__keccak_max_size' in globals():\n    assert length <= __keccak_max_size, \\\n        f'unsafe_keccak() can only be used with length<={__keccak_max_size}. ' \\\n        f'Got: length={length}.'\n\nkeccak_input = bytearray()\nfor word_i, byte_i in enumerate(range(0, length, 16)):\n    word = memory[data + word_i]\n    n_bytes = min(16, length - byte_i)\n    assert 0 <= word < 2 ** (8 * n_bytes)\n    keccak_input += word.to_bytes(n_bytes, 'big')\n\nhashed = keccak(keccak_input)\nids.high = int.from_bytes(hashed[:16], 'big')\nids.low = int.from_bytes(hashed[16:32], 'big')".as_bytes();
+        let mut vm = VirtualMachine::new(
+            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            Vec::new(),
+            false,
+        );
+
+        // initialize memory segments
+        vm.segments.add(&mut vm.memory, None);
+        vm.segments.add(&mut vm.memory, None);
+
+        // initialize fp
+        vm.run_context.fp = MaybeRelocatable::from((0, 4));
+
+        // insert ids.len into memory
+        vm.memory
+            // length
+            .insert(
+                &MaybeRelocatable::from((0, 1)),
+                &MaybeRelocatable::from(bigint!(5)),
+            )
+            .unwrap();
+
+        vm.memory
+            // data
+            .insert(
+                &MaybeRelocatable::from((1, 0)),
+                &MaybeRelocatable::from(bigint!(1)),
+            )
+            .unwrap();
+
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((1, 1)),
+                &MaybeRelocatable::from(bigint!(1)),
+            )
+            .unwrap();
+
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((1, 2)),
+                &MaybeRelocatable::from(bigint!(1)),
+            )
+            .unwrap();
+
+        vm.memory
+            // pointer to data
+            .insert(
+                &MaybeRelocatable::from((0, 2)),
+                &MaybeRelocatable::from((1, 0)),
+            )
+            .unwrap();
+
+        vm.memory
+            // we create a memory gap in (0, 3) and (0, 4)
+            .insert(
+                &MaybeRelocatable::from((0, 5)),
+                &MaybeRelocatable::from(bigint!(0)),
+            )
+            .unwrap();
+
+        let mut ids = HashMap::<String, BigInt>::new();
+        ids.insert(String::from("length"), bigint!(0));
+        ids.insert(String::from("data"), bigint!(1));
+        ids.insert(String::from("high"), bigint!(2));
+        ids.insert(String::from("low"), bigint!(3));
+
+        vm.exec_scopes
+            .assign_or_update_variable("__keccak_max_size", PyValueType::BigInt(bigint!(2)));
+
+        //Create references
+        vm.references = HashMap::from([
+            (
+                0,
+                HintReference {
+                    register: Register::FP,
+                    offset1: -3,
+                    offset2: 0,
+                    inner_dereference: false,
+                    ap_tracking_data: None,
+                },
+            ),
+            (
+                1,
+                HintReference {
+                    register: Register::FP,
+                    offset1: -2,
+                    offset2: 0,
+                    inner_dereference: false,
+                    ap_tracking_data: None,
+                },
+            ),
+            (
+                2,
+                HintReference {
+                    register: Register::FP,
+                    offset1: -1,
+                    offset2: 0,
+                    inner_dereference: false,
+                    ap_tracking_data: None,
+                },
+            ),
+            (
+                3,
+                HintReference {
+                    register: Register::FP,
+                    offset1: 0,
+                    offset2: 0,
+                    inner_dereference: false,
+                    ap_tracking_data: None,
+                },
+            ),
+        ]);
+
+        assert_eq!(
+            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            Err(VirtualMachineError::KeccakMaxSize(bigint!(5), bigint!(2)))
+        );
+    }
+
+    #[test]
+    fn unsafe_keccak_invalid_input_length() {
+        let hint_code = "from eth_hash.auto import keccak\n\ndata, length = ids.data, ids.length\n\nif '__keccak_max_size' in globals():\n    assert length <= __keccak_max_size, \\\n        f'unsafe_keccak() can only be used with length<={__keccak_max_size}. ' \\\n        f'Got: length={length}.'\n\nkeccak_input = bytearray()\nfor word_i, byte_i in enumerate(range(0, length, 16)):\n    word = memory[data + word_i]\n    n_bytes = min(16, length - byte_i)\n    assert 0 <= word < 2 ** (8 * n_bytes)\n    keccak_input += word.to_bytes(n_bytes, 'big')\n\nhashed = keccak(keccak_input)\nids.high = int.from_bytes(hashed[:16], 'big')\nids.low = int.from_bytes(hashed[16:32], 'big')".as_bytes();
+        let mut vm = VirtualMachine::new(
+            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            Vec::new(),
+            false,
+        );
+
+        // initialize memory segments
+        vm.segments.add(&mut vm.memory, None);
+        vm.segments.add(&mut vm.memory, None);
+
+        // initialize fp
+        vm.run_context.fp = MaybeRelocatable::from((0, 4));
+
+        // insert ids.len into memory
+        vm.memory
+            // length
+            .insert(
+                &MaybeRelocatable::from((0, 1)),
+                &MaybeRelocatable::from(bigint_u128!(18446744073709551616)),
+            )
+            .unwrap();
+
+        vm.memory
+            // data
+            .insert(
+                &MaybeRelocatable::from((1, 0)),
+                &MaybeRelocatable::from(bigint!(1)),
+            )
+            .unwrap();
+
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((1, 1)),
+                &MaybeRelocatable::from(bigint!(1)),
+            )
+            .unwrap();
+
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((1, 2)),
+                &MaybeRelocatable::from(bigint!(1)),
+            )
+            .unwrap();
+
+        vm.memory
+            // pointer to data
+            .insert(
+                &MaybeRelocatable::from((0, 2)),
+                &MaybeRelocatable::from((1, 0)),
+            )
+            .unwrap();
+
+        vm.memory
+            // we create a memory gap in (0, 3) and (0, 4)
+            .insert(
+                &MaybeRelocatable::from((0, 5)),
+                &MaybeRelocatable::from(bigint!(0)),
+            )
+            .unwrap();
+
+        let mut ids = HashMap::<String, BigInt>::new();
+        ids.insert(String::from("length"), bigint!(0));
+        ids.insert(String::from("data"), bigint!(1));
+        ids.insert(String::from("high"), bigint!(2));
+        ids.insert(String::from("low"), bigint!(3));
+
+        //Create references
+        vm.references = HashMap::from([
+            (
+                0,
+                HintReference {
+                    register: Register::FP,
+                    offset1: -3,
+                    offset2: 0,
+                    inner_dereference: false,
+                    ap_tracking_data: None,
+                },
+            ),
+            (
+                1,
+                HintReference {
+                    register: Register::FP,
+                    offset1: -2,
+                    offset2: 0,
+                    inner_dereference: false,
+                    ap_tracking_data: None,
+                },
+            ),
+            (
+                2,
+                HintReference {
+                    register: Register::FP,
+                    offset1: -1,
+                    offset2: 0,
+                    inner_dereference: false,
+                    ap_tracking_data: None,
+                },
+            ),
+            (
+                3,
+                HintReference {
+                    register: Register::FP,
+                    offset1: 0,
+                    offset2: 0,
+                    inner_dereference: false,
+                    ap_tracking_data: None,
+                },
+            ),
+        ]);
+
+        assert!(execute_hint(&mut vm, hint_code, ids, &ApTracking::new()).is_err());
+    }
+
+    #[test]
+    fn unsafe_keccak_invalid_word_size() {
+        let hint_code = "from eth_hash.auto import keccak\n\ndata, length = ids.data, ids.length\n\nif '__keccak_max_size' in globals():\n    assert length <= __keccak_max_size, \\\n        f'unsafe_keccak() can only be used with length<={__keccak_max_size}. ' \\\n        f'Got: length={length}.'\n\nkeccak_input = bytearray()\nfor word_i, byte_i in enumerate(range(0, length, 16)):\n    word = memory[data + word_i]\n    n_bytes = min(16, length - byte_i)\n    assert 0 <= word < 2 ** (8 * n_bytes)\n    keccak_input += word.to_bytes(n_bytes, 'big')\n\nhashed = keccak(keccak_input)\nids.high = int.from_bytes(hashed[:16], 'big')\nids.low = int.from_bytes(hashed[16:32], 'big')".as_bytes();
+        let mut vm = VirtualMachine::new(
+            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            Vec::new(),
+            false,
+        );
+
+        // initialize memory segments
+        vm.segments.add(&mut vm.memory, None);
+        vm.segments.add(&mut vm.memory, None);
+
+        // initialize fp
+        vm.run_context.fp = MaybeRelocatable::from((0, 4));
+
+        // insert ids.len into memory
+        vm.memory
+            // length
+            .insert(
+                &MaybeRelocatable::from((0, 1)),
+                &MaybeRelocatable::from(bigint!(3)),
+            )
+            .unwrap();
+
+        vm.memory
+            // data
+            .insert(
+                &MaybeRelocatable::from((1, 0)),
+                &MaybeRelocatable::from(bigint!(-1)),
+            )
+            .unwrap();
+
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((1, 1)),
+                &MaybeRelocatable::from(bigint!(1)),
+            )
+            .unwrap();
+
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((1, 2)),
+                &MaybeRelocatable::from(bigint!(1)),
+            )
+            .unwrap();
+
+        vm.memory
+            // pointer to data
+            .insert(
+                &MaybeRelocatable::from((0, 2)),
+                &MaybeRelocatable::from((1, 0)),
+            )
+            .unwrap();
+
+        vm.memory
+            // we create a memory gap in (0, 3) and (0, 4)
+            .insert(
+                &MaybeRelocatable::from((0, 5)),
+                &MaybeRelocatable::from(bigint!(0)),
+            )
+            .unwrap();
+
+        let mut ids = HashMap::<String, BigInt>::new();
+        ids.insert(String::from("length"), bigint!(0));
+        ids.insert(String::from("data"), bigint!(1));
+        ids.insert(String::from("high"), bigint!(2));
+        ids.insert(String::from("low"), bigint!(3));
+
+        vm.exec_scopes
+            .assign_or_update_variable("__keccak_max_size", PyValueType::BigInt(bigint!(10)));
+
+        //Create references
+        vm.references = HashMap::from([
+            (
+                0,
+                HintReference {
+                    register: Register::FP,
+                    offset1: -3,
+                    offset2: 0,
+                    inner_dereference: false,
+                    ap_tracking_data: None,
+                },
+            ),
+            (
+                1,
+                HintReference {
+                    register: Register::FP,
+                    offset1: -2,
+                    offset2: 0,
+                    inner_dereference: false,
+                    ap_tracking_data: None,
+                },
+            ),
+            (
+                2,
+                HintReference {
+                    register: Register::FP,
+                    offset1: -1,
+                    offset2: 0,
+                    inner_dereference: false,
+                    ap_tracking_data: None,
+                },
+            ),
+            (
+                3,
+                HintReference {
+                    register: Register::FP,
+                    offset1: 0,
+                    offset2: 0,
+                    inner_dereference: false,
+                    ap_tracking_data: None,
+                },
+            ),
+        ]);
+
+        assert_eq!(
+            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            Err(VirtualMachineError::InvalidWordSize(bigint!(-1)))
+        );
     }
 }

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -223,6 +223,18 @@ pub fn get_integer_from_relocatable_plus_offset<'a>(
     )))
 }
 
+// Used for variables that hold pointers.
+pub fn get_ptr_from_var_name<'a>(
+    var_name: &str,
+    ids: &HashMap<String, BigInt>,
+    vm: &'a VirtualMachine,
+    hint_ap_tracking: Option<&ApTracking>,
+) -> Result<&'a Relocatable, VirtualMachineError> {
+    let var_addr = get_relocatable_from_var_name(var_name, ids, vm, hint_ap_tracking)?;
+
+    vm.memory.get_relocatable(&var_addr)
+}
+
 ///Implements hint: memory[ap] = segments.add()
 pub fn add_segment(vm: &mut VirtualMachine) -> Result<(), VirtualMachineError> {
     let new_segment_base =

--- a/src/vm/hints/keccak_utils.rs
+++ b/src/vm/hints/keccak_utils.rs
@@ -44,8 +44,8 @@ pub fn unsafe_keccak(
     ids: HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
-    let length = get_integer_from_var_name("length", &ids, vm, hint_ap_tracking)
-        .map_or_else(Err, |len| Ok(len.clone()))?;
+    let length = get_integer_from_var_name("length", &ids, vm, hint_ap_tracking)?
+        .clone();
 
     if let Some(keccak_max_size) = get_int_from_scope(vm, "__keccak_max_size") {
         if length > keccak_max_size {
@@ -112,7 +112,24 @@ pub fn unsafe_keccak(
     }
 }
 
-pub fn add_padding_at_beginning(bytes_vector: &mut [u8], n_zeros: usize) -> Vec<u8> {
+/*
+Implements hint:
+    %{
+        from eth_hash.auto import keccak
+        keccak_input = bytearray()
+        n_elms = ids.keccak_state.end_ptr - ids.keccak_state.start_ptr
+        for word in memory.get_range(ids.keccak_state.start_ptr, n_elms):
+            keccak_input += word.to_bytes(16, 'big')
+        hashed = keccak(keccak_input)
+        ids.high = int.from_bytes(hashed[:16], 'big')
+        ids.low = int.from_bytes(hashed[16:32], 'big')
+    %}
+ */
+pub fn unsafe_keccak_finalize() {
+
+}
+
+fn add_padding_at_beginning(bytes_vector: &mut [u8], n_zeros: usize) -> Vec<u8> {
     let mut res: Vec<u8> = vec![0; n_zeros];
     res.extend(bytes_vector.iter());
 

--- a/src/vm/hints/keccak_utils.rs
+++ b/src/vm/hints/keccak_utils.rs
@@ -1,0 +1,113 @@
+use super::hint_utils::{
+    get_int_from_scope, get_integer_from_var_name, get_ptr_from_var_name,
+    get_relocatable_from_var_name,
+};
+use crate::types::relocatable::MaybeRelocatable;
+use crate::{
+    bigint,
+    serde::deserialize_program::ApTracking,
+    types::relocatable::Relocatable,
+    vm::{errors::vm_errors::VirtualMachineError, vm_core::VirtualMachine},
+};
+use num_bigint::{BigInt, Sign};
+use num_traits::FromPrimitive;
+use num_traits::ToPrimitive;
+use sha3::{Digest, Keccak256};
+use std::cmp;
+use std::collections::HashMap;
+
+/* Implements hint:
+   %{
+       from eth_hash.auto import keccak
+
+       data, length = ids.data, ids.length
+
+       if '__keccak_max_size' in globals():
+           assert length <= __keccak_max_size, \
+               f'unsafe_keccak() can only be used with length<={__keccak_max_size}. ' \
+               f'Got: length={length}.'
+
+       keccak_input = bytearray()
+       for word_i, byte_i in enumerate(range(0, length, 16)):
+           word = memory[data + word_i]
+           n_bytes = min(16, length - byte_i)
+           assert 0 <= word < 2 ** (8 * n_bytes)
+           keccak_input += word.to_bytes(n_bytes, 'big')
+
+       hashed = keccak(keccak_input)
+       ids.high = int.from_bytes(hashed[:16], 'big')
+       ids.low = int.from_bytes(hashed[16:32], 'big')
+   %}
+*/
+pub fn unsafe_keccak(
+    vm: &mut VirtualMachine,
+    ids: HashMap<String, BigInt>,
+    hint_ap_tracking: Option<&ApTracking>,
+) -> Result<(), VirtualMachineError> {
+    let length = get_integer_from_var_name("length", &ids, vm, hint_ap_tracking)
+        .map_or_else(|e| Err(e), |len| Ok(len.clone()))?;
+
+    if let Some(keccak_max_size) = get_int_from_scope(vm, "__keccak_max_size") {
+        if length > keccak_max_size {
+            return Err(VirtualMachineError::KeccakMaxSize(
+                length.clone(),
+                keccak_max_size,
+            ));
+        }
+    }
+
+    // `data` is an array, represented by a pointer to the first element.
+    let data = get_ptr_from_var_name("data", &ids, vm, hint_ap_tracking)?;
+
+    let high_addr = get_relocatable_from_var_name("high", &ids, vm, hint_ap_tracking)?;
+    let low_addr = get_relocatable_from_var_name("low", &ids, vm, hint_ap_tracking)?;
+
+    // transform to u64 to make ranges cleaner in the for loop below
+    let u64_length = if let Some(u64_length) = length.to_u64() {
+        u64_length
+    } else {
+        return Err(VirtualMachineError::InvalidKeccakInputLength(
+            length.clone(),
+        ));
+    };
+
+    let mut keccak_input = Vec::new();
+    for (word_i, byte_i) in (0..u64_length).enumerate().step_by(16) {
+        let word_addr = Relocatable {
+            segment_index: data.segment_index,
+            offset: data.offset + word_i,
+        };
+        let word = vm.memory.get_integer(&word_addr)?;
+        let n_bytes = cmp::min(16, u64_length - byte_i);
+
+        if &bigint!(0) > word || word >= &bigint!(2).pow(8 * (n_bytes as u32)) {
+            return Err(VirtualMachineError::InvalidWordSize(word.clone()));
+        }
+
+        let (_, mut bytes) = word.to_bytes_be();
+
+        keccak_input.append(&mut bytes);
+    }
+
+    let mut hasher = Keccak256::new();
+    hasher.update(keccak_input);
+
+    let hashed = hasher.finalize();
+
+    let high = BigInt::from_bytes_be(Sign::Plus, &hashed[..16]);
+    let low = BigInt::from_bytes_be(Sign::Plus, &hashed[16..32]);
+
+    match (
+        vm.memory.insert(
+            &MaybeRelocatable::RelocatableValue(high_addr),
+            &MaybeRelocatable::Int(high),
+        ),
+        vm.memory.insert(
+            &MaybeRelocatable::RelocatableValue(low_addr),
+            &MaybeRelocatable::Int(low),
+        ),
+    ) {
+        (Ok(_), Ok(_)) => Ok(()),
+        (Err(error), _) | (_, Err(error)) => Err(VirtualMachineError::MemoryError(error)),
+    }
+}

--- a/src/vm/hints/keccak_utils.rs
+++ b/src/vm/hints/keccak_utils.rs
@@ -44,8 +44,7 @@ pub fn unsafe_keccak(
     ids: HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
-    let length = get_integer_from_var_name("length", &ids, vm, hint_ap_tracking)?
-        .clone();
+    let length = get_integer_from_var_name("length", &ids, vm, hint_ap_tracking)?.clone();
 
     if let Some(keccak_max_size) = get_int_from_scope(vm, "__keccak_max_size") {
         if length > keccak_max_size {
@@ -110,23 +109,6 @@ pub fn unsafe_keccak(
         (Ok(_), Ok(_)) => Ok(()),
         (Err(error), _) | (_, Err(error)) => Err(VirtualMachineError::MemoryError(error)),
     }
-}
-
-/*
-Implements hint:
-    %{
-        from eth_hash.auto import keccak
-        keccak_input = bytearray()
-        n_elms = ids.keccak_state.end_ptr - ids.keccak_state.start_ptr
-        for word in memory.get_range(ids.keccak_state.start_ptr, n_elms):
-            keccak_input += word.to_bytes(16, 'big')
-        hashed = keccak(keccak_input)
-        ids.high = int.from_bytes(hashed[:16], 'big')
-        ids.low = int.from_bytes(hashed[16:32], 'big')
-    %}
- */
-pub fn unsafe_keccak_finalize() {
-
 }
 
 fn add_padding_at_beginning(bytes_vector: &mut [u8], n_zeros: usize) -> Vec<u8> {

--- a/src/vm/hints/mod.rs
+++ b/src/vm/hints/mod.rs
@@ -3,6 +3,7 @@ pub mod dict_manager;
 pub mod execute_hint;
 pub mod find_element_hint;
 pub mod hint_utils;
+pub mod keccak_utils;
 pub mod memset_utils;
 pub mod pow_utils;
 pub mod set;

--- a/tests/cairo_run_test.rs
+++ b/tests/cairo_run_test.rs
@@ -247,3 +247,9 @@ fn cairo_run_set_add() {
     cairo_run::cairo_run(Path::new("cairo_programs/set_add.json"), false)
         .expect("Couldn't run program");
 }
+
+#[test]
+fn cairo_run_unsafe_keccak() {
+    cairo_run::cairo_run(Path::new("cairo_programs/unsafe_keccak.json"), false)
+        .expect("Couldn't run program");
+}


### PR DESCRIPTION
# Implementation of unsafe_keccak hints

## Description
This PR adds support for the hint implemented inside the `unsafe_keccak` function of the `keccak` module.
The external crate [sha3](https://crates.io/crates/sha3) is used to compute the keccak hash function.

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [x] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
