### PR TITLE
Fix compat with Python 3.7 for memory_comparator.py

### DIFF
--- a/tests/memory_comparator.py
+++ b/tests/memory_comparator.py
@@ -30,7 +30,7 @@ def main():
             cleo_mem[k] = v
         assert len(cleo_mem) * 40 == len(cleo_raw), f'{filename2}: {len(cleo_mem) * 40} != {len(cleo_raw)}'
 
-    assert len(cairo_mem) == len(cleo_mem), f'{filename2}: {len(cairo_mem)=} {len(cleo_mem)=}'
+    assert len(cairo_mem) == len(cleo_mem), f'{filename2}: len(cairo_mem)={len(cairo_mem)} len(cairo_mem)={len(cleo_mem)}'
     if cairo_mem != cleo_mem:
         print(f'Mismatch between {filename1} (Cairo) and {filename2} (Cleopatra)')
         print('keys in Cairo but not Cleopatra:')


### PR DESCRIPTION
The current script used a shorthand format for printing that was
supported since 3.8, breaking under older versions.
While 3.7 is EOL, it's our reference interpreter, so it needs to work
correctly.