### PR TITLE
Add integration tests for math.cairo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ BAD_TEST_FILES:=$(wildcard $(BAD_TEST_DIR)/*.cairo)
 COMPILED_BAD_TESTS:=$(patsubst $(BAD_TEST_DIR)/%.cairo, $(BAD_TEST_DIR)/%.json, $(BAD_TEST_FILES))
 
 $(TEST_DIR)/%.json: $(TEST_DIR)/%.cairo
-	cairo-compile $< --output $@
+	cairo-compile --cairo_path="$(TEST_DIR):$(BENCH_DIR)" $< --output $@
 
 $(TEST_DIR)/%.cleopatra.memory: $(TEST_DIR)/%.json build
 	./target/release/cleopatra-run $< --memory_file $@
@@ -32,7 +32,7 @@ $(TEST_DIR)/%.trace: $(TEST_DIR)/%.json
 	cairo-run --layout all --program $< --trace_file $@
 
 $(BENCH_DIR)/%.json: $(BENCH_DIR)/%.cairo
-	cairo-compile $< --output $@
+	cairo-compile --cairo_path="$(TEST_DIR):$(BENCH_DIR)" $< --output $@
 
 $(BAD_TEST_DIR)/%.json: $(BAD_TEST_DIR)/%.cairo
 	cairo-compile $< --output $@

--- a/cairo_programs/benchmarks/math_integration_benchmark.cairo
+++ b/cairo_programs/benchmarks/math_integration_benchmark.cairo
@@ -1,0 +1,6 @@
+from math_integration_tests import run_tests
+
+func main{range_check_ptr}() -> ():
+    run_tests(1000)
+    return()
+end

--- a/cairo_programs/math_integration_tests.cairo
+++ b/cairo_programs/math_integration_tests.cairo
@@ -1,0 +1,257 @@
+%builtins range_check
+
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.math import (
+    assert_not_zero,
+    assert_not_equal,
+    assert_nn,
+    assert_le,
+    assert_lt,
+    assert_nn_le,
+    assert_in_range,
+    assert_250_bit,
+    split_felt,
+    assert_le_felt,
+    assert_lt_felt,
+    abs_value,
+    sign,
+    unsigned_div_rem,
+    signed_div_rem,
+    split_int,
+    sqrt,
+    horner_eval,
+)
+
+func fill_array(array_start: felt*, base: felt, step: felt, iter: felt, last: felt) -> ():
+    if iter == last:
+        return()
+    end
+    assert array_start[iter] = base + step
+    return fill_array(array_start, base + step, step, iter + 1, last)
+end
+
+func test_assert_nn{range_check_ptr}(array_start: felt*, iter: felt, last: felt) -> ():
+    if iter == last:
+        return()
+    end
+    assert_nn(array_start[iter])
+    return test_assert_nn(array_start, iter + 1, last)
+end
+
+func test_assert_not_zero(array_start: felt*, iter: felt, last: felt) -> ():
+    if iter == last:
+        return()
+    end
+    assert_not_zero(array_start[iter])
+    return test_assert_not_zero(array_start, iter + 1, last)
+end
+
+func test_assert_not_equal(array_a: felt*, array_b: felt*, iter: felt, size: felt) -> ():
+    if iter == size:
+        return()
+    end
+    assert_not_equal(array_a[iter], array_b[iter])
+    return test_assert_not_equal(array_a, array_b, iter + 1, size)
+end
+
+func test_assert_le{range_check_ptr}(array_a: felt*, array_b: felt*, iter: felt, size: felt) -> ():
+    if iter == size:
+        return()
+    end
+    assert_le(array_a[iter], array_b[iter])
+    return test_assert_le(array_a, array_b, iter + 1, size)
+end
+
+func test_assert_lt{range_check_ptr}(array_a: felt*, array_b: felt*, iter: felt, size: felt) -> ():
+    if iter == size:
+        return()
+    end
+    assert_lt(array_a[iter], array_b[iter])
+    return test_assert_lt(array_a, array_b, iter + 1, size)
+end
+
+func test_assert_nn_le{range_check_ptr}(array_a: felt*, array_b: felt*, iter: felt, size: felt) -> ():
+    if iter == size:
+        return()
+    end
+    assert_nn_le(array_a[iter], array_b[iter])
+    return test_assert_nn_le(array_a, array_b, iter + 1, size)
+end
+
+func test_assert_in_range{range_check_ptr}(array_start: felt*, iter: felt, size: felt, lower: felt, upper: felt):
+    if iter == size:
+        return()
+    end
+    assert_in_range{range_check_ptr=range_check_ptr}(array_start[iter], lower, upper)
+    return test_assert_in_range{range_check_ptr=range_check_ptr}(array_start, iter + 1, size, lower, upper)
+end
+
+func test_assert_250_bit{range_check_ptr}(array_start: felt*, iter: felt, last: felt) -> ():
+    if iter == last:
+        return()
+    end
+    assert_250_bit(array_start[iter])
+    return test_assert_250_bit(array_start, iter + 1, last)
+end
+
+func test_split_felt{range_check_ptr}(array_start: felt*, iter: felt, last: felt) -> ():
+    alloc_locals
+
+    if iter == last:
+        return()
+    end
+    let (x: felt, y: felt) = split_felt(array_start[iter])
+    assert array_start[iter] = x * (2 ** 128) + y 
+    return test_split_felt(array_start, iter + 1, last)
+end
+
+func test_assert_le_felt{range_check_ptr}(array_a: felt*, array_b: felt*, iter: felt, last: felt) -> ():
+    if iter == last:
+        return()
+    end
+    assert_le_felt(array_a[iter], array_b[iter])
+    return test_assert_le_felt(array_a, array_b, iter + 1, last)
+end
+
+func test_assert_lt_felt{range_check_ptr}(array_a: felt*, array_b: felt*, iter: felt, last: felt) -> ():
+    if iter == last:
+        return()
+    end
+    assert_lt_felt(array_a[iter], array_b[iter])
+    return test_assert_lt_felt(array_a, array_b, iter + 1, last)
+end
+
+func test_abs_value{range_check_ptr}(array_a: felt*, array_b: felt*, iter: felt, last: felt) -> ():
+    alloc_locals
+    if iter == last:
+        return()
+    end
+    let abs_a: felt = abs_value(array_a[iter])
+    let abs_b: felt = abs_value(array_b[iter])
+    assert abs_a = abs_b
+    return test_abs_value(array_a, array_b, iter + 1, last)
+end
+
+func test_same_sign{range_check_ptr}(array_a: felt*, array_b: felt*, iter: felt, last: felt) -> ():
+    alloc_locals
+    if iter == last:
+        return()
+    end
+    let sign_a: felt = sign(array_a[iter])
+    let sign_b: felt = sign(array_b[iter])
+    assert sign_a = sign_b
+    return test_same_sign(array_a, array_b, iter + 1, last)
+end
+
+func test_diff_sign{range_check_ptr}(array_a: felt*, array_b: felt*, iter: felt, last: felt) -> ():
+    alloc_locals
+    if iter == last:
+        return()
+    end
+    let sign_a: felt = sign(array_a[iter])
+    let sign_b: felt = sign(array_b[iter])
+    assert sign_a = -sign_b
+    return test_diff_sign(array_a, array_b, iter + 1, last)
+end
+
+func test_sqrt{range_check_ptr}(array_start: felt*, iter: felt, last: felt) -> ():
+    alloc_locals
+    if iter == last:
+        return()
+    end
+    let (n_sqrt: felt) = sqrt(array_start[iter])
+    assert n_sqrt * n_sqrt = array_start[iter]
+    return test_sqrt(array_start, iter + 1, last)
+end
+
+func test_split_int{range_check_ptr}(array_start: felt*, iter: felt, last: felt) -> ():
+    alloc_locals
+
+    if iter == last:
+        return()
+    end
+    let (output: felt*) = alloc()
+    split_int(array_start[iter], 4, 8, 8, output)
+    assert array_start[iter] = output[0] + output[1] * 8 + output[2] * 64 + output[3] * 512
+    return test_split_int(array_start, iter + 1, last)
+end
+
+func test_horner_eval{range_check_ptr}(array_start: felt*, iter: felt, last: felt) -> ():
+    alloc_locals
+
+    if iter == last:
+        return()
+    end
+
+    let res: felt = horner_eval(3, array_start + iter, 3)
+    assert res = array_start[iter] + 3 * array_start[iter + 1] + 9 * array_start[iter + 2]
+    return test_horner_eval(array_start, iter + 1, last)
+end
+
+func test_{range_check_ptr}(array_start: felt*, iter: felt, last: felt) -> ():
+    if iter == last:
+        return()
+    end
+    #unsigned_div_rem{range_check_ptr}(value, div) -> (q : felt, r : felt):,
+    #signed_div_rem{range_check_ptr}(value, div, bound) -> (q : felt, r : felt):,
+    return test_(array_start, iter + 1, last)
+end
+
+func run_tests{range_check_ptr}(array_len: felt) -> ():
+    alloc_locals
+
+    assert_lt(1, array_len)
+
+    let (array: felt*) = alloc()
+    fill_array(array, 0, 3, 0, array_len)
+
+    let (array_neg: felt*) = alloc()
+    fill_array(array_neg, 0, -3, 0, array_len)
+
+    test_assert_nn(array, 0, array_len)
+    #test_assert_nn(array_neg, 0, array_len)
+
+    test_assert_not_zero(array, 1, array_len)
+    test_assert_not_zero(array_neg, 1, array_len)
+
+    test_assert_not_equal(array, array + 1, 0, array_len - 1)
+    test_assert_not_equal(array + 1, array, 0, array_len - 1)
+    test_assert_not_equal(array_neg, array_neg + 1, 0, array_len - 1)
+    test_assert_not_equal(array_neg + 1, array_neg, 0, array_len - 1)
+
+    test_assert_le(array, array, 0, array_len - 1)
+    test_assert_le(array, array + 1, 0, array_len - 1)
+    test_assert_lt(array, array + 1, 0, array_len - 1)
+    test_assert_nn_le(array, array + 1, 0, array_len - 1)
+
+    test_assert_le_felt(array, array, 0, array_len - 1)
+    test_assert_le_felt(array, array + 1, 0, array_len - 1)
+    test_assert_lt_felt(array, array + 1, 0, array_len - 1)
+
+    test_abs_value(array, array, 0, array_len)
+    test_abs_value(array_neg, array_neg, 0, array_len)
+    test_abs_value(array_neg, array, 0, array_len)
+    test_abs_value(array, array_neg, 0, array_len)
+
+    test_same_sign(array, array, 0, array_len)
+    test_same_sign(array + 1, array + 2, 0, array_len - 2)
+    test_same_sign(array_neg, array_neg, 0, array_len)
+    test_same_sign(array_neg + 1, array_neg + 2, 0, array_len - 2)
+
+    test_diff_sign(array + 1, array_neg + 1, 0, array_len - 1)
+    test_diff_sign(array_neg + 1, array + 1, 0, array_len - 1)
+
+    #test_assert_in_range(array, 0, array_len, 0, array[array_len - 1])
+    test_assert_250_bit(array, 0, array_len)
+    test_split_felt(array, 0, array_len)
+    test_split_int(array, 0, array_len)
+
+    test_horner_eval(array, 0, array_len - 2)
+
+    return()
+end
+
+func main{range_check_ptr}():
+    run_tests(10)
+    return()
+end


### PR DESCRIPTION
## Description

These tests attempt to exercise all the features provided by the math.cairo library to a more extensive degree.
The tests are rather simple, they apply the operations on arrays with several values and test the results are as expected.
The main test function takes a parameter with the size to use for the arrays, so a benchmark only requires passing a bigger number. Said benchmark is part of the PR. Some minor changes to the Makefile were needed to support imports from our custom code.
Due to other pressing concerns I decided to send the PR with missing division tests, as I still consider this valuable even if I'm going to be delaying the missing work.

## Checklist
- [x] Integration tests added.