### PR TITLE
Hint executor customization

### DIFF
--- a/bench/criterion/criterion_benchmark.rs
+++ b/bench/criterion/criterion_benchmark.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use cleopatra_cairo::cairo_run;
+use cleopatra_cairo::vm::hints::execute_hint::BuiltinHintExecutor;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 const BENCH_NAMES: &'static [&'static str] = &[
@@ -12,10 +13,18 @@ const BENCH_NAMES: &'static [&'static str] = &[
 ];
 const BENCH_PATH: &'static str = "cairo_programs/benchmarks/";
 
+static HINT_EXECUTOR: BuiltinHintExecutor = BuiltinHintExecutor {};
+
 pub fn criterion_benchmarks(c: &mut Criterion) {
     for benchmark_name in build_bench_strings() {
         c.bench_function(&benchmark_name.0, |b| {
-            b.iter(|| cairo_run::cairo_run(black_box(Path::new(&benchmark_name.1)), false))
+            b.iter(|| {
+                cairo_run::cairo_run(
+                    black_box(Path::new(&benchmark_name.1)),
+                    false,
+                    &HINT_EXECUTOR,
+                )
+            })
         });
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use cleopatra_cairo::cairo_run;
 use cleopatra_cairo::vm::errors::cairo_run_errors::CairoRunError;
 use cleopatra_cairo::vm::errors::runner_errors::RunnerError;
 use cleopatra_cairo::vm::errors::trace_errors::TraceError;
+use cleopatra_cairo::vm::hints::execute_hint::BuiltinHintExecutor;
 use std::path::PathBuf;
 
 #[cfg(feature = "with_mimalloc")]
@@ -28,9 +29,12 @@ struct Args {
 }
 
 fn main() -> Result<(), CairoRunError> {
+    static HINT_EXECUTOR: BuiltinHintExecutor = BuiltinHintExecutor {};
+
     let args = Args::parse();
     let trace_enabled = args.trace_file.is_some();
-    let mut cairo_runner = match cairo_run::cairo_run(&args.filename, trace_enabled) {
+    let mut cairo_runner = match cairo_run::cairo_run(&args.filename, trace_enabled, &HINT_EXECUTOR)
+    {
         Ok(runner) => runner,
         Err(error) => return Err(error),
     };

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -22,8 +22,7 @@ pub struct ProgramJson {
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
 pub struct HintParams {
-    #[serde(with = "serde_bytes")]
-    pub code: Vec<u8>,
+    pub code: String,
     pub accessible_scopes: Vec<String>,
     pub flow_tracking_data: FlowTrackingData,
 }
@@ -389,10 +388,7 @@ mod tests {
         hints.insert(
             0,
             vec![HintParams {
-                code: vec![
-                    109, 101, 109, 111, 114, 121, 91, 97, 112, 93, 32, 61, 32, 115, 101, 103, 109,
-                    101, 110, 116, 115, 46, 97, 100, 100, 40, 41,
-                ],
+                code: "memory[ap] = segments.add()".to_string(),
                 accessible_scopes: vec![
                     String::from("starkware.cairo.common.alloc"),
                     String::from("starkware.cairo.common.alloc.alloc"),
@@ -583,10 +579,7 @@ mod tests {
         hints.insert(
             0,
             vec![HintParams {
-                code: vec![
-                    109, 101, 109, 111, 114, 121, 91, 97, 112, 93, 32, 61, 32, 115, 101, 103, 109,
-                    101, 110, 116, 115, 46, 97, 100, 100, 40, 41,
-                ],
+                code: "memory[ap] = segments.add()".to_string(),
                 accessible_scopes: vec![
                     String::from("starkware.cairo.common.alloc"),
                     String::from("starkware.cairo.common.alloc.alloc"),
@@ -603,7 +596,7 @@ mod tests {
         hints.insert(
             46,
             vec![HintParams {
-                code: vec![105, 109, 112, 111, 114, 116, 32, 109, 97, 116, 104],
+                code: "import math".to_string(),
                 accessible_scopes: vec![String::from("__main__"), String::from("__main__.main")],
                 flow_tracking_data: FlowTrackingData {
                     ap_tracking: ApTracking {

--- a/src/types/hint_executor.rs
+++ b/src/types/hint_executor.rs
@@ -1,0 +1,15 @@
+use crate::serde::deserialize_program::ApTracking;
+use crate::vm::errors::vm_errors::VirtualMachineError;
+use crate::vm::vm_core::VirtualMachine;
+use num_bigint::BigInt;
+use std::collections::HashMap;
+
+pub trait HintExecutor {
+    fn execute_hint(
+        &self,
+        vm: &mut VirtualMachine,
+        hint_code: &str,
+        ref_ids: &HashMap<String, BigInt>,
+        ap_tracking: &ApTracking,
+    ) -> Result<(), VirtualMachineError>;
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,5 +1,6 @@
 pub mod errors;
 pub mod exec_scope;
+pub mod hint_executor;
 pub mod instruction;
 pub mod program;
 pub mod relocatable;

--- a/src/vm/hints/blake2s_utils.rs
+++ b/src/vm/hints/blake2s_utils.rs
@@ -269,9 +269,11 @@ mod tests {
         types::instruction::Register,
         vm::{
             errors::memory_errors::MemoryError,
-            hints::execute_hint::{execute_hint, HintReference},
+            hints::execute_hint::{BuiltinHintExecutor, HintReference},
         },
     };
+
+    static HINT_EXECUTOR: BuiltinHintExecutor = BuiltinHintExecutor {};
 
     #[test]
     fn compute_blake2s_output_offset_zero() {
@@ -281,6 +283,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -311,7 +314,8 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Err(VirtualMachineError::CantSubOffset(5, 26))
         );
     }
@@ -324,6 +328,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -354,7 +359,8 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Err(VirtualMachineError::UnexpectMemoryGap)
         );
     }
@@ -367,6 +373,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -397,7 +404,8 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Err(VirtualMachineError::ExpectedRelocatable(
                 MaybeRelocatable::from((0, 0))
             ))
@@ -412,6 +420,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -449,7 +458,8 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Err(VirtualMachineError::BigintToU32Fail)
         );
     }
@@ -462,6 +472,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -499,7 +510,8 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((4, 5))
             ))
@@ -514,6 +526,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -544,7 +557,8 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Ok(())
         );
         //Check the inserted data
@@ -586,6 +600,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -623,7 +638,8 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((1, 0)),
@@ -642,6 +658,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -662,7 +679,12 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &HashMap::new(), &ApTracking::default()),
+            vm.hint_executor.execute_hint(
+                &mut vm,
+                hint_code,
+                &HashMap::new(),
+                &ApTracking::default()
+            ),
             Err(VirtualMachineError::FailedToGetIds)
         );
     }
@@ -675,6 +697,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -746,7 +769,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Ok(())
         );
         //Check data ptr
@@ -793,6 +817,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -864,7 +889,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Ok(())
         );
         //Check data ptr
@@ -911,6 +937,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -982,7 +1009,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Ok(())
         );
         //Check data ptr
@@ -1029,6 +1057,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -1100,7 +1129,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Ok(())
         );
         //Check data ptr

--- a/src/vm/hints/blake2s_utils.rs
+++ b/src/vm/hints/blake2s_utils.rs
@@ -122,11 +122,11 @@ pub fn compute_blake2s(
 */
 pub fn finalize_blake2s(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     const N_PACKED_INSTANCES: usize = 7;
-    let blake2s_ptr_end = get_ptr_from_var_name("blake2s_ptr_end", &ids, vm, hint_ap_tracking)?;
+    let blake2s_ptr_end = get_ptr_from_var_name("blake2s_ptr_end", ids, vm, hint_ap_tracking)?;
     let message: [u32; 16] = [0; 16];
     let mut modified_iv = IV;
     modified_iv[0] = IV[0] ^ 0x01010020;
@@ -275,7 +275,7 @@ mod tests {
 
     #[test]
     fn compute_blake2s_output_offset_zero() {
-        let hint_code = "from starkware.cairo.common.cairo_blake2s.blake2s_utils import compute_blake2s_func\ncompute_blake2s_func(segments=segments, output_ptr=ids.output)".as_bytes();
+        let hint_code = "from starkware.cairo.common.cairo_blake2s.blake2s_utils import compute_blake2s_func\ncompute_blake2s_func(segments=segments, output_ptr=ids.output)";
         //Create vm
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -311,14 +311,14 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Err(VirtualMachineError::CantSubOffset(5, 26))
         );
     }
 
     #[test]
     fn compute_blake2s_output_empty_segment() {
-        let hint_code = "from starkware.cairo.common.cairo_blake2s.blake2s_utils import compute_blake2s_func\ncompute_blake2s_func(segments=segments, output_ptr=ids.output)".as_bytes();
+        let hint_code = "from starkware.cairo.common.cairo_blake2s.blake2s_utils import compute_blake2s_func\ncompute_blake2s_func(segments=segments, output_ptr=ids.output)";
         //Create vm
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -354,14 +354,14 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Err(VirtualMachineError::UnexpectMemoryGap)
         );
     }
 
     #[test]
     fn compute_blake2s_output_not_relocatable() {
-        let hint_code = "from starkware.cairo.common.cairo_blake2s.blake2s_utils import compute_blake2s_func\ncompute_blake2s_func(segments=segments, output_ptr=ids.output)".as_bytes();
+        let hint_code = "from starkware.cairo.common.cairo_blake2s.blake2s_utils import compute_blake2s_func\ncompute_blake2s_func(segments=segments, output_ptr=ids.output)";
         //Create vm
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -397,7 +397,7 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Err(VirtualMachineError::ExpectedRelocatable(
                 MaybeRelocatable::from((0, 0))
             ))
@@ -406,7 +406,7 @@ mod tests {
 
     #[test]
     fn compute_blake2s_output_input_bigger_than_u32() {
-        let hint_code = "from starkware.cairo.common.cairo_blake2s.blake2s_utils import compute_blake2s_func\ncompute_blake2s_func(segments=segments, output_ptr=ids.output)".as_bytes();
+        let hint_code = "from starkware.cairo.common.cairo_blake2s.blake2s_utils import compute_blake2s_func\ncompute_blake2s_func(segments=segments, output_ptr=ids.output)";
         //Create vm
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -449,14 +449,14 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Err(VirtualMachineError::BigintToU32Fail)
         );
     }
 
     #[test]
     fn compute_blake2s_output_input_relocatable() {
-        let hint_code = "from starkware.cairo.common.cairo_blake2s.blake2s_utils import compute_blake2s_func\ncompute_blake2s_func(segments=segments, output_ptr=ids.output)".as_bytes();
+        let hint_code = "from starkware.cairo.common.cairo_blake2s.blake2s_utils import compute_blake2s_func\ncompute_blake2s_func(segments=segments, output_ptr=ids.output)";
         //Create vm
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -499,7 +499,7 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((4, 5))
             ))
@@ -508,7 +508,7 @@ mod tests {
 
     #[test]
     fn finalize_blake2s_valid() {
-        let hint_code = "# Add dummy pairs of input and output.\nfrom starkware.cairo.common.cairo_blake2s.blake2s_utils import IV, blake2s_compress\n\n_n_packed_instances = int(ids.N_PACKED_INSTANCES)\nassert 0 <= _n_packed_instances < 20\n_blake2s_input_chunk_size_felts = int(ids.INPUT_BLOCK_FELTS)\nassert 0 <= _blake2s_input_chunk_size_felts < 100\n\nmessage = [0] * _blake2s_input_chunk_size_felts\nmodified_iv = [IV[0] ^ 0x01010020] + IV[1:]\noutput = blake2s_compress(\n    message=message,\n    h=modified_iv,\n    t0=0,\n    t1=0,\n    f0=0xffffffff,\n    f1=0,\n)\npadding = (modified_iv + message + [0, 0xffffffff] + output) * (_n_packed_instances - 1)\nsegments.write_arg(ids.blake2s_ptr_end, padding)".as_bytes();
+        let hint_code = "# Add dummy pairs of input and output.\nfrom starkware.cairo.common.cairo_blake2s.blake2s_utils import IV, blake2s_compress\n\n_n_packed_instances = int(ids.N_PACKED_INSTANCES)\nassert 0 <= _n_packed_instances < 20\n_blake2s_input_chunk_size_felts = int(ids.INPUT_BLOCK_FELTS)\nassert 0 <= _blake2s_input_chunk_size_felts < 100\n\nmessage = [0] * _blake2s_input_chunk_size_felts\nmodified_iv = [IV[0] ^ 0x01010020] + IV[1:]\noutput = blake2s_compress(\n    message=message,\n    h=modified_iv,\n    t0=0,\n    t1=0,\n    f0=0xffffffff,\n    f1=0,\n)\npadding = (modified_iv + message + [0, 0xffffffff] + output) * (_n_packed_instances - 1)\nsegments.write_arg(ids.blake2s_ptr_end, padding)";
         //Create vm
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -544,7 +544,7 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Ok(())
         );
         //Check the inserted data
@@ -580,7 +580,7 @@ mod tests {
 
     #[test]
     fn finalize_blake2s_invalid_segment_taken() {
-        let hint_code = "# Add dummy pairs of input and output.\nfrom starkware.cairo.common.cairo_blake2s.blake2s_utils import IV, blake2s_compress\n\n_n_packed_instances = int(ids.N_PACKED_INSTANCES)\nassert 0 <= _n_packed_instances < 20\n_blake2s_input_chunk_size_felts = int(ids.INPUT_BLOCK_FELTS)\nassert 0 <= _blake2s_input_chunk_size_felts < 100\n\nmessage = [0] * _blake2s_input_chunk_size_felts\nmodified_iv = [IV[0] ^ 0x01010020] + IV[1:]\noutput = blake2s_compress(\n    message=message,\n    h=modified_iv,\n    t0=0,\n    t1=0,\n    f0=0xffffffff,\n    f1=0,\n)\npadding = (modified_iv + message + [0, 0xffffffff] + output) * (_n_packed_instances - 1)\nsegments.write_arg(ids.blake2s_ptr_end, padding)".as_bytes();
+        let hint_code = "# Add dummy pairs of input and output.\nfrom starkware.cairo.common.cairo_blake2s.blake2s_utils import IV, blake2s_compress\n\n_n_packed_instances = int(ids.N_PACKED_INSTANCES)\nassert 0 <= _n_packed_instances < 20\n_blake2s_input_chunk_size_felts = int(ids.INPUT_BLOCK_FELTS)\nassert 0 <= _blake2s_input_chunk_size_felts < 100\n\nmessage = [0] * _blake2s_input_chunk_size_felts\nmodified_iv = [IV[0] ^ 0x01010020] + IV[1:]\noutput = blake2s_compress(\n    message=message,\n    h=modified_iv,\n    t0=0,\n    t1=0,\n    f0=0xffffffff,\n    f1=0,\n)\npadding = (modified_iv + message + [0, 0xffffffff] + output) * (_n_packed_instances - 1)\nsegments.write_arg(ids.blake2s_ptr_end, padding)";
         //Create vm
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -623,7 +623,7 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((1, 0)),
@@ -636,7 +636,7 @@ mod tests {
 
     #[test]
     fn finalize_blake2s_invalid_no_ids() {
-        let hint_code = "# Add dummy pairs of input and output.\nfrom starkware.cairo.common.cairo_blake2s.blake2s_utils import IV, blake2s_compress\n\n_n_packed_instances = int(ids.N_PACKED_INSTANCES)\nassert 0 <= _n_packed_instances < 20\n_blake2s_input_chunk_size_felts = int(ids.INPUT_BLOCK_FELTS)\nassert 0 <= _blake2s_input_chunk_size_felts < 100\n\nmessage = [0] * _blake2s_input_chunk_size_felts\nmodified_iv = [IV[0] ^ 0x01010020] + IV[1:]\noutput = blake2s_compress(\n    message=message,\n    h=modified_iv,\n    t0=0,\n    t1=0,\n    f0=0xffffffff,\n    f1=0,\n)\npadding = (modified_iv + message + [0, 0xffffffff] + output) * (_n_packed_instances - 1)\nsegments.write_arg(ids.blake2s_ptr_end, padding)".as_bytes();
+        let hint_code = "# Add dummy pairs of input and output.\nfrom starkware.cairo.common.cairo_blake2s.blake2s_utils import IV, blake2s_compress\n\n_n_packed_instances = int(ids.N_PACKED_INSTANCES)\nassert 0 <= _n_packed_instances < 20\n_blake2s_input_chunk_size_felts = int(ids.INPUT_BLOCK_FELTS)\nassert 0 <= _blake2s_input_chunk_size_felts < 100\n\nmessage = [0] * _blake2s_input_chunk_size_felts\nmodified_iv = [IV[0] ^ 0x01010020] + IV[1:]\noutput = blake2s_compress(\n    message=message,\n    h=modified_iv,\n    t0=0,\n    t1=0,\n    f0=0xffffffff,\n    f1=0,\n)\npadding = (modified_iv + message + [0, 0xffffffff] + output) * (_n_packed_instances - 1)\nsegments.write_arg(ids.blake2s_ptr_end, padding)";
         //Create vm
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -662,14 +662,14 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, HashMap::new(), &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &HashMap::new(), &ApTracking::default()),
             Err(VirtualMachineError::FailedToGetIds)
         );
     }
 
     #[test]
     fn blake2s_add_uint256_valid_zero() {
-        let hint_code = "B = 32\nMASK = 2 ** 32 - 1\nsegments.write_arg(ids.data, [(ids.low >> (B * i)) & MASK for i in range(4)])\nsegments.write_arg(ids.data + 4, [(ids.high >> (B * i)) & MASK for i in range(4)]".as_bytes();
+        let hint_code = "B = 32\nMASK = 2 ** 32 - 1\nsegments.write_arg(ids.data, [(ids.low >> (B * i)) & MASK for i in range(4)])\nsegments.write_arg(ids.data + 4, [(ids.high >> (B * i)) & MASK for i in range(4)]";
         //Create vm
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -746,7 +746,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Ok(())
         );
         //Check data ptr
@@ -787,7 +787,7 @@ mod tests {
 
     #[test]
     fn blake2s_add_uint256_valid_non_zero() {
-        let hint_code = "B = 32\nMASK = 2 ** 32 - 1\nsegments.write_arg(ids.data, [(ids.low >> (B * i)) & MASK for i in range(4)])\nsegments.write_arg(ids.data + 4, [(ids.high >> (B * i)) & MASK for i in range(4)]".as_bytes();
+        let hint_code = "B = 32\nMASK = 2 ** 32 - 1\nsegments.write_arg(ids.data, [(ids.low >> (B * i)) & MASK for i in range(4)])\nsegments.write_arg(ids.data + 4, [(ids.high >> (B * i)) & MASK for i in range(4)]";
         //Create vm
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -864,7 +864,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Ok(())
         );
         //Check data ptr
@@ -905,7 +905,7 @@ mod tests {
 
     #[test]
     fn blake2s_add_uint256_bigend_valid_zero() {
-        let hint_code = "B = 32\nMASK = 2 ** 32 - 1\nsegments.write_arg(ids.data, [(ids.high >> (B * (3 - i))) & MASK for i in range(4)])\nsegments.write_arg(ids.data + 4, [(ids.low >> (B * (3 - i))) & MASK for i in range(4)])".as_bytes();
+        let hint_code = "B = 32\nMASK = 2 ** 32 - 1\nsegments.write_arg(ids.data, [(ids.high >> (B * (3 - i))) & MASK for i in range(4)])\nsegments.write_arg(ids.data + 4, [(ids.low >> (B * (3 - i))) & MASK for i in range(4)])";
         //Create vm
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -982,7 +982,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Ok(())
         );
         //Check data ptr
@@ -1023,7 +1023,7 @@ mod tests {
 
     #[test]
     fn blake2s_add_uint256_bigend_valid_non_zero() {
-        let hint_code = "B = 32\nMASK = 2 ** 32 - 1\nsegments.write_arg(ids.data, [(ids.high >> (B * (3 - i))) & MASK for i in range(4)])\nsegments.write_arg(ids.data + 4, [(ids.low >> (B * (3 - i))) & MASK for i in range(4)])".as_bytes();
+        let hint_code = "B = 32\nMASK = 2 ** 32 - 1\nsegments.write_arg(ids.data, [(ids.high >> (B * (3 - i))) & MASK for i in range(4)])\nsegments.write_arg(ids.data + 4, [(ids.low >> (B * (3 - i))) & MASK for i in range(4)])";
         //Create vm
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -1100,7 +1100,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Ok(())
         );
         //Check data ptr

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use num_bigint::BigInt;
 
 use crate::serde::deserialize_program::ApTracking;
-use crate::types::instruction::Register;
+use crate::types::{hint_executor::HintExecutor, instruction::Register};
 use crate::vm::errors::vm_errors::VirtualMachineError;
 use crate::vm::hints::blake2s_utils::{
     blake2s_add_uint256, blake2s_add_uint256_bigend, compute_blake2s, finalize_blake2s,
@@ -54,90 +54,100 @@ pub struct HintReference {
     pub immediate: Option<BigInt>,
 }
 
-pub fn execute_hint(
-    vm: &mut VirtualMachine,
-    code: &str,
-    ids: &HashMap<String, BigInt>,
-    ap_tracking: &ApTracking,
-) -> Result<(), VirtualMachineError> {
-    match code {
-        hint_code::ADD_SEGMENT => add_segment(vm),
-        hint_code::IS_NN => is_nn(vm, ids, None),
-        hint_code::IS_NN_OUT_OF_RANGE => is_nn_out_of_range(vm, ids, None),
-        hint_code::IS_LE_FELT => is_le_felt(vm, ids, None),
-        hint_code::ASSERT_LE_FELT => assert_le_felt(vm, ids, None),
-        hint_code::ASSERT_250_BITS => assert_250_bit(vm, ids, None),
-        hint_code::IS_POSITIVE => is_positive(vm, ids, Some(ap_tracking)),
-        hint_code::SPLIT_INT_ASSERT_RANGE => split_int_assert_range(vm, ids, None),
-        hint_code::SPLIT_INT => split_int(vm, ids, None),
-        hint_code::ASSERT_NOT_EQUAL => assert_not_equal(vm, ids, None),
-        hint_code::ASSERT_NN => assert_nn(vm, ids, None),
-        hint_code::SQRT => sqrt(vm, ids, None),
-        hint_code::ASSERT_NOT_ZERO => assert_not_zero(vm, ids, None),
-        hint_code::VM_EXIT_SCOPE => exit_scope(vm),
-        hint_code::MEMCPY_ENTER_SCOPE => memcpy_enter_scope(vm, ids, Some(ap_tracking)),
-        hint_code::MEMSET_ENTER_SCOPE => memset_enter_scope(vm, ids, Some(ap_tracking)),
-        hint_code::MEMCPY_CONTINUE_COPYING => memcpy_continue_copying(vm, ids, Some(ap_tracking)),
-        hint_code::MEMSET_CONTINUE_LOOP => memset_continue_loop(vm, ids, Some(ap_tracking)),
-        hint_code::SPLIT_FELT => split_felt(vm, ids, None),
-        hint_code::UNSIGNED_DIV_REM => unsigned_div_rem(vm, ids, None),
-        hint_code::SIGNED_DIV_REM => signed_div_rem(vm, ids, None),
-        hint_code::ASSERT_LT_FELT => assert_lt_felt(vm, ids, None),
-        hint_code::FIND_ELEMENT => find_element(vm, ids, None),
-        hint_code::SEARCH_SORTED_LOWER => search_sorted_lower(vm, ids, None),
-        hint_code::POW => pow(vm, ids, Some(ap_tracking)),
-        hint_code::SET_ADD => set_add(vm, ids, None),
-        hint_code::DICT_NEW => dict_new(vm),
-        hint_code::DICT_READ => dict_read(vm, ids, None),
-        hint_code::DICT_WRITE => dict_write(vm, ids, None),
-        hint_code::DEFAULT_DICT_NEW => default_dict_new(vm, ids, Some(ap_tracking)),
-        hint_code::SQUASH_DICT_INNER_FIRST_ITERATION => {
-            squash_dict_inner_first_iteration(vm, ids, Some(ap_tracking))
+pub struct BuiltinHintExecutor {}
+
+impl HintExecutor for BuiltinHintExecutor {
+    fn execute_hint(
+        &self,
+        vm: &mut VirtualMachine,
+        code: &str,
+        ids: &HashMap<String, BigInt>,
+        ap_tracking: &ApTracking,
+    ) -> Result<(), VirtualMachineError> {
+        match code {
+            hint_code::ADD_SEGMENT => add_segment(vm),
+            hint_code::IS_NN => is_nn(vm, ids, None),
+            hint_code::IS_NN_OUT_OF_RANGE => is_nn_out_of_range(vm, ids, None),
+            hint_code::IS_LE_FELT => is_le_felt(vm, ids, None),
+            hint_code::ASSERT_LE_FELT => assert_le_felt(vm, ids, None),
+            hint_code::ASSERT_250_BITS => assert_250_bit(vm, ids, None),
+            hint_code::IS_POSITIVE => is_positive(vm, ids, Some(ap_tracking)),
+            hint_code::SPLIT_INT_ASSERT_RANGE => split_int_assert_range(vm, ids, None),
+            hint_code::SPLIT_INT => split_int(vm, ids, None),
+            hint_code::ASSERT_NOT_EQUAL => assert_not_equal(vm, ids, None),
+            hint_code::ASSERT_NN => assert_nn(vm, ids, None),
+            hint_code::SQRT => sqrt(vm, ids, None),
+            hint_code::ASSERT_NOT_ZERO => assert_not_zero(vm, ids, None),
+            hint_code::VM_EXIT_SCOPE => exit_scope(vm),
+            hint_code::MEMCPY_ENTER_SCOPE => memcpy_enter_scope(vm, ids, Some(ap_tracking)),
+            hint_code::MEMSET_ENTER_SCOPE => memset_enter_scope(vm, ids, Some(ap_tracking)),
+            hint_code::MEMCPY_CONTINUE_COPYING => {
+                memcpy_continue_copying(vm, ids, Some(ap_tracking))
+            }
+            hint_code::MEMSET_CONTINUE_LOOP => memset_continue_loop(vm, ids, Some(ap_tracking)),
+            hint_code::SPLIT_FELT => split_felt(vm, ids, None),
+            hint_code::UNSIGNED_DIV_REM => unsigned_div_rem(vm, ids, None),
+            hint_code::SIGNED_DIV_REM => signed_div_rem(vm, ids, None),
+            hint_code::ASSERT_LT_FELT => assert_lt_felt(vm, ids, None),
+            hint_code::FIND_ELEMENT => find_element(vm, ids, None),
+            hint_code::SEARCH_SORTED_LOWER => search_sorted_lower(vm, ids, None),
+            hint_code::POW => pow(vm, ids, Some(ap_tracking)),
+            hint_code::SET_ADD => set_add(vm, ids, None),
+            hint_code::DICT_NEW => dict_new(vm),
+            hint_code::DICT_READ => dict_read(vm, ids, None),
+            hint_code::DICT_WRITE => dict_write(vm, ids, None),
+            hint_code::DEFAULT_DICT_NEW => default_dict_new(vm, ids, Some(ap_tracking)),
+            hint_code::SQUASH_DICT_INNER_FIRST_ITERATION => {
+                squash_dict_inner_first_iteration(vm, ids, Some(ap_tracking))
+            }
+            hint_code::USORT_ENTER_SCOPE => usort_enter_scope(vm),
+            hint_code::USORT_BODY => usort_body(vm, ids, None),
+            hint_code::USORT_VERIFY => verify_usort(vm, ids, None),
+            hint_code::USORT_VERIFY_MULTIPLICITY_ASSERT => verify_multiplicity_assert(vm),
+            hint_code::USORT_VERIFY_MULTIPLICITY_BODY => verify_multiplicity_body(vm, ids, None),
+            hint_code::BLAKE2S_COMPUTE => compute_blake2s(vm, ids, Some(ap_tracking)),
+            hint_code::VERIFY_ZERO => verify_zero(vm, ids, Some(ap_tracking)),
+            hint_code::NONDET_BIGINT3 => nondet_bigint3(vm, ids, Some(ap_tracking)),
+            hint_code::REDUCE => reduce(vm, ids, None),
+            hint_code::BLAKE2S_FINALIZE => finalize_blake2s(vm, ids, Some(ap_tracking)),
+            hint_code::BLAKE2S_ADD_UINT256 => blake2s_add_uint256(vm, ids, Some(ap_tracking)),
+            hint_code::BLAKE2S_ADD_UINT256_BIGEND => {
+                blake2s_add_uint256_bigend(vm, ids, Some(ap_tracking))
+            }
+            hint_code::UNSAFE_KECCAK => unsafe_keccak(vm, ids, None),
+            hint_code::UNSAFE_KECCAK_FINALIZE => unsafe_keccak_finalize(vm, ids, None),
+            hint_code::SQUASH_DICT_INNER_SKIP_LOOP => {
+                squash_dict_inner_skip_loop(vm, ids, Some(ap_tracking))
+            }
+            hint_code::SQUASH_DICT_INNER_CHECK_ACCESS_INDEX => {
+                squash_dict_inner_check_access_index(vm, ids, Some(ap_tracking))
+            }
+            hint_code::SQUASH_DICT_INNER_CONTINUE_LOOP => {
+                squash_dict_inner_continue_loop(vm, ids, Some(ap_tracking))
+            }
+            hint_code::SQUASH_DICT_INNER_ASSERT_LEN_KEYS => squash_dict_inner_assert_len_keys(vm),
+            hint_code::SQUASH_DICT_INNER_LEN_ASSERT => squash_dict_inner_len_assert(vm),
+            hint_code::SQUASH_DICT_INNER_USED_ACCESSES_ASSERT => {
+                squash_dict_inner_used_accesses_assert(vm, ids, Some(ap_tracking))
+            }
+            hint_code::SQUASH_DICT_INNER_NEXT_KEY => {
+                squash_dict_inner_next_key(vm, ids, Some(ap_tracking))
+            }
+            hint_code::SQUASH_DICT => squash_dict(vm, ids, Some(ap_tracking)),
+            hint_code::VM_ENTER_SCOPE => enter_scope(vm),
+            hint_code::DICT_UPDATE => dict_update(vm, ids, None),
+            hint_code::DICT_SQUASH_COPY_DICT => dict_squash_copy_dict(vm, ids, Some(ap_tracking)),
+            hint_code::DICT_SQUASH_UPDATE_PTR => dict_squash_update_ptr(vm, ids, Some(ap_tracking)),
+            hint_code::UINT256_ADD => uint256_add(vm, ids, None),
+            hint_code::SPLIT_64 => split_64(vm, ids, None),
+            hint_code::UINT256_SQRT => uint256_sqrt(vm, ids, None),
+            hint_code::UINT256_SIGNED_NN => uint256_signed_nn(vm, ids, None),
+            hint_code::UINT256_UNSIGNED_DIV_REM => uint256_unsigned_div_rem(vm, ids, None),
+            code => Err(VirtualMachineError::UnknownHint(code.to_string())),
         }
-        hint_code::USORT_ENTER_SCOPE => usort_enter_scope(vm),
-        hint_code::USORT_BODY => usort_body(vm, ids, None),
-        hint_code::USORT_VERIFY => verify_usort(vm, ids, None),
-        hint_code::USORT_VERIFY_MULTIPLICITY_ASSERT => verify_multiplicity_assert(vm),
-        hint_code::USORT_VERIFY_MULTIPLICITY_BODY => verify_multiplicity_body(vm, ids, None),
-        hint_code::BLAKE2S_COMPUTE => compute_blake2s(vm, ids, Some(ap_tracking)),
-        hint_code::VERIFY_ZERO => verify_zero(vm, ids, Some(ap_tracking)),
-        hint_code::NONDET_BIGINT3 => nondet_bigint3(vm, ids, Some(ap_tracking)),
-        hint_code::REDUCE => reduce(vm, &ids, None),
-        hint_code::BLAKE2S_FINALIZE => finalize_blake2s(vm, ids, Some(ap_tracking)),
-        hint_code::BLAKE2S_ADD_UINT256 => blake2s_add_uint256(vm, ids, Some(ap_tracking)),
-        hint_code::BLAKE2S_ADD_UINT256_BIGEND=> blake2s_add_uint256_bigend(vm, ids, Some(ap_tracking)),
-        hint_code::UNSAFE_KECCAK => unsafe_keccak(vm, ids, None),
-        hint_code::UNSAFE_KECCAK_FINALIZE => unsafe_keccak_finalize(vm, ids, None),
-        hint_code::SQUASH_DICT_INNER_SKIP_LOOP => {
-            squash_dict_inner_skip_loop(vm, ids, Some(ap_tracking))
-        }
-        hint_code::SQUASH_DICT_INNER_CHECK_ACCESS_INDEX => {
-            squash_dict_inner_check_access_index(vm, ids, Some(ap_tracking))
-        }
-        hint_code::SQUASH_DICT_INNER_CONTINUE_LOOP => {
-            squash_dict_inner_continue_loop(vm, ids, Some(ap_tracking))
-        }
-        hint_code::SQUASH_DICT_INNER_ASSERT_LEN_KEYS => squash_dict_inner_assert_len_keys(vm),
-        hint_code::SQUASH_DICT_INNER_LEN_ASSERT => squash_dict_inner_len_assert(vm),
-        hint_code::SQUASH_DICT_INNER_USED_ACCESSES_ASSERT => {
-            squash_dict_inner_used_accesses_assert(vm, ids, Some(ap_tracking))
-        }
-        hint_code::SQUASH_DICT_INNER_NEXT_KEY => {
-            squash_dict_inner_next_key(vm, ids, Some(ap_tracking))
-        }
-        hint_code::SQUASH_DICT => squash_dict(vm, ids, Some(ap_tracking)),
-        hint_code::VM_ENTER_SCOPE => enter_scope(vm),
-        hint_code::DICT_UPDATE => dict_update(vm, ids, None),
-        hint_code::DICT_SQUASH_COPY_DICT => dict_squash_copy_dict(vm, ids, Some(ap_tracking)),
-        hint_code::DICT_SQUASH_UPDATE_PTR => dict_squash_update_ptr(vm, ids, Some(ap_tracking)),
-        hint_code::UINT256_ADD => uint256_add(vm, ids, None),
-        hint_code::SPLIT_64 => split_64(vm, ids, None),
-        hint_code::UINT256_SQRT => uint256_sqrt(vm, ids, None),
-        hint_code::UINT256_SIGNED_NN => uint256_signed_nn(vm, ids, None),
-        hint_code::UINT256_UNSIGNED_DIV_REM => uint256_unsigned_div_rem(vm, ids, None),
-        code => Err(VirtualMachineError::UnknownHint(code.to_string())),
     }
 }
+
 #[cfg(test)]
 mod tests {
     use std::ops::Shl;
@@ -156,6 +166,8 @@ mod tests {
 
     use super::*;
 
+    static HINT_EXECUTOR: BuiltinHintExecutor = BuiltinHintExecutor {};
+
     #[test]
     fn run_alloc_hint_empty_memory() {
         let hint_code = "memory[ap] = segments.add()";
@@ -164,9 +176,11 @@ mod tests {
             //ap value is (0,0)
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         //ids and references are not needed for this test
-        execute_hint(&mut vm, hint_code, &HashMap::new(), &ApTracking::new())
+        vm.hint_executor
+            .execute_hint(&mut vm, hint_code, &HashMap::new(), &ApTracking::new())
             .expect("Error while executing hint");
         //first new segment is added
         assert_eq!(vm.segments.num_segments, 1);
@@ -184,6 +198,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         //Add 3 segments to the memory
         for _ in 0..3 {
@@ -191,7 +206,8 @@ mod tests {
         }
         vm.run_context.ap = MaybeRelocatable::from((2, 6));
         //ids and references are not needed for this test
-        execute_hint(&mut vm, hint_code, &HashMap::new(), &ApTracking::new())
+        vm.hint_executor
+            .execute_hint(&mut vm, hint_code, &HashMap::new(), &ApTracking::new())
             .expect("Error while executing hint");
         //Segment N°4 is added
         assert_eq!(vm.segments.num_segments, 4);
@@ -209,6 +225,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         //Add 3 segments to the memory
         for _ in 0..3 {
@@ -224,7 +241,8 @@ mod tests {
             .unwrap();
         //ids and references are not needed for this test
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &HashMap::new(), &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &HashMap::new(), &ApTracking::new()),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((2, 6)),
@@ -242,10 +260,12 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &HashMap::new(), &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &HashMap::new(), &ApTracking::new()),
             Err(VirtualMachineError::UnknownHint(hint_code.to_string())),
         );
     }
@@ -260,6 +280,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -290,7 +311,8 @@ mod tests {
             },
         )]);
         //Execute the hint
-        execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
+        vm.hint_executor
+            .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
             .expect("Error while executing hint");
         //Check that ap now contains false (0)
         assert_eq!(
@@ -309,6 +331,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -339,7 +362,8 @@ mod tests {
             },
         )]);
         //Execute the hint
-        execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
+        vm.hint_executor
+            .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
             .expect("Error while executing hint");
         //Check that ap now contains true (1)
         assert_eq!(
@@ -360,6 +384,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -393,7 +418,8 @@ mod tests {
             },
         )]);
         //Execute the hint
-        execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
+        vm.hint_executor
+            .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
             .expect("Error while executing hint");
         //Check that ap now contains true (1)
         assert_eq!(
@@ -409,6 +435,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -440,7 +467,8 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, &hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, &hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::NoRangeCheckBuiltin)
         );
     }
@@ -455,6 +483,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -466,7 +495,8 @@ mod tests {
         ids.insert(String::from("b"), bigint!(0));
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::IncorrectIds(
                 vec![String::from("a")],
                 vec![String::from("b")]
@@ -484,6 +514,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -509,7 +540,8 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::MemoryGet(MaybeRelocatable::from((
                 0, 0
             ))))
@@ -526,6 +558,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -557,7 +590,8 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((0, 0))
             ))
@@ -575,6 +609,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -646,7 +681,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
         //Hint would return an error if the assertion fails
@@ -662,6 +698,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -714,7 +751,10 @@ mod tests {
             ),
         ]);
         //Execute the hint
-        assert!(execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()).is_ok());
+        assert!(vm
+            .hint_executor
+            .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
+            .is_ok());
     }
 
     #[test]
@@ -724,6 +764,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -777,7 +818,8 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, &hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, &hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::NoRangeCheckBuiltin)
         );
     }
@@ -792,6 +834,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -843,7 +886,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((0, 0)),
@@ -861,6 +905,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -915,7 +960,8 @@ mod tests {
         // Since the ids are a map, the order might not always match and so the error returned
         // sometimes might be different
         assert!(matches!(
-            execute_hint(&mut vm, &hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, &hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::IncorrectIds(_, _))
         ));
     }
@@ -931,6 +977,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
 
         vm.segments.add(&mut vm.memory, None);
@@ -962,7 +1009,8 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
         //Hint would return an error if the assertion fails
@@ -979,6 +1027,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -1010,7 +1059,8 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ValueOutOfRange(bigint!(-1)))
         );
     }
@@ -1026,6 +1076,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
 
         vm.segments.add(&mut vm.memory, None);
@@ -1057,7 +1108,8 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::IncorrectIds(
                 vec![String::from("a")],
                 vec![String::from("incorrect_id")],
@@ -1076,6 +1128,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
 
         vm.segments.add(&mut vm.memory, None);
@@ -1107,7 +1160,8 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::FailedToGetIds)
         );
     }
@@ -1123,6 +1177,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
 
         vm.segments.add(&mut vm.memory, None);
@@ -1154,7 +1209,8 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((0, 0))
             ))
@@ -1169,6 +1225,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![],
             false,
+            &HINT_EXECUTOR,
         );
 
         vm.segments.add(&mut vm.memory, None);
@@ -1200,7 +1257,8 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::NoRangeCheckBuiltin)
         );
     }
@@ -1216,6 +1274,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
 
         vm.segments.add(&mut vm.memory, None);
@@ -1239,7 +1298,8 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::FailedToGetIds)
         );
     }
@@ -1255,6 +1315,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -1326,7 +1387,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::NonLeFelt(bigint!(2), bigint!(1)))
         );
     }
@@ -1342,6 +1404,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -1413,7 +1476,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::FailedToGetIds)
         );
     }
@@ -1429,6 +1493,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -1500,7 +1565,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((0, 0))
             ))
@@ -1518,6 +1584,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -1589,7 +1656,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((0, 1))
             ))
@@ -1607,6 +1675,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -1637,7 +1706,8 @@ mod tests {
             },
         )]);
         //Execute the hint
-        execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
+        vm.hint_executor
+            .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
             .expect("Error while executing hint");
         assert_eq!(
             vm.memory.get(&MaybeRelocatable::from((1, 0))),
@@ -1656,6 +1726,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -1686,7 +1757,8 @@ mod tests {
             },
         )]);
         //Execute the hint
-        execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
+        vm.hint_executor
+            .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
             .expect("Error while executing hint");
         assert_eq!(
             vm.memory.get(&MaybeRelocatable::from((1, 0))),
@@ -1701,6 +1773,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -1752,7 +1825,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::AssertNotEqualFail(
                 MaybeRelocatable::from(bigint!(1)),
                 MaybeRelocatable::from(bigint!(1))
@@ -1768,6 +1842,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -1819,7 +1894,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
     }
@@ -1832,6 +1908,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -1887,7 +1964,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::AssertNotEqualFail(
                 MaybeRelocatable::from(bigint!(-1)),
                 MaybeRelocatable::from(bigint_str!(
@@ -1904,6 +1982,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -1955,7 +2034,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::AssertNotEqualFail(
                 MaybeRelocatable::from((0, 0)),
                 MaybeRelocatable::from((0, 0))
@@ -1971,6 +2051,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -2022,7 +2103,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
     }
@@ -2034,6 +2116,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -2085,7 +2168,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::DiffIndexComp(
                 relocatable!(1, 0),
                 relocatable!(0, 0)
@@ -2101,6 +2185,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -2152,7 +2237,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::DiffTypeComparison(
                 MaybeRelocatable::from((1, 0)),
                 MaybeRelocatable::from(bigint!(1))
@@ -2168,6 +2254,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         //Create references
         vm.references = HashMap::from([(
@@ -2198,7 +2285,8 @@ mod tests {
         ids.insert(String::from("value"), bigint!(0));
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
     }
@@ -2211,6 +2299,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         //Create references
         vm.references = HashMap::from([(
@@ -2241,7 +2330,8 @@ mod tests {
         ids.insert(String::from("value"), bigint!(0));
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::AssertNotZero(bigint!(0), vm.prime))
         );
     }
@@ -2254,6 +2344,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         //Create references
         vm.references = HashMap::from([(
@@ -2284,7 +2375,8 @@ mod tests {
         ids.insert(String::from("value"), bigint!(0));
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::AssertNotZero(
                 vm.prime.clone(),
                 vm.prime
@@ -2300,6 +2392,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         //Create references
         vm.references = HashMap::from([(
@@ -2330,7 +2423,8 @@ mod tests {
         ids.insert(String::from("value"), bigint!(10));
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::FailedToGetReference(bigint!(10)))
         );
     }
@@ -2343,6 +2437,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         //Create references
         vm.references = HashMap::from([(
@@ -2373,7 +2468,8 @@ mod tests {
         ids.insert(String::from("incorrect_id"), bigint!(0));
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::IncorrectIds(
                 vec![String::from("value")],
                 vec![String::from("incorrect_id")],
@@ -2389,6 +2485,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         vm.references = HashMap::from([(
             0,
@@ -2418,7 +2515,8 @@ mod tests {
         ids.insert(String::from("value"), bigint!(0));
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((0, 0))
             ))
@@ -2432,6 +2530,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -2463,7 +2562,8 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::SplitIntNotZero)
         );
     }
@@ -2475,6 +2575,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -2506,7 +2607,8 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
     }
@@ -2518,6 +2620,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -2609,7 +2712,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
         assert_eq!(
@@ -2625,6 +2729,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -2716,7 +2821,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::SplitIntLimbOutOfRange(bigint!(100)))
         );
     }
@@ -2733,6 +2839,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -2777,7 +2884,8 @@ mod tests {
             ),
         ]);
         //Execute the hint
-        execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
+        vm.hint_executor
+            .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
             .expect("Error while executing hint");
         //Check that is_positive now contains 1 (true)
         assert_eq!(
@@ -2798,6 +2906,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -2842,7 +2951,8 @@ mod tests {
             ),
         ]);
         //Execute the hint
-        execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
+        vm.hint_executor
+            .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
             .expect("Error while executing hint");
         //Check that is_positive now contains 0 (false)
         assert_eq!(
@@ -2863,6 +2973,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -2911,7 +3022,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ValueOutsideValidRange(as_int(
                 &BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217727]),
                 &vm.prime
@@ -2930,6 +3042,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -2981,7 +3094,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((0, 1)),
@@ -3000,6 +3114,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -3044,7 +3159,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
         //Check that root (0,1) has the square root of 81
@@ -3062,6 +3178,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -3106,7 +3223,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ValueOutside250BitRange(bigint_str!(
                 b"3618502788666131213697322783095070105623107215331596699973092056135872020400"
             )))
@@ -3121,6 +3239,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -3172,7 +3291,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((0, 1)),
@@ -3193,6 +3313,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -3267,7 +3388,10 @@ mod tests {
             ),
         ]);
         //Execute the hint
-        assert!(execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()).is_ok());
+        assert!(vm
+            .hint_executor
+            .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
+            .is_ok());
         assert_eq!(
             vm.memory.get(&MaybeRelocatable::from((0, 0))),
             Ok(Some(&MaybeRelocatable::from(bigint!(2))))
@@ -3288,6 +3412,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -3363,7 +3488,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::OutOfValidRange(
                 bigint!(-5),
                 bigint_str!(b"10633823966279327296825105735305134080")
@@ -3378,6 +3504,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -3453,7 +3580,8 @@ mod tests {
         ]);
 
         assert_eq!(
-            execute_hint(&mut vm, &hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, &hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::NoRangeCheckBuiltin)
         );
     }
@@ -3468,6 +3596,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -3549,7 +3678,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((0, 0)),
@@ -3570,6 +3700,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -3645,7 +3776,8 @@ mod tests {
         ]);
         //Execute the hint
         assert!(matches!(
-            execute_hint(&mut vm, &hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, &hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::IncorrectIds(_, _))
         ))
     }
@@ -3660,6 +3792,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..5 {
             vm.segments.add(&mut vm.memory, None);
@@ -3764,7 +3897,10 @@ mod tests {
             ),
         ]);
         //Execute the hint
-        assert!(execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()).is_ok());
+        assert!(vm
+            .hint_executor
+            .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
+            .is_ok());
         assert_eq!(
             vm.memory.get(&MaybeRelocatable::from((0, 0))),
             Ok(Some(&MaybeRelocatable::from(bigint!(0))))
@@ -3785,6 +3921,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..5 {
             vm.segments.add(&mut vm.memory, None);
@@ -3889,7 +4026,10 @@ mod tests {
             ),
         ]);
         //Execute the hint
-        assert!(execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()).is_ok());
+        assert!(vm
+            .hint_executor
+            .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
+            .is_ok());
         assert_eq!(
             vm.memory.get(&MaybeRelocatable::from((0, 0))),
             Ok(Some(&MaybeRelocatable::from(bigint!(4))))
@@ -3910,6 +4050,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..5 {
             vm.segments.add(&mut vm.memory, None);
@@ -4015,7 +4156,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::OutOfValidRange(
                 bigint!(-5),
                 bigint_str!(b"10633823966279327296825105735305134080")
@@ -4030,6 +4172,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..5 {
             vm.segments.add(&mut vm.memory, None);
@@ -4135,7 +4278,8 @@ mod tests {
         ]);
 
         assert_eq!(
-            execute_hint(&mut vm, &hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, &hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::NoRangeCheckBuiltin)
         );
     }
@@ -4150,6 +4294,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..5 {
             vm.segments.add(&mut vm.memory, None);
@@ -4261,7 +4406,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((0, 1)),
@@ -4282,6 +4428,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..5 {
             vm.segments.add(&mut vm.memory, None);
@@ -4387,7 +4534,8 @@ mod tests {
         ]);
         //Execute the hint
         assert!(matches!(
-            execute_hint(&mut vm, &hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, &hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::IncorrectIds(_, _))
         ))
     }
@@ -4399,6 +4547,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -4456,7 +4605,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
         //Hint would return an error if the assertion fails
@@ -4479,6 +4629,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory, None);
@@ -4536,7 +4687,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ValueOutside250BitRange(
                 bigint!(1).shl(251i32)
             ))
@@ -4555,6 +4707,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -4623,7 +4776,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
 
@@ -4652,6 +4806,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -4718,7 +4873,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &incomplete_ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &incomplete_ids, &ApTracking::new()),
             Err(VirtualMachineError::IncorrectIds(
                 vec![
                     String::from("high"),
@@ -4741,6 +4897,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -4810,7 +4967,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::FailedToGetIds)
         );
     }
@@ -4827,6 +4985,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -4904,7 +5063,8 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((2, 0)),
@@ -4927,6 +5087,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -5004,7 +5165,8 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((2, 1)),
@@ -5027,6 +5189,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -5095,7 +5258,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((1, 3))
             ))
@@ -5114,6 +5278,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         //Initialize memory segements
         for _ in 0..3 {
@@ -5171,7 +5336,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
     }
@@ -5188,6 +5354,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         //Initialize memory segements
         for _ in 0..3 {
@@ -5245,7 +5412,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::AssertLtFelt(bigint!(3), bigint!(2)))
         );
     }
@@ -5262,6 +5430,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         //Initialize memory segements
         for _ in 0..3 {
@@ -5318,7 +5487,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::IncorrectIds(
                 vec![String::from("a"), String::from("b"),],
                 vec![String::from("a"),],
@@ -5338,6 +5508,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         //Initialize memory segements
         for _ in 0..3 {
@@ -5396,7 +5567,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::FailedToGetIds)
         );
     }
@@ -5413,6 +5585,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         //Initialize memory segements
         for _ in 0..3 {
@@ -5470,7 +5643,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((1, 1))
             ))
@@ -5489,6 +5663,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         //Initialize memory segements
         for _ in 0..3 {
@@ -5546,7 +5721,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((1, 2))
             ))
@@ -5565,6 +5741,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         //Initialize memory segements
         for _ in 0..3 {
@@ -5622,7 +5799,8 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::FailedToGetIds)
         );
     }
@@ -5634,6 +5812,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
 
         // initialize memory segments
@@ -5666,7 +5845,10 @@ mod tests {
             },
         )]);
 
-        assert!(execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()).is_ok());
+        assert!(vm
+            .hint_executor
+            .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
+            .is_ok());
     }
 
     #[test]
@@ -5676,6 +5858,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
 
         // initialize memory segments
@@ -5710,7 +5893,8 @@ mod tests {
         )]);
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((0, 1))
             ))
@@ -5724,6 +5908,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
 
         // initialize memory segments
@@ -5761,7 +5946,10 @@ mod tests {
             },
         )]);
 
-        assert!(execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()).is_ok());
+        assert!(vm
+            .hint_executor
+            .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
+            .is_ok());
     }
 
     #[test]
@@ -5771,6 +5959,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
 
         // initialize memory segments
@@ -5809,7 +5998,8 @@ mod tests {
         )]);
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::VariableNotInScopeError(
                 "n".to_string()
             ))
@@ -5823,6 +6013,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
 
         // initialize memory segments
@@ -5861,7 +6052,8 @@ mod tests {
         )]);
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((0, 1)),
@@ -5879,6 +6071,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
 
         // create new vm scope with dummy variable
@@ -5890,7 +6083,10 @@ mod tests {
         // initialize memory segments
         vm.segments.add(&mut vm.memory, None);
 
-        assert!(execute_hint(&mut vm, hint_code, &HashMap::new(), &ApTracking::new()).is_ok());
+        assert!(vm
+            .hint_executor
+            .execute_hint(&mut vm, hint_code, &HashMap::new(), &ApTracking::new())
+            .is_ok());
     }
 
     #[test]
@@ -5900,6 +6096,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
 
         // new vm scope is not created so that the hint raises an error:
@@ -5909,7 +6106,8 @@ mod tests {
         vm.segments.add(&mut vm.memory, None);
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &HashMap::new(), &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &HashMap::new(), &ApTracking::new()),
             Err(VirtualMachineError::MainScopeError(
                 ExecScopeError::ExitMainScopeError
             ))
@@ -5924,10 +6122,16 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &HashMap::new(), &ApTracking::default()),
+            vm.hint_executor.execute_hint(
+                &mut vm,
+                hint_code,
+                &HashMap::new(),
+                &ApTracking::default()
+            ),
             Ok(())
         );
         //Check exec_scopes
@@ -5942,6 +6146,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
 
         // initialize memory segments
@@ -6055,7 +6260,10 @@ mod tests {
             ),
         ]);
 
-        assert!(execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()).is_ok());
+        assert!(vm
+            .hint_executor
+            .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
+            .is_ok());
     }
 
     #[test]
@@ -6065,6 +6273,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
 
         // initialize memory segments
@@ -6179,7 +6388,8 @@ mod tests {
         ]);
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::KeccakMaxSize(bigint!(5), bigint!(2)))
         );
     }
@@ -6191,6 +6401,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
 
         // initialize memory segments
@@ -6301,7 +6512,10 @@ mod tests {
             ),
         ]);
 
-        assert!(execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()).is_err());
+        assert!(vm
+            .hint_executor
+            .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
+            .is_err());
     }
 
     #[test]
@@ -6311,6 +6525,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
 
         // initialize memory segments
@@ -6425,7 +6640,8 @@ mod tests {
         ]);
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::InvalidWordSize(bigint!(-1)))
         );
     }
@@ -6437,6 +6653,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
 
         // initialize memory segments
@@ -6536,7 +6753,10 @@ mod tests {
             ),
         ]);
 
-        assert!(execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()).is_ok());
+        assert!(vm
+            .hint_executor
+            .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
+            .is_ok());
     }
 
     #[test]
@@ -6546,6 +6766,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
 
         // initialize memory segments
@@ -6639,7 +6860,8 @@ mod tests {
         ]);
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::NoneInMemoryRange)
         );
     }
@@ -6651,6 +6873,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
 
         // initialize memory segments
@@ -6751,6 +6974,9 @@ mod tests {
             ),
         ]);
 
-        assert!(execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()).is_err());
+        assert!(vm
+            .hint_executor
+            .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
+            .is_err());
     }
 }

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -13,6 +13,7 @@ use crate::vm::hints::dict_hint_utils::{
     dict_update, dict_write,
 };
 use crate::vm::hints::find_element_hint::{find_element, search_sorted_lower};
+use crate::vm::hints::hint_code;
 use crate::vm::hints::hint_utils::{
     add_segment, assert_250_bit, assert_le_felt, assert_lt_felt, assert_nn, assert_not_equal,
     assert_not_zero, enter_scope, exit_scope, is_le_felt, is_nn, is_nn_out_of_range, is_positive,
@@ -55,120 +56,86 @@ pub struct HintReference {
 
 pub fn execute_hint(
     vm: &mut VirtualMachine,
-    hint_code: &[u8],
-    ids: HashMap<String, BigInt>,
+    code: &str,
+    ids: &HashMap<String, BigInt>,
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
-    match std::str::from_utf8(hint_code) {
-        Ok("memory[ap] = segments.add()") => add_segment(vm),
-        Ok("memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1") => is_nn(vm, ids, None),
-        Ok("memory[ap] = 0 if 0 <= ((-ids.a - 1) % PRIME) < range_check_builtin.bound else 1") => {
-            is_nn_out_of_range(vm, ids, None)
+    match code {
+        hint_code::ADD_SEGMENT => add_segment(vm),
+        hint_code::IS_NN => is_nn(vm, ids, None),
+        hint_code::IS_NN_OUT_OF_RANGE => is_nn_out_of_range(vm, ids, None),
+        hint_code::IS_LE_FELT => is_le_felt(vm, ids, None),
+        hint_code::ASSERT_LE_FELT => assert_le_felt(vm, ids, None),
+        hint_code::ASSERT_250_BITS => assert_250_bit(vm, ids, None),
+        hint_code::IS_POSITIVE => is_positive(vm, ids, Some(ap_tracking)),
+        hint_code::SPLIT_INT_ASSERT_RANGE => split_int_assert_range(vm, ids, None),
+        hint_code::SPLIT_INT => split_int(vm, ids, None),
+        hint_code::ASSERT_NOT_EQUAL => assert_not_equal(vm, ids, None),
+        hint_code::ASSERT_NN => assert_nn(vm, ids, None),
+        hint_code::SQRT => sqrt(vm, ids, None),
+        hint_code::ASSERT_NOT_ZERO => assert_not_zero(vm, ids, None),
+        hint_code::VM_EXIT_SCOPE => exit_scope(vm),
+        hint_code::MEMCPY_ENTER_SCOPE => memcpy_enter_scope(vm, ids, Some(ap_tracking)),
+        hint_code::MEMSET_ENTER_SCOPE => memset_enter_scope(vm, ids, Some(ap_tracking)),
+        hint_code::MEMCPY_CONTINUE_COPYING => memcpy_continue_copying(vm, ids, Some(ap_tracking)),
+        hint_code::MEMSET_CONTINUE_LOOP => memset_continue_loop(vm, ids, Some(ap_tracking)),
+        hint_code::SPLIT_FELT => split_felt(vm, ids, None),
+        hint_code::UNSIGNED_DIV_REM => unsigned_div_rem(vm, ids, None),
+        hint_code::SIGNED_DIV_REM => signed_div_rem(vm, ids, None),
+        hint_code::ASSERT_LT_FELT => assert_lt_felt(vm, ids, None),
+        hint_code::FIND_ELEMENT => find_element(vm, ids, None),
+        hint_code::SEARCH_SORTED_LOWER => search_sorted_lower(vm, ids, None),
+        hint_code::POW => pow(vm, ids, Some(ap_tracking)),
+        hint_code::SET_ADD => set_add(vm, ids, None),
+        hint_code::DICT_NEW => dict_new(vm),
+        hint_code::DICT_READ => dict_read(vm, ids, None),
+        hint_code::DICT_WRITE => dict_write(vm, ids, None),
+        hint_code::DEFAULT_DICT_NEW => default_dict_new(vm, ids, Some(ap_tracking)),
+        hint_code::SQUASH_DICT_INNER_FIRST_ITERATION => {
+            squash_dict_inner_first_iteration(vm, ids, Some(ap_tracking))
         }
-        Ok("memory[ap] = 0 if (ids.a % PRIME) <= (ids.b % PRIME) else 1") => is_le_felt(vm, ids, None),
-        Ok("from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\na = ids.a % PRIME\nb = ids.b % PRIME\nassert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\nids.small_inputs = int(\n    a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)",
-        ) => assert_le_felt(vm, ids, None),
-        Ok("from starkware.cairo.common.math_utils import as_int\n\n# Correctness check.\nvalue = as_int(ids.value, PRIME) % PRIME\nassert value < ids.UPPER_BOUND, f'{value} is outside of the range [0, 2**250).'\n\n# Calculation for the assertion.\nids.high, ids.low = divmod(ids.value, ids.SHIFT)",
-        ) => assert_250_bit(vm, ids, None),
-        Ok("from starkware.cairo.common.math_utils import is_positive\nids.is_positive = 1 if is_positive(\n    value=ids.value, prime=PRIME, rc_bound=range_check_builtin.bound) else 0"
-        ) => is_positive(vm, ids, Some(ap_tracking)),
-        Ok("assert ids.value == 0, 'split_int(): value is out of range.'"
-        ) => split_int_assert_range(vm, ids, None),
-        Ok("memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base\nassert res < ids.bound, f'split_int(): Limb {res} is out of range.'"
-        ) => split_int(vm, ids, None),
-        Ok("from starkware.cairo.lang.vm.relocatable import RelocatableValue\nboth_ints = isinstance(ids.a, int) and isinstance(ids.b, int)\nboth_relocatable = (\n    isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and\n    ids.a.segment_index == ids.b.segment_index)\nassert both_ints or both_relocatable, \\\n    f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'\nassert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'"
-        ) => assert_not_equal(vm, ids, None),
-        Ok("from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert 0 <= ids.a % PRIME < range_check_builtin.bound, f'a = {ids.a} is out of range.'"
-        ) => assert_nn(vm, ids, None),
-        Ok("from starkware.python.math_utils import isqrt\nvalue = ids.value % PRIME\nassert value < 2 ** 250, f\"value={value} is outside of the range [0, 2**250).\"\nassert 2 ** 250 < PRIME\nids.root = isqrt(value)"
-        ) => sqrt(vm, ids, None),
-        Ok("from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'"
-        ) => assert_not_zero(vm, ids, None),
-        Ok("vm_exit_scope()") => exit_scope(vm),
-        Ok("vm_enter_scope({'n': ids.len})") => memcpy_enter_scope(vm, ids, Some(ap_tracking)),
-        Ok("vm_enter_scope({'n': ids.n})") => memset_enter_scope(vm, ids, Some(ap_tracking)),
-        Ok("n -= 1\nids.continue_copying = 1 if n > 0 else 0") => memcpy_continue_copying(vm, ids, Some(ap_tracking)),
-        Ok("n -= 1\nids.continue_loop = 1 if n > 0 else 0") => memset_continue_loop(vm, ids, Some(ap_tracking)),
-        Ok("from starkware.cairo.common.math_utils import assert_integer\nassert ids.MAX_HIGH < 2**128 and ids.MAX_LOW < 2**128\nassert PRIME - 1 == ids.MAX_HIGH * 2**128 + ids.MAX_LOW\nassert_integer(ids.value)\nids.low = ids.value & ((1 << 128) - 1)\nids.high = ids.value >> 128"
-        ) => split_felt(vm, ids, None),
-        Ok("from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\nids.q, ids.r = divmod(ids.value, ids.div)"
-        ) => unsigned_div_rem(vm, ids, None),
-        Ok("from starkware.cairo.common.math_utils import as_int, assert_integer\n\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\n\nassert_integer(ids.bound)\nassert ids.bound <= range_check_builtin.bound // 2, \\\n    f'bound={hex(ids.bound)} is out of the valid range.'\n\nint_value = as_int(ids.value, PRIME)\nq, ids.r = divmod(int_value, ids.div)\n\nassert -ids.bound <= q < ids.bound, \\\n    f'{int_value} / {ids.div} = {q} is out of the range [{-ids.bound}, {ids.bound}).'\n\nids.biased_q = q + ids.bound"
-        ) => signed_div_rem(vm, ids, None),
-        Ok("from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\nassert (ids.a % PRIME) < (ids.b % PRIME), \\\n    f'a = {ids.a % PRIME} is not less than b = {ids.b % PRIME}.'"
-        ) => assert_lt_felt(vm, ids, None),
-        Ok("array_ptr = ids.array_ptr\nelm_size = ids.elm_size\nassert isinstance(elm_size, int) and elm_size > 0, \\\n    f'Invalid value for elm_size. Got: {elm_size}.'\nkey = ids.key\n\nif '__find_element_index' in globals():\n    ids.index = __find_element_index\n    found_key = memory[array_ptr + elm_size * __find_element_index]\n    assert found_key == key, \\\n        f'Invalid index found in __find_element_index. index: {__find_element_index}, ' \\\n        f'expected key {key}, found key: {found_key}.'\n    # Delete __find_element_index to make sure it's not used for the next calls.\n    del __find_element_index\nelse:\n    n_elms = ids.n_elms\n    assert isinstance(n_elms, int) and n_elms >= 0, \\\n        f'Invalid value for n_elms. Got: {n_elms}.'\n    if '__find_element_max_size' in globals():\n        assert n_elms <= __find_element_max_size, \\\n            f'find_element() can only be used with n_elms<={__find_element_max_size}. ' \\\n            f'Got: n_elms={n_elms}.'\n\n    for i in range(n_elms):\n        if memory[array_ptr + elm_size * i] == key:\n            ids.index = i\n            break\n    else:\n        raise ValueError(f'Key {key} was not found.')"
-        ) => find_element(vm, ids, None),
-        Ok("array_ptr = ids.array_ptr\nelm_size = ids.elm_size\nassert isinstance(elm_size, int) and elm_size > 0, \\\n    f'Invalid value for elm_size. Got: {elm_size}.'\n\nn_elms = ids.n_elms\nassert isinstance(n_elms, int) and n_elms >= 0, \\\n    f'Invalid value for n_elms. Got: {n_elms}.'\nif '__find_element_max_size' in globals():\n    assert n_elms <= __find_element_max_size, \\\n        f'find_element() can only be used with n_elms<={__find_element_max_size}. ' \\\n        f'Got: n_elms={n_elms}.'\n\nfor i in range(n_elms):\n    if memory[array_ptr + elm_size * i] >= ids.key:\n        ids.index = i\n        break\nelse:\n    ids.index = n_elms"
-        ) => search_sorted_lower(vm, ids, None),
-        Ok("ids.locs.bit = (ids.prev_locs.exp % PRIME) & 1") => pow(vm, ids, Some(ap_tracking)),
-        Ok("assert ids.elm_size > 0\nassert ids.set_ptr <= ids.set_end_ptr\nelm_list = memory.get_range(ids.elm_ptr, ids.elm_size)\nfor i in range(0, ids.set_end_ptr - ids.set_ptr, ids.elm_size):\n    if memory.get_range(ids.set_ptr + i, ids.elm_size) == elm_list:\n        ids.index = i // ids.elm_size\n        ids.is_elm_in_set = 1\n        break\nelse:\n    ids.is_elm_in_set = 0") => set_add(vm, ids, None),
-        Ok("if '__dict_manager' not in globals():\n    from starkware.cairo.common.dict import DictManager\n    __dict_manager = DictManager()\n\nmemory[ap] = __dict_manager.new_dict(segments, initial_dict)\ndel initial_dict"
-        ) => dict_new(vm),
-        Ok("dict_tracker = __dict_manager.get_tracker(ids.dict_ptr)\ndict_tracker.current_ptr += ids.DictAccess.SIZE\nids.value = dict_tracker.data[ids.key]"
-        ) => dict_read(vm, ids, None),
-        Ok("dict_tracker = __dict_manager.get_tracker(ids.dict_ptr)\ndict_tracker.current_ptr += ids.DictAccess.SIZE\nids.dict_ptr.prev_value = dict_tracker.data[ids.key]\ndict_tracker.data[ids.key] = ids.new_value"
-        ) => dict_write(vm, ids, None),
-        Ok("if '__dict_manager' not in globals():\n    from starkware.cairo.common.dict import DictManager\n    __dict_manager = DictManager()\n\nmemory[ap] = __dict_manager.new_default_dict(segments, ids.default_value)"
-        ) => default_dict_new(vm, ids, Some(ap_tracking)),
-        Ok("current_access_indices = sorted(access_indices[key])[::-1]\ncurrent_access_index = current_access_indices.pop()\nmemory[ids.range_check_ptr] = current_access_index"
-        ) => squash_dict_inner_first_iteration(vm, ids, Some(ap_tracking)),
-        Ok("ids.should_skip_loop = 0 if current_access_indices else 1"
-        ) => squash_dict_inner_skip_loop(vm, ids, Some(ap_tracking)),
-        Ok("new_access_index = current_access_indices.pop()\nids.loop_temps.index_delta_minus1 = new_access_index - current_access_index - 1\ncurrent_access_index = new_access_index"
-        ) => squash_dict_inner_check_access_index(vm, ids, Some(ap_tracking)),
-        Ok("ids.loop_temps.should_continue = 1 if current_access_indices else 0"
-        ) => squash_dict_inner_continue_loop(vm, ids, Some(ap_tracking)),
-        Ok("assert len(keys) == 0") => squash_dict_inner_assert_len_keys(vm),
-        Ok("assert len(current_access_indices) == 0") => squash_dict_inner_len_assert(vm),
-        Ok("assert ids.n_used_accesses == len(access_indices[key])") => squash_dict_inner_used_accesses_assert(vm, ids, Some(ap_tracking)),
-        Ok("assert len(keys) > 0, 'No keys left but remaining_accesses > 0.'\nids.next_key = key = keys.pop()"
-        ) => squash_dict_inner_next_key(vm, ids, Some(ap_tracking)),
-        Ok("dict_access_size = ids.DictAccess.SIZE\naddress = ids.dict_accesses.address_\nassert ids.ptr_diff % dict_access_size == 0, \\\n    'Accesses array size must be divisible by DictAccess.SIZE'\nn_accesses = ids.n_accesses\nif '__squash_dict_max_size' in globals():\n    assert n_accesses <= __squash_dict_max_size, \\\n        f'squash_dict() can only be used with n_accesses<={__squash_dict_max_size}. ' \\\n        f'Got: n_accesses={n_accesses}.'\n# A map from key to the list of indices accessing it.\naccess_indices = {}\nfor i in range(n_accesses):\n    key = memory[address + dict_access_size * i]\n    access_indices.setdefault(key, []).append(i)\n# Descending list of keys.\nkeys = sorted(access_indices.keys(), reverse=True)\n# Are the keys used bigger than range_check bound.\nids.big_keys = 1 if keys[0] >= range_check_builtin.bound else 0\nids.first_key = key = keys.pop()"
-        ) => squash_dict(vm, ids, Some(ap_tracking)),
-        Ok("vm_enter_scope()") => enter_scope(vm),
-        Ok("# Verify dict pointer and prev value.\ndict_tracker = __dict_manager.get_tracker(ids.dict_ptr)\ncurrent_value = dict_tracker.data[ids.key]\nassert current_value == ids.prev_value, \\\n    f'Wrong previous value in dict. Got {ids.prev_value}, expected {current_value}.'\n\n# Update value.\ndict_tracker.data[ids.key] = ids.new_value\ndict_tracker.current_ptr += ids.DictAccess.SIZE"
-        ) => dict_update(vm, ids, None),
-        Ok("# Prepare arguments for dict_new. In particular, the same dictionary values should be copied\n# to the new (squashed) dictionary.\nvm_enter_scope({\n    # Make __dict_manager accessible.\n    '__dict_manager': __dict_manager,\n    # Create a copy of the dict, in case it changes in the future.\n    'initial_dict': dict(__dict_manager.get_dict(ids.dict_accesses_end)),\n})"
-        ) => dict_squash_copy_dict(vm, ids, Some(ap_tracking)),
-        Ok("# Update the DictTracker's current_ptr to point to the end of the squashed dict.\n__dict_manager.get_tracker(ids.squashed_dict_start).current_ptr = \\\n    ids.squashed_dict_end.address_"
-        ) => dict_squash_update_ptr(vm, ids, Some(ap_tracking)),
-        Ok("sum_low = ids.a.low + ids.b.low\nids.carry_low = 1 if sum_low >= ids.SHIFT else 0\nsum_high = ids.a.high + ids.b.high + ids.carry_low\nids.carry_high = 1 if sum_high >= ids.SHIFT else 0"
-        ) => uint256_add(vm, ids, None),
-        Ok("ids.low = ids.a & ((1<<64) - 1)\nids.high = ids.a >> 64") => split_64(vm, ids, None),
-        Ok("vm_enter_scope(dict(__usort_max_size = globals().get('__usort_max_size')))"
-        ) => usort_enter_scope(vm),
-        Ok("from collections import defaultdict\n\ninput_ptr = ids.input\ninput_len = int(ids.input_len)\nif __usort_max_size is not None:\n    assert input_len <= __usort_max_size, (\n        f\"usort() can only be used with input_len<={__usort_max_size}. \"\n        f\"Got: input_len={input_len}.\"\n    )\n\npositions_dict = defaultdict(list)\nfor i in range(input_len):\n    val = memory[input_ptr + i]\n    positions_dict[val].append(i)\n\noutput = sorted(positions_dict.keys())\nids.output_len = len(output)\nids.output = segments.gen_arg(output)\nids.multiplicities = segments.gen_arg([len(positions_dict[k]) for k in output])"
-        ) => usort_body(vm, &ids, None),
-        Ok("last_pos = 0\npositions = positions_dict[ids.value][::-1]"
-        ) => verify_usort(vm, &ids, None),
-        Ok("assert len(positions) == 0") => verify_multiplicity_assert(vm),
-        Ok("current_pos = positions.pop()\nids.next_item_index = current_pos - last_pos\nlast_pos = current_pos + 1"
-        ) => verify_multiplicity_body(vm, &ids, None),
-        Ok("from starkware.cairo.common.cairo_blake2s.blake2s_utils import compute_blake2s_func\ncompute_blake2s_func(segments=segments, output_ptr=ids.output)"
-        ) => compute_blake2s(vm, &ids, Some(ap_tracking)),
-        Ok("from starkware.python.math_utils import isqrt\nn = (ids.n.high << 128) + ids.n.low\nroot = isqrt(n)\nassert 0 <= root < 2 ** 128\nids.root.low = root\nids.root.high = 0"
-        ) => uint256_sqrt(vm, ids, None),
-        Ok("memory[ap] = 1 if 0 <= (ids.a.high % PRIME) < 2 ** 127 else 0") => uint256_signed_nn(vm, ids, None),
-        Ok("from starkware.cairo.common.cairo_secp.secp_utils import split\n\nsegments.write_arg(ids.res.address_, split(value))") => nondet_bigint3(vm, &ids, Some(ap_tracking)),
-        Ok("from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nq, r = divmod(pack(ids.val, PRIME), SECP_P)\nassert r == 0, f\"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}.\"\nids.q = q % PRIME") => verify_zero(vm, &ids, Some(ap_tracking)),
-        Ok("from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nvalue = pack(ids.x, PRIME) % SECP_P") => reduce(vm, &ids, None),
-        Ok("a = (ids.a.high << 128) + ids.a.low\ndiv = (ids.div.high << 128) + ids.div.low\nquotient, remainder = divmod(a, div)\n\nids.quotient.low = quotient & ((1 << 128) - 1)\nids.quotient.high = quotient >> 128\nids.remainder.low = remainder & ((1 << 128) - 1)\nids.remainder.high = remainder >> 128"
-        ) => uint256_unsigned_div_rem(vm, ids, None),
-        Ok("# Add dummy pairs of input and output.\nfrom starkware.cairo.common.cairo_blake2s.blake2s_utils import IV, blake2s_compress\n\n_n_packed_instances = int(ids.N_PACKED_INSTANCES)\nassert 0 <= _n_packed_instances < 20\n_blake2s_input_chunk_size_felts = int(ids.INPUT_BLOCK_FELTS)\nassert 0 <= _blake2s_input_chunk_size_felts < 100\n\nmessage = [0] * _blake2s_input_chunk_size_felts\nmodified_iv = [IV[0] ^ 0x01010020] + IV[1:]\noutput = blake2s_compress(\n    message=message,\n    h=modified_iv,\n    t0=0,\n    t1=0,\n    f0=0xffffffff,\n    f1=0,\n)\npadding = (modified_iv + message + [0, 0xffffffff] + output) * (_n_packed_instances - 1)\nsegments.write_arg(ids.blake2s_ptr_end, padding)"
-        ) => finalize_blake2s(vm, ids, Some(ap_tracking)),
-        Ok("B = 32\nMASK = 2 ** 32 - 1\nsegments.write_arg(ids.data, [(ids.low >> (B * i)) & MASK for i in range(4)])\nsegments.write_arg(ids.data + 4, [(ids.high >> (B * i)) & MASK for i in range(4)]"
-        ) => blake2s_add_uint256(vm, &ids, Some(ap_tracking)),
-        Ok("B = 32\nMASK = 2 ** 32 - 1\nsegments.write_arg(ids.data, [(ids.high >> (B * (3 - i))) & MASK for i in range(4)])\nsegments.write_arg(ids.data + 4, [(ids.low >> (B * (3 - i))) & MASK for i in range(4)])"
-        ) => blake2s_add_uint256_bigend(vm, &ids, Some(ap_tracking)),
-        Ok("from eth_hash.auto import keccak\n\ndata, length = ids.data, ids.length\n\nif '__keccak_max_size' in globals():\n    assert length <= __keccak_max_size, \\\n        f'unsafe_keccak() can only be used with length<={__keccak_max_size}. ' \\\n        f'Got: length={length}.'\n\nkeccak_input = bytearray()\nfor word_i, byte_i in enumerate(range(0, length, 16)):\n    word = memory[data + word_i]\n    n_bytes = min(16, length - byte_i)\n    assert 0 <= word < 2 ** (8 * n_bytes)\n    keccak_input += word.to_bytes(n_bytes, 'big')\n\nhashed = keccak(keccak_input)\nids.high = int.from_bytes(hashed[:16], 'big')\nids.low = int.from_bytes(hashed[16:32], 'big')"
-        ) => unsafe_keccak(vm, ids, None),
-        Ok("from eth_hash.auto import keccak\nkeccak_input = bytearray()\nn_elms = ids.keccak_state.end_ptr - ids.keccak_state.start_ptr\nfor word in memory.get_range(ids.keccak_state.start_ptr, n_elms):\n    keccak_input += word.to_bytes(16, 'big')\nhashed = keccak(keccak_input)\nids.high = int.from_bytes(hashed[:16], 'big')\nids.low = int.from_bytes(hashed[16:32], 'big')"
-        ) => unsafe_keccak_finalize(vm, &ids, None),
-        Ok(hint_code) => Err(VirtualMachineError::UnknownHint(String::from(hint_code))),
-        Err(_) => Err(VirtualMachineError::InvalidHintEncoding(
-            vm.run_context.pc.clone(),
-        )),
+        hint_code::USORT_ENTER_SCOPE => usort_enter_scope(vm),
+        hint_code::USORT_BODY => usort_body(vm, ids, None),
+        hint_code::USORT_VERIFY => verify_usort(vm, ids, None),
+        hint_code::USORT_VERIFY_MULTIPLICITY_ASSERT => verify_multiplicity_assert(vm),
+        hint_code::USORT_VERIFY_MULTIPLICITY_BODY => verify_multiplicity_body(vm, ids, None),
+        hint_code::BLAKE2S_COMPUTE => compute_blake2s(vm, ids, Some(ap_tracking)),
+        hint_code::VERIFY_ZERO => verify_zero(vm, ids, Some(ap_tracking)),
+        hint_code::NONDET_BIGINT3 => nondet_bigint3(vm, ids, Some(ap_tracking)),
+        hint_code::REDUCE => reduce(vm, &ids, None),
+        hint_code::BLAKE2S_FINALIZE => finalize_blake2s(vm, ids, Some(ap_tracking)),
+        hint_code::BLAKE2S_ADD_UINT256 => blake2s_add_uint256(vm, ids, Some(ap_tracking)),
+        hint_code::BLAKE2S_ADD_UINT256_BIGEND=> blake2s_add_uint256_bigend(vm, ids, Some(ap_tracking)),
+        hint_code::UNSAFE_KECCAK => unsafe_keccak(vm, ids, None),
+        hint_code::UNSAFE_KECCAK_FINALIZE => unsafe_keccak_finalize(vm, ids, None),
+        hint_code::SQUASH_DICT_INNER_SKIP_LOOP => {
+            squash_dict_inner_skip_loop(vm, ids, Some(ap_tracking))
+        }
+        hint_code::SQUASH_DICT_INNER_CHECK_ACCESS_INDEX => {
+            squash_dict_inner_check_access_index(vm, ids, Some(ap_tracking))
+        }
+        hint_code::SQUASH_DICT_INNER_CONTINUE_LOOP => {
+            squash_dict_inner_continue_loop(vm, ids, Some(ap_tracking))
+        }
+        hint_code::SQUASH_DICT_INNER_ASSERT_LEN_KEYS => squash_dict_inner_assert_len_keys(vm),
+        hint_code::SQUASH_DICT_INNER_LEN_ASSERT => squash_dict_inner_len_assert(vm),
+        hint_code::SQUASH_DICT_INNER_USED_ACCESSES_ASSERT => {
+            squash_dict_inner_used_accesses_assert(vm, ids, Some(ap_tracking))
+        }
+        hint_code::SQUASH_DICT_INNER_NEXT_KEY => {
+            squash_dict_inner_next_key(vm, ids, Some(ap_tracking))
+        }
+        hint_code::SQUASH_DICT => squash_dict(vm, ids, Some(ap_tracking)),
+        hint_code::VM_ENTER_SCOPE => enter_scope(vm),
+        hint_code::DICT_UPDATE => dict_update(vm, ids, None),
+        hint_code::DICT_SQUASH_COPY_DICT => dict_squash_copy_dict(vm, ids, Some(ap_tracking)),
+        hint_code::DICT_SQUASH_UPDATE_PTR => dict_squash_update_ptr(vm, ids, Some(ap_tracking)),
+        hint_code::UINT256_ADD => uint256_add(vm, ids, None),
+        hint_code::SPLIT_64 => split_64(vm, ids, None),
+        hint_code::UINT256_SQRT => uint256_sqrt(vm, ids, None),
+        hint_code::UINT256_SIGNED_NN => uint256_signed_nn(vm, ids, None),
+        hint_code::UINT256_UNSIGNED_DIV_REM => uint256_unsigned_div_rem(vm, ids, None),
+        code => Err(VirtualMachineError::UnknownHint(code.to_string())),
     }
 }
 #[cfg(test)]
@@ -191,7 +158,7 @@ mod tests {
 
     #[test]
     fn run_alloc_hint_empty_memory() {
-        let hint_code = "memory[ap] = segments.add()".as_bytes();
+        let hint_code = "memory[ap] = segments.add()";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             //ap value is (0,0)
@@ -199,7 +166,7 @@ mod tests {
             false,
         );
         //ids and references are not needed for this test
-        execute_hint(&mut vm, hint_code, HashMap::new(), &ApTracking::new())
+        execute_hint(&mut vm, hint_code, &HashMap::new(), &ApTracking::new())
             .expect("Error while executing hint");
         //first new segment is added
         assert_eq!(vm.segments.num_segments, 1);
@@ -212,7 +179,7 @@ mod tests {
 
     #[test]
     fn run_alloc_hint_preset_memory() {
-        let hint_code = "memory[ap] = segments.add()".as_bytes();
+        let hint_code = "memory[ap] = segments.add()";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -224,7 +191,7 @@ mod tests {
         }
         vm.run_context.ap = MaybeRelocatable::from((2, 6));
         //ids and references are not needed for this test
-        execute_hint(&mut vm, hint_code, HashMap::new(), &ApTracking::new())
+        execute_hint(&mut vm, hint_code, &HashMap::new(), &ApTracking::new())
             .expect("Error while executing hint");
         //Segment N°4 is added
         assert_eq!(vm.segments.num_segments, 4);
@@ -237,7 +204,7 @@ mod tests {
 
     #[test]
     fn run_alloc_hint_ap_is_not_empty() {
-        let hint_code = "memory[ap] = segments.add()".as_bytes();
+        let hint_code = "memory[ap] = segments.add()";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -257,7 +224,7 @@ mod tests {
             .unwrap();
         //ids and references are not needed for this test
         assert_eq!(
-            execute_hint(&mut vm, hint_code, HashMap::new(), &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &HashMap::new(), &ApTracking::new()),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((2, 6)),
@@ -270,7 +237,7 @@ mod tests {
 
     #[test]
     fn run_unknown_hint() {
-        let hint_code = "random_invalid_code".as_bytes();
+        let hint_code = "random_invalid_code";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -278,17 +245,14 @@ mod tests {
         );
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, HashMap::new(), &ApTracking::new()),
-            Err(VirtualMachineError::UnknownHint(
-                String::from_utf8(hint_code.to_vec()).unwrap()
-            ))
+            execute_hint(&mut vm, hint_code, &HashMap::new(), &ApTracking::new()),
+            Err(VirtualMachineError::UnknownHint(hint_code.to_string())),
         );
     }
 
     #[test]
     fn run_is_nn_hint_false() {
-        let hint_code =
-            "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1".as_bytes();
+        let hint_code = "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -326,7 +290,7 @@ mod tests {
             },
         )]);
         //Execute the hint
-        execute_hint(&mut vm, hint_code, ids, &ApTracking::new())
+        execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
             .expect("Error while executing hint");
         //Check that ap now contains false (0)
         assert_eq!(
@@ -337,8 +301,7 @@ mod tests {
 
     #[test]
     fn run_is_nn_hint_true() {
-        let hint_code =
-            "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1".as_bytes();
+        let hint_code = "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -376,7 +339,7 @@ mod tests {
             },
         )]);
         //Execute the hint
-        execute_hint(&mut vm, hint_code, ids, &ApTracking::new())
+        execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
             .expect("Error while executing hint");
         //Check that ap now contains true (1)
         assert_eq!(
@@ -389,8 +352,7 @@ mod tests {
     //This test contemplates the case when the number itself is negative, but it is within the range (-prime, -range_check_bound)
     //Making the comparison return 1 (true)
     fn run_is_nn_hint_true_border_case() {
-        let hint_code =
-            "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1".as_bytes();
+        let hint_code = "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -431,7 +393,7 @@ mod tests {
             },
         )]);
         //Execute the hint
-        execute_hint(&mut vm, hint_code, ids, &ApTracking::new())
+        execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
             .expect("Error while executing hint");
         //Check that ap now contains true (1)
         assert_eq!(
@@ -441,23 +403,8 @@ mod tests {
     }
 
     #[test]
-    fn run_invalid_encoding_hint() {
-        let hint_code = [0x80];
-        let mut vm = VirtualMachine::new(
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-            Vec::new(),
-            false,
-        );
-        assert_eq!(
-            execute_hint(&mut vm, &hint_code, HashMap::new(), &ApTracking::new()),
-            Err(VirtualMachineError::InvalidHintEncoding(vm.run_context.pc))
-        );
-    }
-
-    #[test]
     fn run_is_nn_hint_no_range_check_builtin() {
-        let hint_code =
-            "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1".as_bytes();
+        let hint_code = "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -493,15 +440,14 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, &hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, &hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::NoRangeCheckBuiltin)
         );
     }
 
     #[test]
     fn run_is_nn_hint_incorrect_ids() {
-        let hint_code =
-            "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1".as_bytes();
+        let hint_code = "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -520,7 +466,7 @@ mod tests {
         ids.insert(String::from("b"), bigint!(0));
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::IncorrectIds(
                 vec![String::from("a")],
                 vec![String::from("b")]
@@ -530,8 +476,7 @@ mod tests {
 
     #[test]
     fn run_is_nn_hint_cant_get_ids_from_memory() {
-        let hint_code =
-            "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1".as_bytes();
+        let hint_code = "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -564,7 +509,7 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::MemoryGet(MaybeRelocatable::from((
                 0, 0
             ))))
@@ -573,8 +518,7 @@ mod tests {
 
     #[test]
     fn run_is_nn_hint_ids_are_relocatable_values() {
-        let hint_code =
-            "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1".as_bytes();
+        let hint_code = "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -613,7 +557,7 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((0, 0))
             ))
@@ -623,7 +567,7 @@ mod tests {
     #[test]
     fn run_assert_le_felt_valid() {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\na = ids.a % PRIME\nb = ids.b % PRIME\nassert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\nids.small_inputs = int(\n    a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"
-            .as_bytes();
+            ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -702,7 +646,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
         //Hint would return an error if the assertion fails
@@ -710,7 +654,7 @@ mod tests {
 
     #[test]
     fn is_le_felt_hint_true() {
-        let hint_code = "memory[ap] = 0 if (ids.a % PRIME) <= (ids.b % PRIME) else 1".as_bytes();
+        let hint_code = "memory[ap] = 0 if (ids.a % PRIME) <= (ids.b % PRIME) else 1";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -770,12 +714,12 @@ mod tests {
             ),
         ]);
         //Execute the hint
-        assert!(execute_hint(&mut vm, hint_code, ids, &ApTracking::new()).is_ok());
+        assert!(execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()).is_ok());
     }
 
     #[test]
     fn run_is_le_felt_hint_no_range_check_builtin() {
-        let hint_code = "memory[ap] = 0 if (ids.a % PRIME) <= (ids.b % PRIME) else 1".as_bytes();
+        let hint_code = "memory[ap] = 0 if (ids.a % PRIME) <= (ids.b % PRIME) else 1";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -833,14 +777,14 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, &hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, &hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::NoRangeCheckBuiltin)
         );
     }
 
     #[test]
     fn run_is_le_felt_hint_inconsistent_memory() {
-        let hint_code = "memory[ap] = 0 if (ids.a % PRIME) <= (ids.b % PRIME) else 1".as_bytes();
+        let hint_code = "memory[ap] = 0 if (ids.a % PRIME) <= (ids.b % PRIME) else 1";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -899,7 +843,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((0, 0)),
@@ -912,7 +856,7 @@ mod tests {
 
     #[test]
     fn run_is_le_felt_hint_incorrect_ids() {
-        let hint_code = "memory[ap] = 0 if (ids.a % PRIME) <= (ids.b % PRIME) else 1".as_bytes();
+        let hint_code = "memory[ap] = 0 if (ids.a % PRIME) <= (ids.b % PRIME) else 1";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -971,7 +915,7 @@ mod tests {
         // Since the ids are a map, the order might not always match and so the error returned
         // sometimes might be different
         assert!(matches!(
-            execute_hint(&mut vm, &hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, &hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::IncorrectIds(_, _))
         ));
     }
@@ -979,7 +923,7 @@ mod tests {
     #[test]
     fn run_assert_nn_valid() {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert 0 <= ids.a % PRIME < range_check_builtin.bound, f'a = {ids.a} is out of range.'"
-            .as_bytes();
+            ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -1018,7 +962,7 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
         //Hint would return an error if the assertion fails
@@ -1027,7 +971,7 @@ mod tests {
     #[test]
     fn run_assert_nn_invalid() {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert 0 <= ids.a % PRIME < range_check_builtin.bound, f'a = {ids.a} is out of range.'"
-            .as_bytes();
+            ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -1066,7 +1010,7 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ValueOutOfRange(bigint!(-1)))
         );
     }
@@ -1074,7 +1018,7 @@ mod tests {
     #[test]
     fn run_assert_nn_incorrect_ids() {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert 0 <= ids.a % PRIME < range_check_builtin.bound, f'a = {ids.a} is out of range.'"
-            .as_bytes();
+            ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -1113,7 +1057,7 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::IncorrectIds(
                 vec![String::from("a")],
                 vec![String::from("incorrect_id")],
@@ -1124,7 +1068,7 @@ mod tests {
     #[test]
     fn run_assert_nn_incorrect_reference() {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert 0 <= ids.a % PRIME < range_check_builtin.bound, f'a = {ids.a} is out of range.'"
-            .as_bytes();
+            ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -1163,7 +1107,7 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::FailedToGetIds)
         );
     }
@@ -1171,7 +1115,7 @@ mod tests {
     #[test]
     fn run_assert_nn_a_is_not_integer() {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert 0 <= ids.a % PRIME < range_check_builtin.bound, f'a = {ids.a} is out of range.'"
-            .as_bytes();
+            ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -1210,7 +1154,7 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((0, 0))
             ))
@@ -1220,7 +1164,7 @@ mod tests {
     #[test]
     fn run_assert_nn_no_range_check_builtin() {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert 0 <= ids.a % PRIME < range_check_builtin.bound, f'a = {ids.a} is out of range.'"
-            .as_bytes();
+            ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![],
@@ -1256,7 +1200,7 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::NoRangeCheckBuiltin)
         );
     }
@@ -1264,7 +1208,7 @@ mod tests {
     #[test]
     fn run_assert_nn_reference_is_not_in_memory() {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert 0 <= ids.a % PRIME < range_check_builtin.bound, f'a = {ids.a} is out of range.'"
-            .as_bytes();
+            ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -1295,7 +1239,7 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::FailedToGetIds)
         );
     }
@@ -1303,7 +1247,7 @@ mod tests {
     #[test]
     fn run_is_assert_le_felt_invalid() {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\na = ids.a % PRIME\nb = ids.b % PRIME\nassert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\nids.small_inputs = int(\n    a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"
-            .as_bytes();
+            ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -1382,7 +1326,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::NonLeFelt(bigint!(2), bigint!(1)))
         );
     }
@@ -1390,7 +1334,7 @@ mod tests {
     #[test]
     fn run_is_assert_le_felt_small_inputs_not_local() {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\na = ids.a % PRIME\nb = ids.b % PRIME\nassert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\nids.small_inputs = int(\n    a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"
-            .as_bytes();
+            ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -1469,7 +1413,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::FailedToGetIds)
         );
     }
@@ -1477,7 +1421,7 @@ mod tests {
     #[test]
     fn run_is_assert_le_felt_a_is_not_integer() {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\na = ids.a % PRIME\nb = ids.b % PRIME\nassert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\nids.small_inputs = int(\n    a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"
-            .as_bytes();
+            ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -1556,7 +1500,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((0, 0))
             ))
@@ -1566,7 +1510,7 @@ mod tests {
     #[test]
     fn run_is_assert_le_felt_b_is_not_integer() {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\na = ids.a % PRIME\nb = ids.b % PRIME\nassert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\nids.small_inputs = int(\n    a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"
-            .as_bytes();
+            ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -1645,7 +1589,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((0, 1))
             ))
@@ -1655,8 +1599,7 @@ mod tests {
     #[test]
     fn run_is_nn_hint_out_of_range_false() {
         let hint_code =
-            "memory[ap] = 0 if 0 <= ((-ids.a - 1) % PRIME) < range_check_builtin.bound else 1"
-                .as_bytes();
+            "memory[ap] = 0 if 0 <= ((-ids.a - 1) % PRIME) < range_check_builtin.bound else 1";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -1694,7 +1637,7 @@ mod tests {
             },
         )]);
         //Execute the hint
-        execute_hint(&mut vm, hint_code, ids, &ApTracking::new())
+        execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
             .expect("Error while executing hint");
         assert_eq!(
             vm.memory.get(&MaybeRelocatable::from((1, 0))),
@@ -1705,8 +1648,7 @@ mod tests {
     #[test]
     fn run_is_nn_hint_out_of_range_true() {
         let hint_code =
-            "memory[ap] = 0 if 0 <= ((-ids.a - 1) % PRIME) < range_check_builtin.bound else 1"
-                .as_bytes();
+            "memory[ap] = 0 if 0 <= ((-ids.a - 1) % PRIME) < range_check_builtin.bound else 1";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -1744,7 +1686,7 @@ mod tests {
             },
         )]);
         //Execute the hint
-        execute_hint(&mut vm, hint_code, ids, &ApTracking::new())
+        execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
             .expect("Error while executing hint");
         assert_eq!(
             vm.memory.get(&MaybeRelocatable::from((1, 0))),
@@ -1754,7 +1696,7 @@ mod tests {
     #[test]
     fn run_assert_not_equal_int_false() {
         let hint_code = "from starkware.cairo.lang.vm.relocatable import RelocatableValue\nboth_ints = isinstance(ids.a, int) and isinstance(ids.b, int)\nboth_relocatable = (\n    isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and\n    ids.a.segment_index == ids.b.segment_index)\nassert both_ints or both_relocatable, \\\n    f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'\nassert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'"
-            .as_bytes();
+            ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -1810,7 +1752,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::AssertNotEqualFail(
                 MaybeRelocatable::from(bigint!(1)),
                 MaybeRelocatable::from(bigint!(1))
@@ -1821,7 +1763,7 @@ mod tests {
     #[test]
     fn run_assert_not_equal_int_true() {
         let hint_code = "from starkware.cairo.lang.vm.relocatable import RelocatableValue\nboth_ints = isinstance(ids.a, int) and isinstance(ids.b, int)\nboth_relocatable = (\n    isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and\n    ids.a.segment_index == ids.b.segment_index)\nassert both_ints or both_relocatable, \\\n    f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'\nassert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'"
-            .as_bytes();
+            ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -1877,7 +1819,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
     }
@@ -1885,7 +1827,7 @@ mod tests {
     #[test]
     fn run_assert_not_equal_int_false_mod() {
         let hint_code = "from starkware.cairo.lang.vm.relocatable import RelocatableValue\nboth_ints = isinstance(ids.a, int) and isinstance(ids.b, int)\nboth_relocatable = (\n    isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and\n    ids.a.segment_index == ids.b.segment_index)\nassert both_ints or both_relocatable, \\\n    f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'\nassert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'"
-            .as_bytes();
+            ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -1945,7 +1887,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::AssertNotEqualFail(
                 MaybeRelocatable::from(bigint!(-1)),
                 MaybeRelocatable::from(bigint_str!(
@@ -1957,8 +1899,7 @@ mod tests {
 
     #[test]
     fn run_assert_not_equal_relocatable_false() {
-        let hint_code = "from starkware.cairo.lang.vm.relocatable import RelocatableValue\nboth_ints = isinstance(ids.a, int) and isinstance(ids.b, int)\nboth_relocatable = (\n    isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and\n    ids.a.segment_index == ids.b.segment_index)\nassert both_ints or both_relocatable, \\\n    f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'\nassert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'"
-            .as_bytes();
+        let hint_code = "from starkware.cairo.lang.vm.relocatable import RelocatableValue\nboth_ints = isinstance(ids.a, int) and isinstance(ids.b, int)\nboth_relocatable = (\n    isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and\n    ids.a.segment_index == ids.b.segment_index)\nassert both_ints or both_relocatable, \\\n    f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'\nassert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -2014,7 +1955,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::AssertNotEqualFail(
                 MaybeRelocatable::from((0, 0)),
                 MaybeRelocatable::from((0, 0))
@@ -2025,7 +1966,7 @@ mod tests {
     #[test]
     fn run_assert_not_equal_relocatable_true() {
         let hint_code = "from starkware.cairo.lang.vm.relocatable import RelocatableValue\nboth_ints = isinstance(ids.a, int) and isinstance(ids.b, int)\nboth_relocatable = (\n    isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and\n    ids.a.segment_index == ids.b.segment_index)\nassert both_ints or both_relocatable, \\\n    f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'\nassert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'"
-            .as_bytes();
+            ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -2081,15 +2022,14 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
     }
 
     #[test]
     fn run_assert_non_equal_relocatable_diff_index() {
-        let hint_code = "from starkware.cairo.lang.vm.relocatable import RelocatableValue\nboth_ints = isinstance(ids.a, int) and isinstance(ids.b, int)\nboth_relocatable = (\n    isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and\n    ids.a.segment_index == ids.b.segment_index)\nassert both_ints or both_relocatable, \\\n    f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'\nassert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'"
-            .as_bytes();
+        let hint_code = "from starkware.cairo.lang.vm.relocatable import RelocatableValue\nboth_ints = isinstance(ids.a, int) and isinstance(ids.b, int)\nboth_relocatable = (\n    isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and\n    ids.a.segment_index == ids.b.segment_index)\nassert both_ints or both_relocatable, \\\n    f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'\nassert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -2145,7 +2085,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::DiffIndexComp(
                 relocatable!(1, 0),
                 relocatable!(0, 0)
@@ -2156,7 +2096,7 @@ mod tests {
     #[test]
     fn run_assert_not_equal_relocatable_and_integer() {
         let hint_code = "from starkware.cairo.lang.vm.relocatable import RelocatableValue\nboth_ints = isinstance(ids.a, int) and isinstance(ids.b, int)\nboth_relocatable = (\n    isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and\n    ids.a.segment_index == ids.b.segment_index)\nassert both_ints or both_relocatable, \\\n    f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'\nassert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'"
-            .as_bytes();
+            ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -2212,7 +2152,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::DiffTypeComparison(
                 MaybeRelocatable::from((1, 0)),
                 MaybeRelocatable::from(bigint!(1))
@@ -2223,7 +2163,7 @@ mod tests {
     #[test]
     fn run_assert_not_zero_true() {
         let hint_code =
-    "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'".as_bytes();
+    "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -2258,7 +2198,7 @@ mod tests {
         ids.insert(String::from("value"), bigint!(0));
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
     }
@@ -2266,7 +2206,7 @@ mod tests {
     #[test]
     fn run_assert_not_zero_false() {
         let hint_code =
-    "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'".as_bytes();
+    "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -2301,7 +2241,7 @@ mod tests {
         ids.insert(String::from("value"), bigint!(0));
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::AssertNotZero(bigint!(0), vm.prime))
         );
     }
@@ -2309,7 +2249,7 @@ mod tests {
     #[test]
     fn run_assert_not_zero_false_with_prime() {
         let hint_code =
-    "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'".as_bytes();
+    "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -2344,7 +2284,7 @@ mod tests {
         ids.insert(String::from("value"), bigint!(0));
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::AssertNotZero(
                 vm.prime.clone(),
                 vm.prime
@@ -2355,7 +2295,7 @@ mod tests {
     #[test]
     fn run_assert_not_zero_failed_to_get_reference() {
         let hint_code =
-    "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'".as_bytes();
+    "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -2390,7 +2330,7 @@ mod tests {
         ids.insert(String::from("value"), bigint!(10));
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::FailedToGetReference(bigint!(10)))
         );
     }
@@ -2398,7 +2338,7 @@ mod tests {
     #[test]
     fn run_assert_not_zero_incorrect_id() {
         let hint_code =
-    "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'".as_bytes();
+    "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -2433,7 +2373,7 @@ mod tests {
         ids.insert(String::from("incorrect_id"), bigint!(0));
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::IncorrectIds(
                 vec![String::from("value")],
                 vec![String::from("incorrect_id")],
@@ -2444,7 +2384,7 @@ mod tests {
     #[test]
     fn run_assert_not_zero_expected_integer_error() {
         let hint_code =
-    "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'".as_bytes();
+    "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -2478,7 +2418,7 @@ mod tests {
         ids.insert(String::from("value"), bigint!(0));
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((0, 0))
             ))
@@ -2487,7 +2427,7 @@ mod tests {
 
     #[test]
     fn run_split_int_assertion_invalid() {
-        let hint_code = "assert ids.value == 0, 'split_int(): value is out of range.'".as_bytes();
+        let hint_code = "assert ids.value == 0, 'split_int(): value is out of range.'";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -2523,14 +2463,14 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::SplitIntNotZero)
         );
     }
 
     #[test]
     fn run_split_int_assertion_valid() {
-        let hint_code = "assert ids.value == 0, 'split_int(): value is out of range.'".as_bytes();
+        let hint_code = "assert ids.value == 0, 'split_int(): value is out of range.'";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -2566,14 +2506,14 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
     }
 
     #[test]
     fn run_split_int_valid() {
-        let hint_code = "memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base\nassert res < ids.bound, f'split_int(): Limb {res} is out of range.'".as_bytes();
+        let hint_code = "memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base\nassert res < ids.bound, f'split_int(): Limb {res} is out of range.'";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -2669,7 +2609,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
         assert_eq!(
@@ -2680,7 +2620,7 @@ mod tests {
 
     #[test]
     fn run_split_int_invalid() {
-        let hint_code = "memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base\nassert res < ids.bound, f'split_int(): Limb {res} is out of range.'".as_bytes();
+        let hint_code = "memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base\nassert res < ids.bound, f'split_int(): Limb {res} is out of range.'";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -2776,7 +2716,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::SplitIntLimbOutOfRange(bigint!(100)))
         );
     }
@@ -2785,7 +2725,7 @@ mod tests {
     fn run_is_positive_hint_true() {
         let hint_code =
         "from starkware.cairo.common.math_utils import is_positive\nids.is_positive = 1 if is_positive(\n    value=ids.value, prime=PRIME, rc_bound=range_check_builtin.bound) else 0"
-        .as_bytes();
+        ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -2837,7 +2777,7 @@ mod tests {
             ),
         ]);
         //Execute the hint
-        execute_hint(&mut vm, hint_code, ids, &ApTracking::new())
+        execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
             .expect("Error while executing hint");
         //Check that is_positive now contains 1 (true)
         assert_eq!(
@@ -2850,7 +2790,7 @@ mod tests {
     fn run_is_positive_hint_false() {
         let hint_code =
         "from starkware.cairo.common.math_utils import is_positive\nids.is_positive = 1 if is_positive(\n    value=ids.value, prime=PRIME, rc_bound=range_check_builtin.bound) else 0"
-        .as_bytes();
+        ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -2902,7 +2842,7 @@ mod tests {
             ),
         ]);
         //Execute the hint
-        execute_hint(&mut vm, hint_code, ids, &ApTracking::new())
+        execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
             .expect("Error while executing hint");
         //Check that is_positive now contains 0 (false)
         assert_eq!(
@@ -2915,7 +2855,7 @@ mod tests {
     fn run_is_positive_hint_outside_valid_range() {
         let hint_code =
         "from starkware.cairo.common.math_utils import is_positive\nids.is_positive = 1 if is_positive(\n    value=ids.value, prime=PRIME, rc_bound=range_check_builtin.bound) else 0"
-        .as_bytes();
+        ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -2971,7 +2911,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ValueOutsideValidRange(as_int(
                 &BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217727]),
                 &vm.prime
@@ -2982,7 +2922,7 @@ mod tests {
     #[test]
     fn run_is_positive_hint_is_positive_not_empty() {
         let hint_code ="from starkware.cairo.common.math_utils import is_positive\nids.is_positive = 1 if is_positive(\n    value=ids.value, prime=PRIME, rc_bound=range_check_builtin.bound) else 0"
-        .as_bytes();
+        ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -3041,7 +2981,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((0, 1)),
@@ -3055,7 +2995,7 @@ mod tests {
     #[test]
     fn run_sqrt_valid() {
         let hint_code = "from starkware.python.math_utils import isqrt\nvalue = ids.value % PRIME\nassert value < 2 ** 250, f\"value={value} is outside of the range [0, 2**250).\"\nassert 2 ** 250 < PRIME\nids.root = isqrt(value)"
-            .as_bytes();
+            ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -3104,7 +3044,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
         //Check that root (0,1) has the square root of 81
@@ -3117,7 +3057,7 @@ mod tests {
     #[test]
     fn run_sqrt_invalid_negative_number() {
         let hint_code = "from starkware.python.math_utils import isqrt\nvalue = ids.value % PRIME\nassert value < 2 ** 250, f\"value={value} is outside of the range [0, 2**250).\"\nassert 2 ** 250 < PRIME\nids.root = isqrt(value)"
-            .as_bytes();
+            ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -3166,7 +3106,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ValueOutside250BitRange(bigint_str!(
                 b"3618502788666131213697322783095070105623107215331596699973092056135872020400"
             )))
@@ -3176,7 +3116,7 @@ mod tests {
     #[test]
     fn run_sqrt_invalid_mismatched_root() {
         let hint_code = "from starkware.python.math_utils import isqrt\nvalue = ids.value % PRIME\nassert value < 2 ** 250, f\"value={value} is outside of the range [0, 2**250).\"\nassert 2 ** 250 < PRIME\nids.root = isqrt(value)"
-            .as_bytes();
+            ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -3232,7 +3172,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((0, 1)),
@@ -3245,7 +3185,7 @@ mod tests {
 
     #[test]
     fn unsigned_div_rem_success() {
-        let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\nids.q, ids.r = divmod(ids.value, ids.div)".as_bytes();
+        let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\nids.q, ids.r = divmod(ids.value, ids.div)";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -3327,7 +3267,7 @@ mod tests {
             ),
         ]);
         //Execute the hint
-        assert!(execute_hint(&mut vm, hint_code, ids, &ApTracking::new()).is_ok());
+        assert!(execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()).is_ok());
         assert_eq!(
             vm.memory.get(&MaybeRelocatable::from((0, 0))),
             Ok(Some(&MaybeRelocatable::from(bigint!(2))))
@@ -3340,7 +3280,7 @@ mod tests {
 
     #[test]
     fn unsigned_div_rem_out_of_range() {
-        let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\nids.q, ids.r = divmod(ids.value, ids.div)".as_bytes();
+        let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\nids.q, ids.r = divmod(ids.value, ids.div)";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -3423,7 +3363,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::OutOfValidRange(
                 bigint!(-5),
                 bigint_str!(b"10633823966279327296825105735305134080")
@@ -3433,7 +3373,7 @@ mod tests {
 
     #[test]
     fn unsigned_div_rem_no_range_check_builtin() {
-        let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\nids.q, ids.r = divmod(ids.value, ids.div)".as_bytes();
+        let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\nids.q, ids.r = divmod(ids.value, ids.div)";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -3513,14 +3453,14 @@ mod tests {
         ]);
 
         assert_eq!(
-            execute_hint(&mut vm, &hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, &hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::NoRangeCheckBuiltin)
         );
     }
 
     #[test]
     fn unsigned_div_rem_inconsitent_memory() {
-        let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\nids.q, ids.r = divmod(ids.value, ids.div)".as_bytes();
+        let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\nids.q, ids.r = divmod(ids.value, ids.div)";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -3609,7 +3549,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((0, 0)),
@@ -3622,7 +3562,7 @@ mod tests {
 
     #[test]
     fn unsigned_div_rem_incorrect_ids() {
-        let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\nids.q, ids.r = divmod(ids.value, ids.div)".as_bytes();
+        let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\nids.q, ids.r = divmod(ids.value, ids.div)";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -3705,14 +3645,14 @@ mod tests {
         ]);
         //Execute the hint
         assert!(matches!(
-            execute_hint(&mut vm, &hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, &hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::IncorrectIds(_, _))
         ))
     }
 
     #[test]
     fn signed_div_rem_success() {
-        let hint_code = "from starkware.cairo.common.math_utils import as_int, assert_integer\n\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\n\nassert_integer(ids.bound)\nassert ids.bound <= range_check_builtin.bound // 2, \\\n    f'bound={hex(ids.bound)} is out of the valid range.'\n\nint_value = as_int(ids.value, PRIME)\nq, ids.r = divmod(int_value, ids.div)\n\nassert -ids.bound <= q < ids.bound, \\\n    f'{int_value} / {ids.div} = {q} is out of the range [{-ids.bound}, {ids.bound}).'\n\nids.biased_q = q + ids.bound".as_bytes();
+        let hint_code = "from starkware.cairo.common.math_utils import as_int, assert_integer\n\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\n\nassert_integer(ids.bound)\nassert ids.bound <= range_check_builtin.bound // 2, \\\n    f'bound={hex(ids.bound)} is out of the valid range.'\n\nint_value = as_int(ids.value, PRIME)\nq, ids.r = divmod(int_value, ids.div)\n\nassert -ids.bound <= q < ids.bound, \\\n    f'{int_value} / {ids.div} = {q} is out of the range [{-ids.bound}, {ids.bound}).'\n\nids.biased_q = q + ids.bound";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -3824,7 +3764,7 @@ mod tests {
             ),
         ]);
         //Execute the hint
-        assert!(execute_hint(&mut vm, hint_code, ids, &ApTracking::new()).is_ok());
+        assert!(execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()).is_ok());
         assert_eq!(
             vm.memory.get(&MaybeRelocatable::from((0, 0))),
             Ok(Some(&MaybeRelocatable::from(bigint!(0))))
@@ -3837,7 +3777,7 @@ mod tests {
 
     #[test]
     fn signed_div_rem_negative_quotient() {
-        let hint_code = "from starkware.cairo.common.math_utils import as_int, assert_integer\n\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\n\nassert_integer(ids.bound)\nassert ids.bound <= range_check_builtin.bound // 2, \\\n    f'bound={hex(ids.bound)} is out of the valid range.'\n\nint_value = as_int(ids.value, PRIME)\nq, ids.r = divmod(int_value, ids.div)\n\nassert -ids.bound <= q < ids.bound, \\\n    f'{int_value} / {ids.div} = {q} is out of the range [{-ids.bound}, {ids.bound}).'\n\nids.biased_q = q + ids.bound".as_bytes();
+        let hint_code = "from starkware.cairo.common.math_utils import as_int, assert_integer\n\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\n\nassert_integer(ids.bound)\nassert ids.bound <= range_check_builtin.bound // 2, \\\n    f'bound={hex(ids.bound)} is out of the valid range.'\n\nint_value = as_int(ids.value, PRIME)\nq, ids.r = divmod(int_value, ids.div)\n\nassert -ids.bound <= q < ids.bound, \\\n    f'{int_value} / {ids.div} = {q} is out of the range [{-ids.bound}, {ids.bound}).'\n\nids.biased_q = q + ids.bound";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -3949,7 +3889,7 @@ mod tests {
             ),
         ]);
         //Execute the hint
-        assert!(execute_hint(&mut vm, hint_code, ids, &ApTracking::new()).is_ok());
+        assert!(execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()).is_ok());
         assert_eq!(
             vm.memory.get(&MaybeRelocatable::from((0, 0))),
             Ok(Some(&MaybeRelocatable::from(bigint!(4))))
@@ -3962,7 +3902,7 @@ mod tests {
 
     #[test]
     fn signed_div_rem_out_of_range() {
-        let hint_code = "from starkware.cairo.common.math_utils import as_int, assert_integer\n\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\n\nassert_integer(ids.bound)\nassert ids.bound <= range_check_builtin.bound // 2, \\\n    f'bound={hex(ids.bound)} is out of the valid range.'\n\nint_value = as_int(ids.value, PRIME)\nq, ids.r = divmod(int_value, ids.div)\n\nassert -ids.bound <= q < ids.bound, \\\n    f'{int_value} / {ids.div} = {q} is out of the range [{-ids.bound}, {ids.bound}).'\n\nids.biased_q = q + ids.bound".as_bytes();
+        let hint_code = "from starkware.cairo.common.math_utils import as_int, assert_integer\n\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\n\nassert_integer(ids.bound)\nassert ids.bound <= range_check_builtin.bound // 2, \\\n    f'bound={hex(ids.bound)} is out of the valid range.'\n\nint_value = as_int(ids.value, PRIME)\nq, ids.r = divmod(int_value, ids.div)\n\nassert -ids.bound <= q < ids.bound, \\\n    f'{int_value} / {ids.div} = {q} is out of the range [{-ids.bound}, {ids.bound}).'\n\nids.biased_q = q + ids.bound";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -4075,7 +4015,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::OutOfValidRange(
                 bigint!(-5),
                 bigint_str!(b"10633823966279327296825105735305134080")
@@ -4085,7 +4025,7 @@ mod tests {
 
     #[test]
     fn signed_div_rem_no_range_check_builtin() {
-        let hint_code = "from starkware.cairo.common.math_utils import as_int, assert_integer\n\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\n\nassert_integer(ids.bound)\nassert ids.bound <= range_check_builtin.bound // 2, \\\n    f'bound={hex(ids.bound)} is out of the valid range.'\n\nint_value = as_int(ids.value, PRIME)\nq, ids.r = divmod(int_value, ids.div)\n\nassert -ids.bound <= q < ids.bound, \\\n    f'{int_value} / {ids.div} = {q} is out of the range [{-ids.bound}, {ids.bound}).'\n\nids.biased_q = q + ids.bound".as_bytes();
+        let hint_code = "from starkware.cairo.common.math_utils import as_int, assert_integer\n\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\n\nassert_integer(ids.bound)\nassert ids.bound <= range_check_builtin.bound // 2, \\\n    f'bound={hex(ids.bound)} is out of the valid range.'\n\nint_value = as_int(ids.value, PRIME)\nq, ids.r = divmod(int_value, ids.div)\n\nassert -ids.bound <= q < ids.bound, \\\n    f'{int_value} / {ids.div} = {q} is out of the range [{-ids.bound}, {ids.bound}).'\n\nids.biased_q = q + ids.bound";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -4195,14 +4135,14 @@ mod tests {
         ]);
 
         assert_eq!(
-            execute_hint(&mut vm, &hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, &hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::NoRangeCheckBuiltin)
         );
     }
 
     #[test]
     fn signed_div_rem_inconsitent_memory() {
-        let hint_code = "from starkware.cairo.common.math_utils import as_int, assert_integer\n\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\n\nassert_integer(ids.bound)\nassert ids.bound <= range_check_builtin.bound // 2, \\\n    f'bound={hex(ids.bound)} is out of the valid range.'\n\nint_value = as_int(ids.value, PRIME)\nq, ids.r = divmod(int_value, ids.div)\n\nassert -ids.bound <= q < ids.bound, \\\n    f'{int_value} / {ids.div} = {q} is out of the range [{-ids.bound}, {ids.bound}).'\n\nids.biased_q = q + ids.bound".as_bytes();
+        let hint_code = "from starkware.cairo.common.math_utils import as_int, assert_integer\n\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\n\nassert_integer(ids.bound)\nassert ids.bound <= range_check_builtin.bound // 2, \\\n    f'bound={hex(ids.bound)} is out of the valid range.'\n\nint_value = as_int(ids.value, PRIME)\nq, ids.r = divmod(int_value, ids.div)\n\nassert -ids.bound <= q < ids.bound, \\\n    f'{int_value} / {ids.div} = {q} is out of the range [{-ids.bound}, {ids.bound}).'\n\nids.biased_q = q + ids.bound";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -4321,7 +4261,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((0, 1)),
@@ -4334,7 +4274,7 @@ mod tests {
 
     #[test]
     fn signed_div_rem_incorrect_ids() {
-        let hint_code = "from starkware.cairo.common.math_utils import as_int, assert_integer\n\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\n\nassert_integer(ids.bound)\nassert ids.bound <= range_check_builtin.bound // 2, \\\n    f'bound={hex(ids.bound)} is out of the valid range.'\n\nint_value = as_int(ids.value, PRIME)\nq, ids.r = divmod(int_value, ids.div)\n\nassert -ids.bound <= q < ids.bound, \\\n    f'{int_value} / {ids.div} = {q} is out of the range [{-ids.bound}, {ids.bound}).'\n\nids.biased_q = q + ids.bound".as_bytes();
+        let hint_code = "from starkware.cairo.common.math_utils import as_int, assert_integer\n\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\n\nassert_integer(ids.bound)\nassert ids.bound <= range_check_builtin.bound // 2, \\\n    f'bound={hex(ids.bound)} is out of the valid range.'\n\nint_value = as_int(ids.value, PRIME)\nq, ids.r = divmod(int_value, ids.div)\n\nassert -ids.bound <= q < ids.bound, \\\n    f'{int_value} / {ids.div} = {q} is out of the range [{-ids.bound}, {ids.bound}).'\n\nids.biased_q = q + ids.bound";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -4447,14 +4387,14 @@ mod tests {
         ]);
         //Execute the hint
         assert!(matches!(
-            execute_hint(&mut vm, &hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, &hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::IncorrectIds(_, _))
         ))
     }
     #[test]
     fn run_assert_250_bit_valid() {
         let hint_code = "from starkware.cairo.common.math_utils import as_int\n\n# Correctness check.\nvalue = as_int(ids.value, PRIME) % PRIME\nassert value < ids.UPPER_BOUND, f'{value} is outside of the range [0, 2**250).'\n\n# Calculation for the assertion.\nids.high, ids.low = divmod(ids.value, ids.SHIFT)"
-             .as_bytes();
+             ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -4516,7 +4456,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
         //Hint would return an error if the assertion fails
@@ -4534,7 +4474,7 @@ mod tests {
     #[test]
     fn run_assert_250_bit_invalid() {
         let hint_code = "from starkware.cairo.common.math_utils import as_int\n\n# Correctness check.\nvalue = as_int(ids.value, PRIME) % PRIME\nassert value < ids.UPPER_BOUND, f'{value} is outside of the range [0, 2**250).'\n\n# Calculation for the assertion.\nids.high, ids.low = divmod(ids.value, ids.SHIFT)"
-             .as_bytes();
+             ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -4596,7 +4536,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ValueOutside250BitRange(
                 bigint!(1).shl(251i32)
             ))
@@ -4607,7 +4547,7 @@ mod tests {
     fn run_split_felt_ok() {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert ids.MAX_HIGH < 2**128 and ids.MAX_LOW < 2**128\nassert PRIME - 1 == ids.MAX_HIGH * 2**128 + ids.MAX_LOW\nassert_integer(ids.value)\nids.low = ids.value & ((1 << 128) - 1)\nids.high = ids.value >> 128"
-        .as_bytes();
+        ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -4683,7 +4623,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
 
@@ -4704,7 +4644,7 @@ mod tests {
     fn run_split_felt_incorrect_ids() {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert ids.MAX_HIGH < 2**128 and ids.MAX_LOW < 2**128\nassert PRIME - 1 == ids.MAX_HIGH * 2**128 + ids.MAX_LOW\nassert_integer(ids.value)\nids.low = ids.value & ((1 << 128) - 1)\nids.high = ids.value >> 128"
-        .as_bytes();
+        ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -4778,7 +4718,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, incomplete_ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &incomplete_ids, &ApTracking::new()),
             Err(VirtualMachineError::IncorrectIds(
                 vec![
                     String::from("high"),
@@ -4793,7 +4733,7 @@ mod tests {
     fn run_split_felt_failed_to_get_ids() {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert ids.MAX_HIGH < 2**128 and ids.MAX_LOW < 2**128\nassert PRIME - 1 == ids.MAX_HIGH * 2**128 + ids.MAX_LOW\nassert_integer(ids.value)\nids.low = ids.value & ((1 << 128) - 1)\nids.high = ids.value >> 128"
-        .as_bytes();
+        ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -4870,7 +4810,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::FailedToGetIds)
         );
     }
@@ -4879,7 +4819,7 @@ mod tests {
     fn run_split_felt_fails_first_insert() {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert ids.MAX_HIGH < 2**128 and ids.MAX_LOW < 2**128\nassert PRIME - 1 == ids.MAX_HIGH * 2**128 + ids.MAX_LOW\nassert_integer(ids.value)\nids.low = ids.value & ((1 << 128) - 1)\nids.high = ids.value >> 128"
-        .as_bytes();
+        ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -4964,7 +4904,7 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((2, 0)),
@@ -4979,7 +4919,7 @@ mod tests {
     fn run_split_felt_fails_second_insert() {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert ids.MAX_HIGH < 2**128 and ids.MAX_LOW < 2**128\nassert PRIME - 1 == ids.MAX_HIGH * 2**128 + ids.MAX_LOW\nassert_integer(ids.value)\nids.low = ids.value & ((1 << 128) - 1)\nids.high = ids.value >> 128"
-        .as_bytes();
+        ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -5064,7 +5004,7 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((2, 1)),
@@ -5079,7 +5019,7 @@ mod tests {
     fn run_split_felt_value_is_not_integer() {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert ids.MAX_HIGH < 2**128 and ids.MAX_LOW < 2**128\nassert PRIME - 1 == ids.MAX_HIGH * 2**128 + ids.MAX_LOW\nassert_integer(ids.value)\nids.low = ids.value & ((1 << 128) - 1)\nids.high = ids.value >> 128"
-        .as_bytes();
+        ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -5155,7 +5095,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((1, 3))
             ))
@@ -5166,7 +5106,7 @@ mod tests {
     fn run_assert_lt_felt_ok() {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\nassert (ids.a % PRIME) < (ids.b % PRIME), \\\n    f'a = {ids.a % PRIME} is not less than b = {ids.b % PRIME}.'"
-        .as_bytes();
+        ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -5231,7 +5171,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
     }
@@ -5240,7 +5180,7 @@ mod tests {
     fn run_assert_lt_felt_assert_fails() {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\nassert (ids.a % PRIME) < (ids.b % PRIME), \\\n    f'a = {ids.a % PRIME} is not less than b = {ids.b % PRIME}.'"
-        .as_bytes();
+        ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -5305,7 +5245,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::AssertLtFelt(bigint!(3), bigint!(2)))
         );
     }
@@ -5314,7 +5254,7 @@ mod tests {
     fn run_assert_lt_felt_incorrect_ids() {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\nassert (ids.a % PRIME) < (ids.b % PRIME), \\\n    f'a = {ids.a % PRIME} is not less than b = {ids.b % PRIME}.'"
-        .as_bytes();
+        ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -5378,7 +5318,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::IncorrectIds(
                 vec![String::from("a"), String::from("b"),],
                 vec![String::from("a"),],
@@ -5390,7 +5330,7 @@ mod tests {
     fn run_assert_lt_felt_incorrect_references() {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\nassert (ids.a % PRIME) < (ids.b % PRIME), \\\n    f'a = {ids.a % PRIME} is not less than b = {ids.b % PRIME}.'"
-        .as_bytes();
+        ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -5456,7 +5396,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::FailedToGetIds)
         );
     }
@@ -5465,7 +5405,7 @@ mod tests {
     fn run_assert_lt_felt_a_is_not_integer() {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\nassert (ids.a % PRIME) < (ids.b % PRIME), \\\n    f'a = {ids.a % PRIME} is not less than b = {ids.b % PRIME}.'"
-        .as_bytes();
+        ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -5530,7 +5470,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((1, 1))
             ))
@@ -5541,7 +5481,7 @@ mod tests {
     fn run_assert_lt_felt_b_is_not_integer() {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\nassert (ids.a % PRIME) < (ids.b % PRIME), \\\n    f'a = {ids.a % PRIME} is not less than b = {ids.b % PRIME}.'"
-        .as_bytes();
+        ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -5606,7 +5546,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((1, 2))
             ))
@@ -5617,7 +5557,7 @@ mod tests {
     fn run_assert_lt_felt_ok_failed_to_get_ids() {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\nassert (ids.a % PRIME) < (ids.b % PRIME), \\\n    f'a = {ids.a % PRIME} is not less than b = {ids.b % PRIME}.'"
-        .as_bytes();
+        ;
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -5682,14 +5622,14 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::FailedToGetIds)
         );
     }
 
     #[test]
     fn memcpy_enter_scope_valid() {
-        let hint_code = "vm_enter_scope({'n': ids.len})".as_bytes();
+        let hint_code = "vm_enter_scope({'n': ids.len})";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -5726,12 +5666,12 @@ mod tests {
             },
         )]);
 
-        assert!(execute_hint(&mut vm, hint_code, ids, &ApTracking::new()).is_ok());
+        assert!(execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()).is_ok());
     }
 
     #[test]
     fn memcpy_enter_scope_invalid() {
-        let hint_code = "vm_enter_scope({'n': ids.len})".as_bytes();
+        let hint_code = "vm_enter_scope({'n': ids.len})";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -5770,7 +5710,7 @@ mod tests {
         )]);
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((0, 1))
             ))
@@ -5779,7 +5719,7 @@ mod tests {
 
     #[test]
     fn memcpy_continue_copying_valid() {
-        let hint_code = "n -= 1\nids.continue_copying = 1 if n > 0 else 0".as_bytes();
+        let hint_code = "n -= 1\nids.continue_copying = 1 if n > 0 else 0";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -5821,12 +5761,12 @@ mod tests {
             },
         )]);
 
-        assert!(execute_hint(&mut vm, hint_code, ids, &ApTracking::new()).is_ok());
+        assert!(execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()).is_ok());
     }
 
     #[test]
     fn memcpy_continue_copying_variable_not_in_scope_error() {
-        let hint_code = "n -= 1\nids.continue_copying = 1 if n > 0 else 0".as_bytes();
+        let hint_code = "n -= 1\nids.continue_copying = 1 if n > 0 else 0";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -5869,7 +5809,7 @@ mod tests {
         )]);
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::VariableNotInScopeError(
                 "n".to_string()
             ))
@@ -5878,7 +5818,7 @@ mod tests {
 
     #[test]
     fn memcpy_continue_copying_insert_error() {
-        let hint_code = "n -= 1\nids.continue_copying = 1 if n > 0 else 0".as_bytes();
+        let hint_code = "n -= 1\nids.continue_copying = 1 if n > 0 else 0";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -5921,7 +5861,7 @@ mod tests {
         )]);
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((0, 1)),
@@ -5934,7 +5874,7 @@ mod tests {
 
     #[test]
     fn exit_scope_valid() {
-        let hint_code = "vm_exit_scope()".as_bytes();
+        let hint_code = "vm_exit_scope()";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -5950,12 +5890,12 @@ mod tests {
         // initialize memory segments
         vm.segments.add(&mut vm.memory, None);
 
-        assert!(execute_hint(&mut vm, hint_code, HashMap::new(), &ApTracking::new()).is_ok());
+        assert!(execute_hint(&mut vm, hint_code, &HashMap::new(), &ApTracking::new()).is_ok());
     }
 
     #[test]
     fn exit_scope_invalid() {
-        let hint_code = "vm_exit_scope()".as_bytes();
+        let hint_code = "vm_exit_scope()";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -5969,7 +5909,7 @@ mod tests {
         vm.segments.add(&mut vm.memory, None);
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, HashMap::new(), &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &HashMap::new(), &ApTracking::new()),
             Err(VirtualMachineError::MainScopeError(
                 ExecScopeError::ExitMainScopeError
             ))
@@ -5978,7 +5918,7 @@ mod tests {
 
     #[test]
     fn run_enter_scope() {
-        let hint_code = "vm_enter_scope()".as_bytes();
+        let hint_code = "vm_enter_scope()";
         //Create vm
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -5987,7 +5927,7 @@ mod tests {
         );
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, HashMap::new(), &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &HashMap::new(), &ApTracking::default()),
             Ok(())
         );
         //Check exec_scopes
@@ -5997,7 +5937,7 @@ mod tests {
 
     #[test]
     fn unsafe_keccak_valid() {
-        let hint_code = "from eth_hash.auto import keccak\n\ndata, length = ids.data, ids.length\n\nif '__keccak_max_size' in globals():\n    assert length <= __keccak_max_size, \\\n        f'unsafe_keccak() can only be used with length<={__keccak_max_size}. ' \\\n        f'Got: length={length}.'\n\nkeccak_input = bytearray()\nfor word_i, byte_i in enumerate(range(0, length, 16)):\n    word = memory[data + word_i]\n    n_bytes = min(16, length - byte_i)\n    assert 0 <= word < 2 ** (8 * n_bytes)\n    keccak_input += word.to_bytes(n_bytes, 'big')\n\nhashed = keccak(keccak_input)\nids.high = int.from_bytes(hashed[:16], 'big')\nids.low = int.from_bytes(hashed[16:32], 'big')".as_bytes();
+        let hint_code = "from eth_hash.auto import keccak\n\ndata, length = ids.data, ids.length\n\nif '__keccak_max_size' in globals():\n    assert length <= __keccak_max_size, \\\n        f'unsafe_keccak() can only be used with length<={__keccak_max_size}. ' \\\n        f'Got: length={length}.'\n\nkeccak_input = bytearray()\nfor word_i, byte_i in enumerate(range(0, length, 16)):\n    word = memory[data + word_i]\n    n_bytes = min(16, length - byte_i)\n    assert 0 <= word < 2 ** (8 * n_bytes)\n    keccak_input += word.to_bytes(n_bytes, 'big')\n\nhashed = keccak(keccak_input)\nids.high = int.from_bytes(hashed[:16], 'big')\nids.low = int.from_bytes(hashed[16:32], 'big')";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -6115,12 +6055,12 @@ mod tests {
             ),
         ]);
 
-        assert!(execute_hint(&mut vm, hint_code, ids, &ApTracking::new()).is_ok());
+        assert!(execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()).is_ok());
     }
 
     #[test]
     fn unsafe_keccak_max_size() {
-        let hint_code = "from eth_hash.auto import keccak\n\ndata, length = ids.data, ids.length\n\nif '__keccak_max_size' in globals():\n    assert length <= __keccak_max_size, \\\n        f'unsafe_keccak() can only be used with length<={__keccak_max_size}. ' \\\n        f'Got: length={length}.'\n\nkeccak_input = bytearray()\nfor word_i, byte_i in enumerate(range(0, length, 16)):\n    word = memory[data + word_i]\n    n_bytes = min(16, length - byte_i)\n    assert 0 <= word < 2 ** (8 * n_bytes)\n    keccak_input += word.to_bytes(n_bytes, 'big')\n\nhashed = keccak(keccak_input)\nids.high = int.from_bytes(hashed[:16], 'big')\nids.low = int.from_bytes(hashed[16:32], 'big')".as_bytes();
+        let hint_code = "from eth_hash.auto import keccak\n\ndata, length = ids.data, ids.length\n\nif '__keccak_max_size' in globals():\n    assert length <= __keccak_max_size, \\\n        f'unsafe_keccak() can only be used with length<={__keccak_max_size}. ' \\\n        f'Got: length={length}.'\n\nkeccak_input = bytearray()\nfor word_i, byte_i in enumerate(range(0, length, 16)):\n    word = memory[data + word_i]\n    n_bytes = min(16, length - byte_i)\n    assert 0 <= word < 2 ** (8 * n_bytes)\n    keccak_input += word.to_bytes(n_bytes, 'big')\n\nhashed = keccak(keccak_input)\nids.high = int.from_bytes(hashed[:16], 'big')\nids.low = int.from_bytes(hashed[16:32], 'big')";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -6239,14 +6179,14 @@ mod tests {
         ]);
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::KeccakMaxSize(bigint!(5), bigint!(2)))
         );
     }
 
     #[test]
     fn unsafe_keccak_invalid_input_length() {
-        let hint_code = "from eth_hash.auto import keccak\n\ndata, length = ids.data, ids.length\n\nif '__keccak_max_size' in globals():\n    assert length <= __keccak_max_size, \\\n        f'unsafe_keccak() can only be used with length<={__keccak_max_size}. ' \\\n        f'Got: length={length}.'\n\nkeccak_input = bytearray()\nfor word_i, byte_i in enumerate(range(0, length, 16)):\n    word = memory[data + word_i]\n    n_bytes = min(16, length - byte_i)\n    assert 0 <= word < 2 ** (8 * n_bytes)\n    keccak_input += word.to_bytes(n_bytes, 'big')\n\nhashed = keccak(keccak_input)\nids.high = int.from_bytes(hashed[:16], 'big')\nids.low = int.from_bytes(hashed[16:32], 'big')".as_bytes();
+        let hint_code = "from eth_hash.auto import keccak\n\ndata, length = ids.data, ids.length\n\nif '__keccak_max_size' in globals():\n    assert length <= __keccak_max_size, \\\n        f'unsafe_keccak() can only be used with length<={__keccak_max_size}. ' \\\n        f'Got: length={length}.'\n\nkeccak_input = bytearray()\nfor word_i, byte_i in enumerate(range(0, length, 16)):\n    word = memory[data + word_i]\n    n_bytes = min(16, length - byte_i)\n    assert 0 <= word < 2 ** (8 * n_bytes)\n    keccak_input += word.to_bytes(n_bytes, 'big')\n\nhashed = keccak(keccak_input)\nids.high = int.from_bytes(hashed[:16], 'big')\nids.low = int.from_bytes(hashed[16:32], 'big')";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -6361,12 +6301,12 @@ mod tests {
             ),
         ]);
 
-        assert!(execute_hint(&mut vm, hint_code, ids, &ApTracking::new()).is_err());
+        assert!(execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()).is_err());
     }
 
     #[test]
     fn unsafe_keccak_invalid_word_size() {
-        let hint_code = "from eth_hash.auto import keccak\n\ndata, length = ids.data, ids.length\n\nif '__keccak_max_size' in globals():\n    assert length <= __keccak_max_size, \\\n        f'unsafe_keccak() can only be used with length<={__keccak_max_size}. ' \\\n        f'Got: length={length}.'\n\nkeccak_input = bytearray()\nfor word_i, byte_i in enumerate(range(0, length, 16)):\n    word = memory[data + word_i]\n    n_bytes = min(16, length - byte_i)\n    assert 0 <= word < 2 ** (8 * n_bytes)\n    keccak_input += word.to_bytes(n_bytes, 'big')\n\nhashed = keccak(keccak_input)\nids.high = int.from_bytes(hashed[:16], 'big')\nids.low = int.from_bytes(hashed[16:32], 'big')".as_bytes();
+        let hint_code = "from eth_hash.auto import keccak\n\ndata, length = ids.data, ids.length\n\nif '__keccak_max_size' in globals():\n    assert length <= __keccak_max_size, \\\n        f'unsafe_keccak() can only be used with length<={__keccak_max_size}. ' \\\n        f'Got: length={length}.'\n\nkeccak_input = bytearray()\nfor word_i, byte_i in enumerate(range(0, length, 16)):\n    word = memory[data + word_i]\n    n_bytes = min(16, length - byte_i)\n    assert 0 <= word < 2 ** (8 * n_bytes)\n    keccak_input += word.to_bytes(n_bytes, 'big')\n\nhashed = keccak(keccak_input)\nids.high = int.from_bytes(hashed[:16], 'big')\nids.low = int.from_bytes(hashed[16:32], 'big')";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -6485,14 +6425,14 @@ mod tests {
         ]);
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::InvalidWordSize(bigint!(-1)))
         );
     }
 
     #[test]
     fn unsafe_keccak_finalize_valid() {
-        let hint_code = "from eth_hash.auto import keccak\nkeccak_input = bytearray()\nn_elms = ids.keccak_state.end_ptr - ids.keccak_state.start_ptr\nfor word in memory.get_range(ids.keccak_state.start_ptr, n_elms):\n    keccak_input += word.to_bytes(16, 'big')\nhashed = keccak(keccak_input)\nids.high = int.from_bytes(hashed[:16], 'big')\nids.low = int.from_bytes(hashed[16:32], 'big')".as_bytes();
+        let hint_code = "from eth_hash.auto import keccak\nkeccak_input = bytearray()\nn_elms = ids.keccak_state.end_ptr - ids.keccak_state.start_ptr\nfor word in memory.get_range(ids.keccak_state.start_ptr, n_elms):\n    keccak_input += word.to_bytes(16, 'big')\nhashed = keccak(keccak_input)\nids.high = int.from_bytes(hashed[:16], 'big')\nids.low = int.from_bytes(hashed[16:32], 'big')";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -6596,12 +6536,12 @@ mod tests {
             ),
         ]);
 
-        assert!(execute_hint(&mut vm, hint_code, ids, &ApTracking::new()).is_ok());
+        assert!(execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()).is_ok());
     }
 
     #[test]
     fn unsafe_keccak_finalize_nones_in_range() {
-        let hint_code = "from eth_hash.auto import keccak\nkeccak_input = bytearray()\nn_elms = ids.keccak_state.end_ptr - ids.keccak_state.start_ptr\nfor word in memory.get_range(ids.keccak_state.start_ptr, n_elms):\n    keccak_input += word.to_bytes(16, 'big')\nhashed = keccak(keccak_input)\nids.high = int.from_bytes(hashed[:16], 'big')\nids.low = int.from_bytes(hashed[16:32], 'big')".as_bytes();
+        let hint_code = "from eth_hash.auto import keccak\nkeccak_input = bytearray()\nn_elms = ids.keccak_state.end_ptr - ids.keccak_state.start_ptr\nfor word in memory.get_range(ids.keccak_state.start_ptr, n_elms):\n    keccak_input += word.to_bytes(16, 'big')\nhashed = keccak(keccak_input)\nids.high = int.from_bytes(hashed[:16], 'big')\nids.low = int.from_bytes(hashed[16:32], 'big')";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -6699,14 +6639,14 @@ mod tests {
         ]);
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::NoneInMemoryRange)
         );
     }
 
     #[test]
     fn unsafe_keccak_finalize_expected_integer_at_range() {
-        let hint_code = "from eth_hash.auto import keccak\nkeccak_input = bytearray()\nn_elms = ids.keccak_state.end_ptr - ids.keccak_state.start_ptr\nfor word in memory.get_range(ids.keccak_state.start_ptr, n_elms):\n    keccak_input += word.to_bytes(16, 'big')\nhashed = keccak(keccak_input)\nids.high = int.from_bytes(hashed[:16], 'big')\nids.low = int.from_bytes(hashed[16:32], 'big')".as_bytes();
+        let hint_code = "from eth_hash.auto import keccak\nkeccak_input = bytearray()\nn_elms = ids.keccak_state.end_ptr - ids.keccak_state.start_ptr\nfor word in memory.get_range(ids.keccak_state.start_ptr, n_elms):\n    keccak_input += word.to_bytes(16, 'big')\nhashed = keccak(keccak_input)\nids.high = int.from_bytes(hashed[:16], 'big')\nids.low = int.from_bytes(hashed[16:32], 'big')";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -6811,6 +6751,6 @@ mod tests {
             ),
         ]);
 
-        assert!(execute_hint(&mut vm, hint_code, ids, &ApTracking::new()).is_err());
+        assert!(execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()).is_err());
     }
 }

--- a/src/vm/hints/hint_code.rs
+++ b/src/vm/hints/hint_code.rs
@@ -1,0 +1,387 @@
+pub(crate) const ADD_SEGMENT: &str = "memory[ap] = segments.add()";
+
+pub(crate) const VM_ENTER_SCOPE: &str = "vm_enter_scope()";
+pub(crate) const VM_EXIT_SCOPE: &str = "vm_exit_scope()";
+
+pub(crate) const MEMCPY_ENTER_SCOPE: &str = "vm_enter_scope({'n': ids.len})";
+pub(crate) const MEMCPY_CONTINUE_COPYING: &str = r#"n -= 1
+ids.continue_copying = 1 if n > 0 else 0"#;
+
+pub(crate) const MEMSET_ENTER_SCOPE: &str = "vm_enter_scope({'n': ids.n})";
+pub(crate) const MEMSET_CONTINUE_LOOP: &str = r#"n -= 1
+ids.continue_loop = 1 if n > 0 else 0"#;
+
+pub(crate) const POW: &str = "ids.locs.bit = (ids.prev_locs.exp % PRIME) & 1";
+
+pub(crate) const IS_NN: &str =
+    "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1";
+pub(crate) const IS_NN_OUT_OF_RANGE: &str =
+    "memory[ap] = 0 if 0 <= ((-ids.a - 1) % PRIME) < range_check_builtin.bound else 1";
+pub(crate) const IS_LE_FELT: &str = "memory[ap] = 0 if (ids.a % PRIME) <= (ids.b % PRIME) else 1";
+pub(crate) const IS_POSITIVE: &str = r#"from starkware.cairo.common.math_utils import is_positive
+ids.is_positive = 1 if is_positive(
+    value=ids.value, prime=PRIME, rc_bound=range_check_builtin.bound) else 0"#;
+
+pub(crate) const ASSERT_NN: &str = r#"from starkware.cairo.common.math_utils import assert_integer
+assert_integer(ids.a)
+assert 0 <= ids.a % PRIME < range_check_builtin.bound, f'a = {ids.a} is out of range.'"#;
+
+pub(crate) const ASSERT_NOT_ZERO: &str = r#"from starkware.cairo.common.math_utils import assert_integer
+assert_integer(ids.value)
+assert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'"#;
+
+pub(crate) const ASSERT_NOT_EQUAL: &str = r#"from starkware.cairo.lang.vm.relocatable import RelocatableValue
+both_ints = isinstance(ids.a, int) and isinstance(ids.b, int)
+both_relocatable = (
+    isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and
+    ids.a.segment_index == ids.b.segment_index)
+assert both_ints or both_relocatable, \
+    f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'
+assert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'"#;
+
+pub(crate) const ASSERT_LE_FELT: &str = r#"from starkware.cairo.common.math_utils import assert_integer
+assert_integer(ids.a)
+assert_integer(ids.b)
+a = ids.a % PRIME
+b = ids.b % PRIME
+assert a <= b, f'a = {a} is not less than or equal to b = {b}.'
+
+ids.small_inputs = int(
+    a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"#;
+
+pub(crate) const ASSERT_LT_FELT: &str = r#"from starkware.cairo.common.math_utils import assert_integer
+assert_integer(ids.a)
+assert_integer(ids.b)
+assert (ids.a % PRIME) < (ids.b % PRIME), \
+    f'a = {ids.a % PRIME} is not less than b = {ids.b % PRIME}.'"#;
+
+pub(crate) const SPLIT_INT_ASSERT_RANGE: &str =
+    "assert ids.value == 0, 'split_int(): value is out of range.'";
+
+pub(crate) const ASSERT_250_BITS: &str = r#"from starkware.cairo.common.math_utils import as_int
+
+# Correctness check.
+value = as_int(ids.value, PRIME) % PRIME
+assert value < ids.UPPER_BOUND, f'{value} is outside of the range [0, 2**250).'
+
+# Calculation for the assertion.
+ids.high, ids.low = divmod(ids.value, ids.SHIFT)"#;
+
+pub(crate) const SPLIT_INT: &str = r#"memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base
+assert res < ids.bound, f'split_int(): Limb {res} is out of range.'"#;
+
+pub(crate) const SPLIT_64: &str = r#"ids.low = ids.a & ((1<<64) - 1)
+ids.high = ids.a >> 64"#;
+
+pub(crate) const SPLIT_FELT: &str = r#"from starkware.cairo.common.math_utils import assert_integer
+assert ids.MAX_HIGH < 2**128 and ids.MAX_LOW < 2**128
+assert PRIME - 1 == ids.MAX_HIGH * 2**128 + ids.MAX_LOW
+assert_integer(ids.value)
+ids.low = ids.value & ((1 << 128) - 1)
+ids.high = ids.value >> 128"#;
+
+pub(crate) const SQRT: &str = r#"from starkware.python.math_utils import isqrt
+value = ids.value % PRIME
+assert value < 2 ** 250, f"value={value} is outside of the range [0, 2**250)."
+assert 2 ** 250 < PRIME
+ids.root = isqrt(value)"#;
+
+pub(crate) const UNSIGNED_DIV_REM: &str = r#"from starkware.cairo.common.math_utils import assert_integer
+assert_integer(ids.div)
+assert 0 < ids.div <= PRIME // range_check_builtin.bound, \
+    f'div={hex(ids.div)} is out of the valid range.'
+ids.q, ids.r = divmod(ids.value, ids.div)"#;
+
+pub(crate) const SIGNED_DIV_REM: &str = r#"from starkware.cairo.common.math_utils import as_int, assert_integer
+
+assert_integer(ids.div)
+assert 0 < ids.div <= PRIME // range_check_builtin.bound, \
+    f'div={hex(ids.div)} is out of the valid range.'
+
+assert_integer(ids.bound)
+assert ids.bound <= range_check_builtin.bound // 2, \
+    f'bound={hex(ids.bound)} is out of the valid range.'
+
+int_value = as_int(ids.value, PRIME)
+q, ids.r = divmod(int_value, ids.div)
+
+assert -ids.bound <= q < ids.bound, \
+    f'{int_value} / {ids.div} = {q} is out of the range [{-ids.bound}, {ids.bound}).'
+
+ids.biased_q = q + ids.bound"#;
+
+pub(crate) const FIND_ELEMENT: &str = r#"array_ptr = ids.array_ptr
+elm_size = ids.elm_size
+assert isinstance(elm_size, int) and elm_size > 0, \
+    f'Invalid value for elm_size. Got: {elm_size}.'
+key = ids.key
+
+if '__find_element_index' in globals():
+    ids.index = __find_element_index
+    found_key = memory[array_ptr + elm_size * __find_element_index]
+    assert found_key == key, \
+        f'Invalid index found in __find_element_index. index: {__find_element_index}, ' \
+        f'expected key {key}, found key: {found_key}.'
+    # Delete __find_element_index to make sure it's not used for the next calls.
+    del __find_element_index
+else:
+    n_elms = ids.n_elms
+    assert isinstance(n_elms, int) and n_elms >= 0, \
+        f'Invalid value for n_elms. Got: {n_elms}.'
+    if '__find_element_max_size' in globals():
+        assert n_elms <= __find_element_max_size, \
+            f'find_element() can only be used with n_elms<={__find_element_max_size}. ' \
+            f'Got: n_elms={n_elms}.'
+
+    for i in range(n_elms):
+        if memory[array_ptr + elm_size * i] == key:
+            ids.index = i
+            break
+    else:
+        raise ValueError(f'Key {key} was not found.')"#;
+
+pub(crate) const SEARCH_SORTED_LOWER: &str = r#"array_ptr = ids.array_ptr
+elm_size = ids.elm_size
+assert isinstance(elm_size, int) and elm_size > 0, \
+    f'Invalid value for elm_size. Got: {elm_size}.'
+
+n_elms = ids.n_elms
+assert isinstance(n_elms, int) and n_elms >= 0, \
+    f'Invalid value for n_elms. Got: {n_elms}.'
+if '__find_element_max_size' in globals():
+    assert n_elms <= __find_element_max_size, \
+        f'find_element() can only be used with n_elms<={__find_element_max_size}. ' \
+        f'Got: n_elms={n_elms}.'
+
+for i in range(n_elms):
+    if memory[array_ptr + elm_size * i] >= ids.key:
+        ids.index = i
+        break
+else:
+    ids.index = n_elms"#;
+
+pub(crate) const SET_ADD: &str = r#"assert ids.elm_size > 0
+assert ids.set_ptr <= ids.set_end_ptr
+elm_list = memory.get_range(ids.elm_ptr, ids.elm_size)
+for i in range(0, ids.set_end_ptr - ids.set_ptr, ids.elm_size):
+    if memory.get_range(ids.set_ptr + i, ids.elm_size) == elm_list:
+        ids.index = i // ids.elm_size
+        ids.is_elm_in_set = 1
+        break
+else:
+    ids.is_elm_in_set = 0"#;
+
+pub(crate) const DEFAULT_DICT_NEW: &str = r#"if '__dict_manager' not in globals():
+    from starkware.cairo.common.dict import DictManager
+    __dict_manager = DictManager()
+
+memory[ap] = __dict_manager.new_default_dict(segments, ids.default_value)"#;
+
+pub(crate) const DICT_NEW: &str = r#"if '__dict_manager' not in globals():
+    from starkware.cairo.common.dict import DictManager
+    __dict_manager = DictManager()
+
+memory[ap] = __dict_manager.new_dict(segments, initial_dict)
+del initial_dict"#;
+
+pub(crate) const DICT_READ: &str = r#"dict_tracker = __dict_manager.get_tracker(ids.dict_ptr)
+dict_tracker.current_ptr += ids.DictAccess.SIZE
+ids.value = dict_tracker.data[ids.key]"#;
+
+pub(crate) const DICT_WRITE: &str = r#"dict_tracker = __dict_manager.get_tracker(ids.dict_ptr)
+dict_tracker.current_ptr += ids.DictAccess.SIZE
+ids.dict_ptr.prev_value = dict_tracker.data[ids.key]
+dict_tracker.data[ids.key] = ids.new_value"#;
+
+pub(crate) const DICT_UPDATE: &str = r#"# Verify dict pointer and prev value.
+dict_tracker = __dict_manager.get_tracker(ids.dict_ptr)
+current_value = dict_tracker.data[ids.key]
+assert current_value == ids.prev_value, \
+    f'Wrong previous value in dict. Got {ids.prev_value}, expected {current_value}.'
+
+# Update value.
+dict_tracker.data[ids.key] = ids.new_value
+dict_tracker.current_ptr += ids.DictAccess.SIZE"#;
+
+pub(crate) const SQUASH_DICT: &str = r#"dict_access_size = ids.DictAccess.SIZE
+address = ids.dict_accesses.address_
+assert ids.ptr_diff % dict_access_size == 0, \
+    'Accesses array size must be divisible by DictAccess.SIZE'
+n_accesses = ids.n_accesses
+if '__squash_dict_max_size' in globals():
+    assert n_accesses <= __squash_dict_max_size, \
+        f'squash_dict() can only be used with n_accesses<={__squash_dict_max_size}. ' \
+        f'Got: n_accesses={n_accesses}.'
+# A map from key to the list of indices accessing it.
+access_indices = {}
+for i in range(n_accesses):
+    key = memory[address + dict_access_size * i]
+    access_indices.setdefault(key, []).append(i)
+# Descending list of keys.
+keys = sorted(access_indices.keys(), reverse=True)
+# Are the keys used bigger than range_check bound.
+ids.big_keys = 1 if keys[0] >= range_check_builtin.bound else 0
+ids.first_key = key = keys.pop()"#;
+
+pub(crate) const SQUASH_DICT_INNER_SKIP_LOOP: &str =
+    "ids.should_skip_loop = 0 if current_access_indices else 1";
+pub(crate) const SQUASH_DICT_INNER_FIRST_ITERATION: &str = r#"current_access_indices = sorted(access_indices[key])[::-1]
+current_access_index = current_access_indices.pop()
+memory[ids.range_check_ptr] = current_access_index"#;
+
+pub(crate) const SQUASH_DICT_INNER_CHECK_ACCESS_INDEX: &str = r#"new_access_index = current_access_indices.pop()
+ids.loop_temps.index_delta_minus1 = new_access_index - current_access_index - 1
+current_access_index = new_access_index"#;
+
+pub(crate) const SQUASH_DICT_INNER_CONTINUE_LOOP: &str =
+    "ids.loop_temps.should_continue = 1 if current_access_indices else 0";
+pub(crate) const SQUASH_DICT_INNER_ASSERT_LEN_KEYS: &str = "assert len(keys) == 0";
+pub(crate) const SQUASH_DICT_INNER_LEN_ASSERT: &str = "assert len(current_access_indices) == 0";
+pub(crate) const SQUASH_DICT_INNER_USED_ACCESSES_ASSERT: &str =
+    "assert ids.n_used_accesses == len(access_indices[key])";
+pub(crate) const SQUASH_DICT_INNER_NEXT_KEY: &str = r#"assert len(keys) > 0, 'No keys left but remaining_accesses > 0.'
+ids.next_key = key = keys.pop()"#;
+
+pub(crate) const DICT_SQUASH_COPY_DICT: &str = r#"# Prepare arguments for dict_new. In particular, the same dictionary values should be copied
+# to the new (squashed) dictionary.
+vm_enter_scope({
+    # Make __dict_manager accessible.
+    '__dict_manager': __dict_manager,
+    # Create a copy of the dict, in case it changes in the future.
+    'initial_dict': dict(__dict_manager.get_dict(ids.dict_accesses_end)),
+})"#;
+
+pub(crate) const DICT_SQUASH_UPDATE_PTR: &str = r#"# Update the DictTracker's current_ptr to point to the end of the squashed dict.
+__dict_manager.get_tracker(ids.squashed_dict_start).current_ptr = \
+    ids.squashed_dict_end.address_"#;
+
+pub(crate) const UINT256_ADD: &str = r#"sum_low = ids.a.low + ids.b.low
+ids.carry_low = 1 if sum_low >= ids.SHIFT else 0
+sum_high = ids.a.high + ids.b.high + ids.carry_low
+ids.carry_high = 1 if sum_high >= ids.SHIFT else 0"#;
+
+pub(crate) const UINT256_SQRT: &str = r#"from starkware.python.math_utils import isqrt
+n = (ids.n.high << 128) + ids.n.low
+root = isqrt(n)
+assert 0 <= root < 2 ** 128
+ids.root.low = root
+ids.root.high = 0"#;
+
+pub(crate) const UINT256_SIGNED_NN: &str =
+    "memory[ap] = 1 if 0 <= (ids.a.high % PRIME) < 2 ** 127 else 0";
+
+pub(crate) const UINT256_UNSIGNED_DIV_REM: &str = r#"a = (ids.a.high << 128) + ids.a.low
+div = (ids.div.high << 128) + ids.div.low
+quotient, remainder = divmod(a, div)
+
+ids.quotient.low = quotient & ((1 << 128) - 1)
+ids.quotient.high = quotient >> 128
+ids.remainder.low = remainder & ((1 << 128) - 1)
+ids.remainder.high = remainder >> 128"#;
+
+pub(crate) const USORT_ENTER_SCOPE: &str =
+    "vm_enter_scope(dict(__usort_max_size = globals().get('__usort_max_size')))";
+pub(crate) const USORT_BODY: &str = r#"from collections import defaultdict
+
+input_ptr = ids.input
+input_len = int(ids.input_len)
+if __usort_max_size is not None:
+    assert input_len <= __usort_max_size, (
+        f"usort() can only be used with input_len<={__usort_max_size}. "
+        f"Got: input_len={input_len}."
+    )
+
+positions_dict = defaultdict(list)
+for i in range(input_len):
+    val = memory[input_ptr + i]
+    positions_dict[val].append(i)
+
+output = sorted(positions_dict.keys())
+ids.output_len = len(output)
+ids.output = segments.gen_arg(output)
+ids.multiplicities = segments.gen_arg([len(positions_dict[k]) for k in output])"#;
+
+pub(crate) const USORT_VERIFY: &str = r#"last_pos = 0
+positions = positions_dict[ids.value][::-1]"#;
+
+pub(crate) const USORT_VERIFY_MULTIPLICITY_ASSERT: &str = "assert len(positions) == 0";
+pub(crate) const USORT_VERIFY_MULTIPLICITY_BODY: &str = r#"current_pos = positions.pop()
+ids.next_item_index = current_pos - last_pos
+last_pos = current_pos + 1"#;
+
+pub(crate) const BLAKE2S_COMPUTE: &str = r#"from starkware.cairo.common.cairo_blake2s.blake2s_utils import compute_blake2s_func
+compute_blake2s_func(segments=segments, output_ptr=ids.output)"#;
+
+pub(crate) const BLAKE2S_FINALIZE: &str = r#"# Add dummy pairs of input and output.
+from starkware.cairo.common.cairo_blake2s.blake2s_utils import IV, blake2s_compress
+
+_n_packed_instances = int(ids.N_PACKED_INSTANCES)
+assert 0 <= _n_packed_instances < 20
+_blake2s_input_chunk_size_felts = int(ids.INPUT_BLOCK_FELTS)
+assert 0 <= _blake2s_input_chunk_size_felts < 100
+
+message = [0] * _blake2s_input_chunk_size_felts
+modified_iv = [IV[0] ^ 0x01010020] + IV[1:]
+output = blake2s_compress(
+    message=message,
+    h=modified_iv,
+    t0=0,
+    t1=0,
+    f0=0xffffffff,
+    f1=0,
+)
+padding = (modified_iv + message + [0, 0xffffffff] + output) * (_n_packed_instances - 1)
+segments.write_arg(ids.blake2s_ptr_end, padding)"#;
+
+pub(crate) const BLAKE2S_ADD_UINT256: &str = r#"B = 32
+MASK = 2 ** 32 - 1
+segments.write_arg(ids.data, [(ids.low >> (B * i)) & MASK for i in range(4)])
+segments.write_arg(ids.data + 4, [(ids.high >> (B * i)) & MASK for i in range(4)]"#;
+
+pub(crate) const BLAKE2S_ADD_UINT256_BIGEND: &str = r#"B = 32
+MASK = 2 ** 32 - 1
+segments.write_arg(ids.data, [(ids.high >> (B * (3 - i))) & MASK for i in range(4)])
+segments.write_arg(ids.data + 4, [(ids.low >> (B * (3 - i))) & MASK for i in range(4)])"#;
+
+pub(crate) const NONDET_BIGINT3: &str = r#"from starkware.cairo.common.cairo_secp.secp_utils import split
+
+segments.write_arg(ids.res.address_, split(value))"#;
+
+pub(crate) const VERIFY_ZERO: &str = r#"from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack
+
+q, r = divmod(pack(ids.val, PRIME), SECP_P)
+assert r == 0, f"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}."
+ids.q = q % PRIME"#;
+
+pub(crate) const REDUCE: &str = r#"from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack
+
+value = pack(ids.x, PRIME) % SECP_P"#;
+
+pub(crate) const UNSAFE_KECCAK: &str = r#"from eth_hash.auto import keccak
+
+data, length = ids.data, ids.length
+
+if '__keccak_max_size' in globals():
+    assert length <= __keccak_max_size, \
+        f'unsafe_keccak() can only be used with length<={__keccak_max_size}. ' \
+        f'Got: length={length}.'
+
+keccak_input = bytearray()
+for word_i, byte_i in enumerate(range(0, length, 16)):
+    word = memory[data + word_i]
+    n_bytes = min(16, length - byte_i)
+    assert 0 <= word < 2 ** (8 * n_bytes)
+    keccak_input += word.to_bytes(n_bytes, 'big')
+
+hashed = keccak(keccak_input)
+ids.high = int.from_bytes(hashed[:16], 'big')
+ids.low = int.from_bytes(hashed[16:32], 'big')"#;
+
+pub(crate) const UNSAFE_KECCAK_FINALIZE: &str = r#"from eth_hash.auto import keccak
+keccak_input = bytearray()
+n_elms = ids.keccak_state.end_ptr - ids.keccak_state.start_ptr
+for word in memory.get_range(ids.keccak_state.start_ptr, n_elms):
+    keccak_input += word.to_bytes(16, 'big')
+hashed = keccak(keccak_input)
+ids.high = int.from_bytes(hashed[:16], 'big')
+ids.low = int.from_bytes(hashed[16:32], 'big')"#;

--- a/src/vm/hints/hint_code.rs
+++ b/src/vm/hints/hint_code.rs
@@ -1,37 +1,36 @@
-pub(crate) const ADD_SEGMENT: &'static str = "memory[ap] = segments.add()";
+pub(crate) const ADD_SEGMENT: &str = "memory[ap] = segments.add()";
 
-pub(crate) const VM_ENTER_SCOPE: &'static str = "vm_enter_scope()";
-pub(crate) const VM_EXIT_SCOPE: &'static str = "vm_exit_scope()";
+pub(crate) const VM_ENTER_SCOPE: &str = "vm_enter_scope()";
+pub(crate) const VM_EXIT_SCOPE: &str = "vm_exit_scope()";
 
-pub(crate) const MEMCPY_ENTER_SCOPE: &'static str = "vm_enter_scope({'n': ids.len})";
-pub(crate) const MEMCPY_CONTINUE_COPYING: &'static str = r#"n -= 1
+pub(crate) const MEMCPY_ENTER_SCOPE: &str = "vm_enter_scope({'n': ids.len})";
+pub(crate) const MEMCPY_CONTINUE_COPYING: &str = r#"n -= 1
 ids.continue_copying = 1 if n > 0 else 0"#;
 
-pub(crate) const MEMSET_ENTER_SCOPE: &'static str = "vm_enter_scope({'n': ids.n})";
-pub(crate) const MEMSET_CONTINUE_LOOP: &'static str = r#"n -= 1
+pub(crate) const MEMSET_ENTER_SCOPE: &str = "vm_enter_scope({'n': ids.n})";
+pub(crate) const MEMSET_CONTINUE_LOOP: &str = r#"n -= 1
 ids.continue_loop = 1 if n > 0 else 0"#;
 
-pub(crate) const POW: &'static str = "ids.locs.bit = (ids.prev_locs.exp % PRIME) & 1";
+pub(crate) const POW: &str = "ids.locs.bit = (ids.prev_locs.exp % PRIME) & 1";
 
-pub(crate) const IS_NN: &'static str =
+pub(crate) const IS_NN: &str =
     "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1";
-pub(crate) const IS_NN_OUT_OF_RANGE: &'static str =
+pub(crate) const IS_NN_OUT_OF_RANGE: &str =
     "memory[ap] = 0 if 0 <= ((-ids.a - 1) % PRIME) < range_check_builtin.bound else 1";
-pub(crate) const IS_LE_FELT: &'static str =
-    "memory[ap] = 0 if (ids.a % PRIME) <= (ids.b % PRIME) else 1";
-pub(crate) const IS_POSITIVE: &'static str = r#"from starkware.cairo.common.math_utils import is_positive
+pub(crate) const IS_LE_FELT: &str = "memory[ap] = 0 if (ids.a % PRIME) <= (ids.b % PRIME) else 1";
+pub(crate) const IS_POSITIVE: &str = r#"from starkware.cairo.common.math_utils import is_positive
 ids.is_positive = 1 if is_positive(
     value=ids.value, prime=PRIME, rc_bound=range_check_builtin.bound) else 0"#;
 
-pub(crate) const ASSERT_NN: &'static str = r#"from starkware.cairo.common.math_utils import assert_integer
+pub(crate) const ASSERT_NN: &str = r#"from starkware.cairo.common.math_utils import assert_integer
 assert_integer(ids.a)
 assert 0 <= ids.a % PRIME < range_check_builtin.bound, f'a = {ids.a} is out of range.'"#;
 
-pub(crate) const ASSERT_NOT_ZERO: &'static str = r#"from starkware.cairo.common.math_utils import assert_integer
+pub(crate) const ASSERT_NOT_ZERO: &str = r#"from starkware.cairo.common.math_utils import assert_integer
 assert_integer(ids.value)
 assert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'"#;
 
-pub(crate) const ASSERT_NOT_EQUAL: &'static str = r#"from starkware.cairo.lang.vm.relocatable import RelocatableValue
+pub(crate) const ASSERT_NOT_EQUAL: &str = r#"from starkware.cairo.lang.vm.relocatable import RelocatableValue
 both_ints = isinstance(ids.a, int) and isinstance(ids.b, int)
 both_relocatable = (
     isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and
@@ -40,7 +39,7 @@ assert both_ints or both_relocatable, \
     f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'
 assert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'"#;
 
-pub(crate) const ASSERT_LE_FELT: &'static str = r#"from starkware.cairo.common.math_utils import assert_integer
+pub(crate) const ASSERT_LE_FELT: &str = r#"from starkware.cairo.common.math_utils import assert_integer
 assert_integer(ids.a)
 assert_integer(ids.b)
 a = ids.a % PRIME
@@ -50,16 +49,16 @@ assert a <= b, f'a = {a} is not less than or equal to b = {b}.'
 ids.small_inputs = int(
     a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"#;
 
-pub(crate) const ASSERT_LT_FELT: &'static str = r#"from starkware.cairo.common.math_utils import assert_integer
+pub(crate) const ASSERT_LT_FELT: &str = r#"from starkware.cairo.common.math_utils import assert_integer
 assert_integer(ids.a)
 assert_integer(ids.b)
 assert (ids.a % PRIME) < (ids.b % PRIME), \
     f'a = {ids.a % PRIME} is not less than b = {ids.b % PRIME}.'"#;
 
-pub(crate) const SPLIT_INT_ASSERT_RANGE: &'static str =
+pub(crate) const SPLIT_INT_ASSERT_RANGE: &str =
     "assert ids.value == 0, 'split_int(): value is out of range.'";
 
-pub(crate) const ASSERT_250_BITS: &'static str = r#"from starkware.cairo.common.math_utils import as_int
+pub(crate) const ASSERT_250_BITS: &str = r#"from starkware.cairo.common.math_utils import as_int
 
 # Correctness check.
 value = as_int(ids.value, PRIME) % PRIME
@@ -68,32 +67,32 @@ assert value < ids.UPPER_BOUND, f'{value} is outside of the range [0, 2**250).'
 # Calculation for the assertion.
 ids.high, ids.low = divmod(ids.value, ids.SHIFT)"#;
 
-pub(crate) const SPLIT_INT: &'static str = r#"memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base
+pub(crate) const SPLIT_INT: &str = r#"memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base
 assert res < ids.bound, f'split_int(): Limb {res} is out of range.'"#;
 
-pub(crate) const SPLIT_64: &'static str = r#"ids.low = ids.a & ((1<<64) - 1)
+pub(crate) const SPLIT_64: &str = r#"ids.low = ids.a & ((1<<64) - 1)
 ids.high = ids.a >> 64"#;
 
-pub(crate) const SPLIT_FELT: &'static str = r#"from starkware.cairo.common.math_utils import assert_integer
+pub(crate) const SPLIT_FELT: &str = r#"from starkware.cairo.common.math_utils import assert_integer
 assert ids.MAX_HIGH < 2**128 and ids.MAX_LOW < 2**128
 assert PRIME - 1 == ids.MAX_HIGH * 2**128 + ids.MAX_LOW
 assert_integer(ids.value)
 ids.low = ids.value & ((1 << 128) - 1)
 ids.high = ids.value >> 128"#;
 
-pub(crate) const SQRT: &'static str = r#"from starkware.python.math_utils import isqrt
+pub(crate) const SQRT: &str = r#"from starkware.python.math_utils import isqrt
 value = ids.value % PRIME
 assert value < 2 ** 250, f"value={value} is outside of the range [0, 2**250)."
 assert 2 ** 250 < PRIME
 ids.root = isqrt(value)"#;
 
-pub(crate) const UNSIGNED_DIV_REM: &'static str = r#"from starkware.cairo.common.math_utils import assert_integer
+pub(crate) const UNSIGNED_DIV_REM: &str = r#"from starkware.cairo.common.math_utils import assert_integer
 assert_integer(ids.div)
 assert 0 < ids.div <= PRIME // range_check_builtin.bound, \
     f'div={hex(ids.div)} is out of the valid range.'
 ids.q, ids.r = divmod(ids.value, ids.div)"#;
 
-pub(crate) const SIGNED_DIV_REM: &'static str = r#"from starkware.cairo.common.math_utils import as_int, assert_integer
+pub(crate) const SIGNED_DIV_REM: &str = r#"from starkware.cairo.common.math_utils import as_int, assert_integer
 
 assert_integer(ids.div)
 assert 0 < ids.div <= PRIME // range_check_builtin.bound, \
@@ -111,7 +110,7 @@ assert -ids.bound <= q < ids.bound, \
 
 ids.biased_q = q + ids.bound"#;
 
-pub(crate) const FIND_ELEMENT: &'static str = r#"array_ptr = ids.array_ptr
+pub(crate) const FIND_ELEMENT: &str = r#"array_ptr = ids.array_ptr
 elm_size = ids.elm_size
 assert isinstance(elm_size, int) and elm_size > 0, \
     f'Invalid value for elm_size. Got: {elm_size}.'
@@ -141,7 +140,7 @@ else:
     else:
         raise ValueError(f'Key {key} was not found.')"#;
 
-pub(crate) const SEARCH_SORTED_LOWER: &'static str = r#"array_ptr = ids.array_ptr
+pub(crate) const SEARCH_SORTED_LOWER: &str = r#"array_ptr = ids.array_ptr
 elm_size = ids.elm_size
 assert isinstance(elm_size, int) and elm_size > 0, \
     f'Invalid value for elm_size. Got: {elm_size}.'
@@ -161,7 +160,7 @@ for i in range(n_elms):
 else:
     ids.index = n_elms"#;
 
-pub(crate) const SET_ADD: &'static str = r#"assert ids.elm_size > 0
+pub(crate) const SET_ADD: &str = r#"assert ids.elm_size > 0
 assert ids.set_ptr <= ids.set_end_ptr
 elm_list = memory.get_range(ids.elm_ptr, ids.elm_size)
 for i in range(0, ids.set_end_ptr - ids.set_ptr, ids.elm_size):
@@ -172,29 +171,29 @@ for i in range(0, ids.set_end_ptr - ids.set_ptr, ids.elm_size):
 else:
     ids.is_elm_in_set = 0"#;
 
-pub(crate) const DEFAULT_DICT_NEW: &'static str = r#"if '__dict_manager' not in globals():
+pub(crate) const DEFAULT_DICT_NEW: &str = r#"if '__dict_manager' not in globals():
     from starkware.cairo.common.dict import DictManager
     __dict_manager = DictManager()
 
 memory[ap] = __dict_manager.new_default_dict(segments, ids.default_value)"#;
 
-pub(crate) const DICT_NEW: &'static str = r#"if '__dict_manager' not in globals():
+pub(crate) const DICT_NEW: &str = r#"if '__dict_manager' not in globals():
     from starkware.cairo.common.dict import DictManager
     __dict_manager = DictManager()
 
 memory[ap] = __dict_manager.new_dict(segments, initial_dict)
 del initial_dict"#;
 
-pub(crate) const DICT_READ: &'static str = r#"dict_tracker = __dict_manager.get_tracker(ids.dict_ptr)
+pub(crate) const DICT_READ: &str = r#"dict_tracker = __dict_manager.get_tracker(ids.dict_ptr)
 dict_tracker.current_ptr += ids.DictAccess.SIZE
 ids.value = dict_tracker.data[ids.key]"#;
 
-pub(crate) const DICT_WRITE: &'static str = r#"dict_tracker = __dict_manager.get_tracker(ids.dict_ptr)
+pub(crate) const DICT_WRITE: &str = r#"dict_tracker = __dict_manager.get_tracker(ids.dict_ptr)
 dict_tracker.current_ptr += ids.DictAccess.SIZE
 ids.dict_ptr.prev_value = dict_tracker.data[ids.key]
 dict_tracker.data[ids.key] = ids.new_value"#;
 
-pub(crate) const DICT_UPDATE: &'static str = r#"# Verify dict pointer and prev value.
+pub(crate) const DICT_UPDATE: &str = r#"# Verify dict pointer and prev value.
 dict_tracker = __dict_manager.get_tracker(ids.dict_ptr)
 current_value = dict_tracker.data[ids.key]
 assert current_value == ids.prev_value, \
@@ -204,7 +203,7 @@ assert current_value == ids.prev_value, \
 dict_tracker.data[ids.key] = ids.new_value
 dict_tracker.current_ptr += ids.DictAccess.SIZE"#;
 
-pub(crate) const SQUASH_DICT: &'static str = r#"dict_access_size = ids.DictAccess.SIZE
+pub(crate) const SQUASH_DICT: &str = r#"dict_access_size = ids.DictAccess.SIZE
 address = ids.dict_accesses.address_
 assert ids.ptr_diff % dict_access_size == 0, \
     'Accesses array size must be divisible by DictAccess.SIZE'
@@ -224,27 +223,26 @@ keys = sorted(access_indices.keys(), reverse=True)
 ids.big_keys = 1 if keys[0] >= range_check_builtin.bound else 0
 ids.first_key = key = keys.pop()"#;
 
-pub(crate) const SQUASH_DICT_INNER_SKIP_LOOP: &'static str =
+pub(crate) const SQUASH_DICT_INNER_SKIP_LOOP: &str =
     "ids.should_skip_loop = 0 if current_access_indices else 1";
-pub(crate) const SQUASH_DICT_INNER_FIRST_ITERATION: &'static str = r#"current_access_indices = sorted(access_indices[key])[::-1]
+pub(crate) const SQUASH_DICT_INNER_FIRST_ITERATION: &str = r#"current_access_indices = sorted(access_indices[key])[::-1]
 current_access_index = current_access_indices.pop()
 memory[ids.range_check_ptr] = current_access_index"#;
 
-pub(crate) const SQUASH_DICT_INNER_CHECK_ACCESS_INDEX: &'static str = r#"new_access_index = current_access_indices.pop()
+pub(crate) const SQUASH_DICT_INNER_CHECK_ACCESS_INDEX: &str = r#"new_access_index = current_access_indices.pop()
 ids.loop_temps.index_delta_minus1 = new_access_index - current_access_index - 1
 current_access_index = new_access_index"#;
 
-pub(crate) const SQUASH_DICT_INNER_CONTINUE_LOOP: &'static str =
+pub(crate) const SQUASH_DICT_INNER_CONTINUE_LOOP: &str =
     "ids.loop_temps.should_continue = 1 if current_access_indices else 0";
-pub(crate) const SQUASH_DICT_INNER_ASSERT_LEN_KEYS: &'static str = "assert len(keys) == 0";
-pub(crate) const SQUASH_DICT_INNER_LEN_ASSERT: &'static str =
-    "assert len(current_access_indices) == 0";
-pub(crate) const SQUASH_DICT_INNER_USED_ACCESSES_ASSERT: &'static str =
+pub(crate) const SQUASH_DICT_INNER_ASSERT_LEN_KEYS: &str = "assert len(keys) == 0";
+pub(crate) const SQUASH_DICT_INNER_LEN_ASSERT: &str = "assert len(current_access_indices) == 0";
+pub(crate) const SQUASH_DICT_INNER_USED_ACCESSES_ASSERT: &str =
     "assert ids.n_used_accesses == len(access_indices[key])";
-pub(crate) const SQUASH_DICT_INNER_NEXT_KEY: &'static str = r#"assert len(keys) > 0, 'No keys left but remaining_accesses > 0.'
+pub(crate) const SQUASH_DICT_INNER_NEXT_KEY: &str = r#"assert len(keys) > 0, 'No keys left but remaining_accesses > 0.'
 ids.next_key = key = keys.pop()"#;
 
-pub(crate) const DICT_SQUASH_COPY_DICT: &'static str = r#"# Prepare arguments for dict_new. In particular, the same dictionary values should be copied
+pub(crate) const DICT_SQUASH_COPY_DICT: &str = r#"# Prepare arguments for dict_new. In particular, the same dictionary values should be copied
 # to the new (squashed) dictionary.
 vm_enter_scope({
     # Make __dict_manager accessible.
@@ -253,26 +251,26 @@ vm_enter_scope({
     'initial_dict': dict(__dict_manager.get_dict(ids.dict_accesses_end)),
 })"#;
 
-pub(crate) const DICT_SQUASH_UPDATE_PTR: &'static str = r#"# Update the DictTracker's current_ptr to point to the end of the squashed dict.
+pub(crate) const DICT_SQUASH_UPDATE_PTR: &str = r#"# Update the DictTracker's current_ptr to point to the end of the squashed dict.
 __dict_manager.get_tracker(ids.squashed_dict_start).current_ptr = \
     ids.squashed_dict_end.address_"#;
 
-pub(crate) const UINT256_ADD: &'static str = r#"sum_low = ids.a.low + ids.b.low
+pub(crate) const UINT256_ADD: &str = r#"sum_low = ids.a.low + ids.b.low
 ids.carry_low = 1 if sum_low >= ids.SHIFT else 0
 sum_high = ids.a.high + ids.b.high + ids.carry_low
 ids.carry_high = 1 if sum_high >= ids.SHIFT else 0"#;
 
-pub(crate) const UINT256_SQRT: &'static str = r#"from starkware.python.math_utils import isqrt
+pub(crate) const UINT256_SQRT: &str = r#"from starkware.python.math_utils import isqrt
 n = (ids.n.high << 128) + ids.n.low
 root = isqrt(n)
 assert 0 <= root < 2 ** 128
 ids.root.low = root
 ids.root.high = 0"#;
 
-pub(crate) const UINT256_SIGNED_NN: &'static str =
+pub(crate) const UINT256_SIGNED_NN: &str =
     "memory[ap] = 1 if 0 <= (ids.a.high % PRIME) < 2 ** 127 else 0";
 
-pub(crate) const UINT256_UNSIGNED_DIV_REM: &'static str = r#"a = (ids.a.high << 128) + ids.a.low
+pub(crate) const UINT256_UNSIGNED_DIV_REM: &str = r#"a = (ids.a.high << 128) + ids.a.low
 div = (ids.div.high << 128) + ids.div.low
 quotient, remainder = divmod(a, div)
 
@@ -281,9 +279,9 @@ ids.quotient.high = quotient >> 128
 ids.remainder.low = remainder & ((1 << 128) - 1)
 ids.remainder.high = remainder >> 128"#;
 
-pub(crate) const USORT_ENTER_SCOPE: &'static str =
+pub(crate) const USORT_ENTER_SCOPE: &str =
     "vm_enter_scope(dict(__usort_max_size = globals().get('__usort_max_size')))";
-pub(crate) const USORT_BODY: &'static str = r#"from collections import defaultdict
+pub(crate) const USORT_BODY: &str = r#"from collections import defaultdict
 
 input_ptr = ids.input
 input_len = int(ids.input_len)
@@ -303,18 +301,18 @@ ids.output_len = len(output)
 ids.output = segments.gen_arg(output)
 ids.multiplicities = segments.gen_arg([len(positions_dict[k]) for k in output])"#;
 
-pub(crate) const USORT_VERIFY: &'static str = r#"last_pos = 0
+pub(crate) const USORT_VERIFY: &str = r#"last_pos = 0
 positions = positions_dict[ids.value][::-1]"#;
 
-pub(crate) const USORT_VERIFY_MULTIPLICITY_ASSERT: &'static str = "assert len(positions) == 0";
-pub(crate) const USORT_VERIFY_MULTIPLICITY_BODY: &'static str = r#"current_pos = positions.pop()
+pub(crate) const USORT_VERIFY_MULTIPLICITY_ASSERT: &str = "assert len(positions) == 0";
+pub(crate) const USORT_VERIFY_MULTIPLICITY_BODY: &str = r#"current_pos = positions.pop()
 ids.next_item_index = current_pos - last_pos
 last_pos = current_pos + 1"#;
 
-pub(crate) const BLAKE2S_COMPUTE: &'static str = r#"from starkware.cairo.common.cairo_blake2s.blake2s_utils import compute_blake2s_func
+pub(crate) const BLAKE2S_COMPUTE: &str = r#"from starkware.cairo.common.cairo_blake2s.blake2s_utils import compute_blake2s_func
 compute_blake2s_func(segments=segments, output_ptr=ids.output)"#;
 
-pub(crate) const BLAKE2S_FINALIZE: &'static str = r#"# Add dummy pairs of input and output.
+pub(crate) const BLAKE2S_FINALIZE: &str = r#"# Add dummy pairs of input and output.
 from starkware.cairo.common.cairo_blake2s.blake2s_utils import IV, blake2s_compress
 
 _n_packed_instances = int(ids.N_PACKED_INSTANCES)
@@ -335,31 +333,31 @@ output = blake2s_compress(
 padding = (modified_iv + message + [0, 0xffffffff] + output) * (_n_packed_instances - 1)
 segments.write_arg(ids.blake2s_ptr_end, padding)"#;
 
-pub(crate) const BLAKE2S_ADD_UINT256: &'static str = r#"B = 32
+pub(crate) const BLAKE2S_ADD_UINT256: &str = r#"B = 32
 MASK = 2 ** 32 - 1
 segments.write_arg(ids.data, [(ids.low >> (B * i)) & MASK for i in range(4)])
 segments.write_arg(ids.data + 4, [(ids.high >> (B * i)) & MASK for i in range(4)]"#;
 
-pub(crate) const BLAKE2S_ADD_UINT256_BIGEND: &'static str = r#"B = 32
+pub(crate) const BLAKE2S_ADD_UINT256_BIGEND: &str = r#"B = 32
 MASK = 2 ** 32 - 1
 segments.write_arg(ids.data, [(ids.high >> (B * (3 - i))) & MASK for i in range(4)])
 segments.write_arg(ids.data + 4, [(ids.low >> (B * (3 - i))) & MASK for i in range(4)])"#;
 
-pub(crate) const NONDET_BIGINT3: &'static str = r#"from starkware.cairo.common.cairo_secp.secp_utils import split
+pub(crate) const NONDET_BIGINT3: &str = r#"from starkware.cairo.common.cairo_secp.secp_utils import split
 
 segments.write_arg(ids.res.address_, split(value))"#;
 
-pub(crate) const VERIFY_ZERO: &'static str = r#"from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack
+pub(crate) const VERIFY_ZERO: &str = r#"from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack
 
 q, r = divmod(pack(ids.val, PRIME), SECP_P)
 assert r == 0, f"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}."
 ids.q = q % PRIME"#;
 
-pub(crate) const REDUCE: &'static str = r#"from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack
+pub(crate) const REDUCE: &str = r#"from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack
 
 value = pack(ids.x, PRIME) % SECP_P"#;
 
-pub(crate) const UNSAFE_KECCAK: &'static str = r#"from eth_hash.auto import keccak
+pub(crate) const UNSAFE_KECCAK: &str = r#"from eth_hash.auto import keccak
 
 data, length = ids.data, ids.length
 
@@ -379,7 +377,7 @@ hashed = keccak(keccak_input)
 ids.high = int.from_bytes(hashed[:16], 'big')
 ids.low = int.from_bytes(hashed[16:32], 'big')"#;
 
-pub(crate) const UNSAFE_KECCAK_FINALIZE: &'static str = r#"from eth_hash.auto import keccak
+pub(crate) const UNSAFE_KECCAK_FINALIZE: &str = r#"from eth_hash.auto import keccak
 keccak_input = bytearray()
 n_elms = ids.keccak_state.end_ptr - ids.keccak_state.start_ptr
 for word in memory.get_range(ids.keccak_state.start_ptr, n_elms):

--- a/src/vm/hints/hint_code.rs
+++ b/src/vm/hints/hint_code.rs
@@ -1,36 +1,37 @@
-pub(crate) const ADD_SEGMENT: &str = "memory[ap] = segments.add()";
+pub(crate) const ADD_SEGMENT: &'static str = "memory[ap] = segments.add()";
 
-pub(crate) const VM_ENTER_SCOPE: &str = "vm_enter_scope()";
-pub(crate) const VM_EXIT_SCOPE: &str = "vm_exit_scope()";
+pub(crate) const VM_ENTER_SCOPE: &'static str = "vm_enter_scope()";
+pub(crate) const VM_EXIT_SCOPE: &'static str = "vm_exit_scope()";
 
-pub(crate) const MEMCPY_ENTER_SCOPE: &str = "vm_enter_scope({'n': ids.len})";
-pub(crate) const MEMCPY_CONTINUE_COPYING: &str = r#"n -= 1
+pub(crate) const MEMCPY_ENTER_SCOPE: &'static str = "vm_enter_scope({'n': ids.len})";
+pub(crate) const MEMCPY_CONTINUE_COPYING: &'static str = r#"n -= 1
 ids.continue_copying = 1 if n > 0 else 0"#;
 
-pub(crate) const MEMSET_ENTER_SCOPE: &str = "vm_enter_scope({'n': ids.n})";
-pub(crate) const MEMSET_CONTINUE_LOOP: &str = r#"n -= 1
+pub(crate) const MEMSET_ENTER_SCOPE: &'static str = "vm_enter_scope({'n': ids.n})";
+pub(crate) const MEMSET_CONTINUE_LOOP: &'static str = r#"n -= 1
 ids.continue_loop = 1 if n > 0 else 0"#;
 
-pub(crate) const POW: &str = "ids.locs.bit = (ids.prev_locs.exp % PRIME) & 1";
+pub(crate) const POW: &'static str = "ids.locs.bit = (ids.prev_locs.exp % PRIME) & 1";
 
-pub(crate) const IS_NN: &str =
+pub(crate) const IS_NN: &'static str =
     "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1";
-pub(crate) const IS_NN_OUT_OF_RANGE: &str =
+pub(crate) const IS_NN_OUT_OF_RANGE: &'static str =
     "memory[ap] = 0 if 0 <= ((-ids.a - 1) % PRIME) < range_check_builtin.bound else 1";
-pub(crate) const IS_LE_FELT: &str = "memory[ap] = 0 if (ids.a % PRIME) <= (ids.b % PRIME) else 1";
-pub(crate) const IS_POSITIVE: &str = r#"from starkware.cairo.common.math_utils import is_positive
+pub(crate) const IS_LE_FELT: &'static str =
+    "memory[ap] = 0 if (ids.a % PRIME) <= (ids.b % PRIME) else 1";
+pub(crate) const IS_POSITIVE: &'static str = r#"from starkware.cairo.common.math_utils import is_positive
 ids.is_positive = 1 if is_positive(
     value=ids.value, prime=PRIME, rc_bound=range_check_builtin.bound) else 0"#;
 
-pub(crate) const ASSERT_NN: &str = r#"from starkware.cairo.common.math_utils import assert_integer
+pub(crate) const ASSERT_NN: &'static str = r#"from starkware.cairo.common.math_utils import assert_integer
 assert_integer(ids.a)
 assert 0 <= ids.a % PRIME < range_check_builtin.bound, f'a = {ids.a} is out of range.'"#;
 
-pub(crate) const ASSERT_NOT_ZERO: &str = r#"from starkware.cairo.common.math_utils import assert_integer
+pub(crate) const ASSERT_NOT_ZERO: &'static str = r#"from starkware.cairo.common.math_utils import assert_integer
 assert_integer(ids.value)
 assert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'"#;
 
-pub(crate) const ASSERT_NOT_EQUAL: &str = r#"from starkware.cairo.lang.vm.relocatable import RelocatableValue
+pub(crate) const ASSERT_NOT_EQUAL: &'static str = r#"from starkware.cairo.lang.vm.relocatable import RelocatableValue
 both_ints = isinstance(ids.a, int) and isinstance(ids.b, int)
 both_relocatable = (
     isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and
@@ -39,7 +40,7 @@ assert both_ints or both_relocatable, \
     f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'
 assert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'"#;
 
-pub(crate) const ASSERT_LE_FELT: &str = r#"from starkware.cairo.common.math_utils import assert_integer
+pub(crate) const ASSERT_LE_FELT: &'static str = r#"from starkware.cairo.common.math_utils import assert_integer
 assert_integer(ids.a)
 assert_integer(ids.b)
 a = ids.a % PRIME
@@ -49,16 +50,16 @@ assert a <= b, f'a = {a} is not less than or equal to b = {b}.'
 ids.small_inputs = int(
     a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)"#;
 
-pub(crate) const ASSERT_LT_FELT: &str = r#"from starkware.cairo.common.math_utils import assert_integer
+pub(crate) const ASSERT_LT_FELT: &'static str = r#"from starkware.cairo.common.math_utils import assert_integer
 assert_integer(ids.a)
 assert_integer(ids.b)
 assert (ids.a % PRIME) < (ids.b % PRIME), \
     f'a = {ids.a % PRIME} is not less than b = {ids.b % PRIME}.'"#;
 
-pub(crate) const SPLIT_INT_ASSERT_RANGE: &str =
+pub(crate) const SPLIT_INT_ASSERT_RANGE: &'static str =
     "assert ids.value == 0, 'split_int(): value is out of range.'";
 
-pub(crate) const ASSERT_250_BITS: &str = r#"from starkware.cairo.common.math_utils import as_int
+pub(crate) const ASSERT_250_BITS: &'static str = r#"from starkware.cairo.common.math_utils import as_int
 
 # Correctness check.
 value = as_int(ids.value, PRIME) % PRIME
@@ -67,32 +68,32 @@ assert value < ids.UPPER_BOUND, f'{value} is outside of the range [0, 2**250).'
 # Calculation for the assertion.
 ids.high, ids.low = divmod(ids.value, ids.SHIFT)"#;
 
-pub(crate) const SPLIT_INT: &str = r#"memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base
+pub(crate) const SPLIT_INT: &'static str = r#"memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base
 assert res < ids.bound, f'split_int(): Limb {res} is out of range.'"#;
 
-pub(crate) const SPLIT_64: &str = r#"ids.low = ids.a & ((1<<64) - 1)
+pub(crate) const SPLIT_64: &'static str = r#"ids.low = ids.a & ((1<<64) - 1)
 ids.high = ids.a >> 64"#;
 
-pub(crate) const SPLIT_FELT: &str = r#"from starkware.cairo.common.math_utils import assert_integer
+pub(crate) const SPLIT_FELT: &'static str = r#"from starkware.cairo.common.math_utils import assert_integer
 assert ids.MAX_HIGH < 2**128 and ids.MAX_LOW < 2**128
 assert PRIME - 1 == ids.MAX_HIGH * 2**128 + ids.MAX_LOW
 assert_integer(ids.value)
 ids.low = ids.value & ((1 << 128) - 1)
 ids.high = ids.value >> 128"#;
 
-pub(crate) const SQRT: &str = r#"from starkware.python.math_utils import isqrt
+pub(crate) const SQRT: &'static str = r#"from starkware.python.math_utils import isqrt
 value = ids.value % PRIME
 assert value < 2 ** 250, f"value={value} is outside of the range [0, 2**250)."
 assert 2 ** 250 < PRIME
 ids.root = isqrt(value)"#;
 
-pub(crate) const UNSIGNED_DIV_REM: &str = r#"from starkware.cairo.common.math_utils import assert_integer
+pub(crate) const UNSIGNED_DIV_REM: &'static str = r#"from starkware.cairo.common.math_utils import assert_integer
 assert_integer(ids.div)
 assert 0 < ids.div <= PRIME // range_check_builtin.bound, \
     f'div={hex(ids.div)} is out of the valid range.'
 ids.q, ids.r = divmod(ids.value, ids.div)"#;
 
-pub(crate) const SIGNED_DIV_REM: &str = r#"from starkware.cairo.common.math_utils import as_int, assert_integer
+pub(crate) const SIGNED_DIV_REM: &'static str = r#"from starkware.cairo.common.math_utils import as_int, assert_integer
 
 assert_integer(ids.div)
 assert 0 < ids.div <= PRIME // range_check_builtin.bound, \
@@ -110,7 +111,7 @@ assert -ids.bound <= q < ids.bound, \
 
 ids.biased_q = q + ids.bound"#;
 
-pub(crate) const FIND_ELEMENT: &str = r#"array_ptr = ids.array_ptr
+pub(crate) const FIND_ELEMENT: &'static str = r#"array_ptr = ids.array_ptr
 elm_size = ids.elm_size
 assert isinstance(elm_size, int) and elm_size > 0, \
     f'Invalid value for elm_size. Got: {elm_size}.'
@@ -140,7 +141,7 @@ else:
     else:
         raise ValueError(f'Key {key} was not found.')"#;
 
-pub(crate) const SEARCH_SORTED_LOWER: &str = r#"array_ptr = ids.array_ptr
+pub(crate) const SEARCH_SORTED_LOWER: &'static str = r#"array_ptr = ids.array_ptr
 elm_size = ids.elm_size
 assert isinstance(elm_size, int) and elm_size > 0, \
     f'Invalid value for elm_size. Got: {elm_size}.'
@@ -160,7 +161,7 @@ for i in range(n_elms):
 else:
     ids.index = n_elms"#;
 
-pub(crate) const SET_ADD: &str = r#"assert ids.elm_size > 0
+pub(crate) const SET_ADD: &'static str = r#"assert ids.elm_size > 0
 assert ids.set_ptr <= ids.set_end_ptr
 elm_list = memory.get_range(ids.elm_ptr, ids.elm_size)
 for i in range(0, ids.set_end_ptr - ids.set_ptr, ids.elm_size):
@@ -171,29 +172,29 @@ for i in range(0, ids.set_end_ptr - ids.set_ptr, ids.elm_size):
 else:
     ids.is_elm_in_set = 0"#;
 
-pub(crate) const DEFAULT_DICT_NEW: &str = r#"if '__dict_manager' not in globals():
+pub(crate) const DEFAULT_DICT_NEW: &'static str = r#"if '__dict_manager' not in globals():
     from starkware.cairo.common.dict import DictManager
     __dict_manager = DictManager()
 
 memory[ap] = __dict_manager.new_default_dict(segments, ids.default_value)"#;
 
-pub(crate) const DICT_NEW: &str = r#"if '__dict_manager' not in globals():
+pub(crate) const DICT_NEW: &'static str = r#"if '__dict_manager' not in globals():
     from starkware.cairo.common.dict import DictManager
     __dict_manager = DictManager()
 
 memory[ap] = __dict_manager.new_dict(segments, initial_dict)
 del initial_dict"#;
 
-pub(crate) const DICT_READ: &str = r#"dict_tracker = __dict_manager.get_tracker(ids.dict_ptr)
+pub(crate) const DICT_READ: &'static str = r#"dict_tracker = __dict_manager.get_tracker(ids.dict_ptr)
 dict_tracker.current_ptr += ids.DictAccess.SIZE
 ids.value = dict_tracker.data[ids.key]"#;
 
-pub(crate) const DICT_WRITE: &str = r#"dict_tracker = __dict_manager.get_tracker(ids.dict_ptr)
+pub(crate) const DICT_WRITE: &'static str = r#"dict_tracker = __dict_manager.get_tracker(ids.dict_ptr)
 dict_tracker.current_ptr += ids.DictAccess.SIZE
 ids.dict_ptr.prev_value = dict_tracker.data[ids.key]
 dict_tracker.data[ids.key] = ids.new_value"#;
 
-pub(crate) const DICT_UPDATE: &str = r#"# Verify dict pointer and prev value.
+pub(crate) const DICT_UPDATE: &'static str = r#"# Verify dict pointer and prev value.
 dict_tracker = __dict_manager.get_tracker(ids.dict_ptr)
 current_value = dict_tracker.data[ids.key]
 assert current_value == ids.prev_value, \
@@ -203,7 +204,7 @@ assert current_value == ids.prev_value, \
 dict_tracker.data[ids.key] = ids.new_value
 dict_tracker.current_ptr += ids.DictAccess.SIZE"#;
 
-pub(crate) const SQUASH_DICT: &str = r#"dict_access_size = ids.DictAccess.SIZE
+pub(crate) const SQUASH_DICT: &'static str = r#"dict_access_size = ids.DictAccess.SIZE
 address = ids.dict_accesses.address_
 assert ids.ptr_diff % dict_access_size == 0, \
     'Accesses array size must be divisible by DictAccess.SIZE'
@@ -223,26 +224,27 @@ keys = sorted(access_indices.keys(), reverse=True)
 ids.big_keys = 1 if keys[0] >= range_check_builtin.bound else 0
 ids.first_key = key = keys.pop()"#;
 
-pub(crate) const SQUASH_DICT_INNER_SKIP_LOOP: &str =
+pub(crate) const SQUASH_DICT_INNER_SKIP_LOOP: &'static str =
     "ids.should_skip_loop = 0 if current_access_indices else 1";
-pub(crate) const SQUASH_DICT_INNER_FIRST_ITERATION: &str = r#"current_access_indices = sorted(access_indices[key])[::-1]
+pub(crate) const SQUASH_DICT_INNER_FIRST_ITERATION: &'static str = r#"current_access_indices = sorted(access_indices[key])[::-1]
 current_access_index = current_access_indices.pop()
 memory[ids.range_check_ptr] = current_access_index"#;
 
-pub(crate) const SQUASH_DICT_INNER_CHECK_ACCESS_INDEX: &str = r#"new_access_index = current_access_indices.pop()
+pub(crate) const SQUASH_DICT_INNER_CHECK_ACCESS_INDEX: &'static str = r#"new_access_index = current_access_indices.pop()
 ids.loop_temps.index_delta_minus1 = new_access_index - current_access_index - 1
 current_access_index = new_access_index"#;
 
-pub(crate) const SQUASH_DICT_INNER_CONTINUE_LOOP: &str =
+pub(crate) const SQUASH_DICT_INNER_CONTINUE_LOOP: &'static str =
     "ids.loop_temps.should_continue = 1 if current_access_indices else 0";
-pub(crate) const SQUASH_DICT_INNER_ASSERT_LEN_KEYS: &str = "assert len(keys) == 0";
-pub(crate) const SQUASH_DICT_INNER_LEN_ASSERT: &str = "assert len(current_access_indices) == 0";
-pub(crate) const SQUASH_DICT_INNER_USED_ACCESSES_ASSERT: &str =
+pub(crate) const SQUASH_DICT_INNER_ASSERT_LEN_KEYS: &'static str = "assert len(keys) == 0";
+pub(crate) const SQUASH_DICT_INNER_LEN_ASSERT: &'static str =
+    "assert len(current_access_indices) == 0";
+pub(crate) const SQUASH_DICT_INNER_USED_ACCESSES_ASSERT: &'static str =
     "assert ids.n_used_accesses == len(access_indices[key])";
-pub(crate) const SQUASH_DICT_INNER_NEXT_KEY: &str = r#"assert len(keys) > 0, 'No keys left but remaining_accesses > 0.'
+pub(crate) const SQUASH_DICT_INNER_NEXT_KEY: &'static str = r#"assert len(keys) > 0, 'No keys left but remaining_accesses > 0.'
 ids.next_key = key = keys.pop()"#;
 
-pub(crate) const DICT_SQUASH_COPY_DICT: &str = r#"# Prepare arguments for dict_new. In particular, the same dictionary values should be copied
+pub(crate) const DICT_SQUASH_COPY_DICT: &'static str = r#"# Prepare arguments for dict_new. In particular, the same dictionary values should be copied
 # to the new (squashed) dictionary.
 vm_enter_scope({
     # Make __dict_manager accessible.
@@ -251,26 +253,26 @@ vm_enter_scope({
     'initial_dict': dict(__dict_manager.get_dict(ids.dict_accesses_end)),
 })"#;
 
-pub(crate) const DICT_SQUASH_UPDATE_PTR: &str = r#"# Update the DictTracker's current_ptr to point to the end of the squashed dict.
+pub(crate) const DICT_SQUASH_UPDATE_PTR: &'static str = r#"# Update the DictTracker's current_ptr to point to the end of the squashed dict.
 __dict_manager.get_tracker(ids.squashed_dict_start).current_ptr = \
     ids.squashed_dict_end.address_"#;
 
-pub(crate) const UINT256_ADD: &str = r#"sum_low = ids.a.low + ids.b.low
+pub(crate) const UINT256_ADD: &'static str = r#"sum_low = ids.a.low + ids.b.low
 ids.carry_low = 1 if sum_low >= ids.SHIFT else 0
 sum_high = ids.a.high + ids.b.high + ids.carry_low
 ids.carry_high = 1 if sum_high >= ids.SHIFT else 0"#;
 
-pub(crate) const UINT256_SQRT: &str = r#"from starkware.python.math_utils import isqrt
+pub(crate) const UINT256_SQRT: &'static str = r#"from starkware.python.math_utils import isqrt
 n = (ids.n.high << 128) + ids.n.low
 root = isqrt(n)
 assert 0 <= root < 2 ** 128
 ids.root.low = root
 ids.root.high = 0"#;
 
-pub(crate) const UINT256_SIGNED_NN: &str =
+pub(crate) const UINT256_SIGNED_NN: &'static str =
     "memory[ap] = 1 if 0 <= (ids.a.high % PRIME) < 2 ** 127 else 0";
 
-pub(crate) const UINT256_UNSIGNED_DIV_REM: &str = r#"a = (ids.a.high << 128) + ids.a.low
+pub(crate) const UINT256_UNSIGNED_DIV_REM: &'static str = r#"a = (ids.a.high << 128) + ids.a.low
 div = (ids.div.high << 128) + ids.div.low
 quotient, remainder = divmod(a, div)
 
@@ -279,9 +281,9 @@ ids.quotient.high = quotient >> 128
 ids.remainder.low = remainder & ((1 << 128) - 1)
 ids.remainder.high = remainder >> 128"#;
 
-pub(crate) const USORT_ENTER_SCOPE: &str =
+pub(crate) const USORT_ENTER_SCOPE: &'static str =
     "vm_enter_scope(dict(__usort_max_size = globals().get('__usort_max_size')))";
-pub(crate) const USORT_BODY: &str = r#"from collections import defaultdict
+pub(crate) const USORT_BODY: &'static str = r#"from collections import defaultdict
 
 input_ptr = ids.input
 input_len = int(ids.input_len)
@@ -301,18 +303,18 @@ ids.output_len = len(output)
 ids.output = segments.gen_arg(output)
 ids.multiplicities = segments.gen_arg([len(positions_dict[k]) for k in output])"#;
 
-pub(crate) const USORT_VERIFY: &str = r#"last_pos = 0
+pub(crate) const USORT_VERIFY: &'static str = r#"last_pos = 0
 positions = positions_dict[ids.value][::-1]"#;
 
-pub(crate) const USORT_VERIFY_MULTIPLICITY_ASSERT: &str = "assert len(positions) == 0";
-pub(crate) const USORT_VERIFY_MULTIPLICITY_BODY: &str = r#"current_pos = positions.pop()
+pub(crate) const USORT_VERIFY_MULTIPLICITY_ASSERT: &'static str = "assert len(positions) == 0";
+pub(crate) const USORT_VERIFY_MULTIPLICITY_BODY: &'static str = r#"current_pos = positions.pop()
 ids.next_item_index = current_pos - last_pos
 last_pos = current_pos + 1"#;
 
-pub(crate) const BLAKE2S_COMPUTE: &str = r#"from starkware.cairo.common.cairo_blake2s.blake2s_utils import compute_blake2s_func
+pub(crate) const BLAKE2S_COMPUTE: &'static str = r#"from starkware.cairo.common.cairo_blake2s.blake2s_utils import compute_blake2s_func
 compute_blake2s_func(segments=segments, output_ptr=ids.output)"#;
 
-pub(crate) const BLAKE2S_FINALIZE: &str = r#"# Add dummy pairs of input and output.
+pub(crate) const BLAKE2S_FINALIZE: &'static str = r#"# Add dummy pairs of input and output.
 from starkware.cairo.common.cairo_blake2s.blake2s_utils import IV, blake2s_compress
 
 _n_packed_instances = int(ids.N_PACKED_INSTANCES)
@@ -333,31 +335,31 @@ output = blake2s_compress(
 padding = (modified_iv + message + [0, 0xffffffff] + output) * (_n_packed_instances - 1)
 segments.write_arg(ids.blake2s_ptr_end, padding)"#;
 
-pub(crate) const BLAKE2S_ADD_UINT256: &str = r#"B = 32
+pub(crate) const BLAKE2S_ADD_UINT256: &'static str = r#"B = 32
 MASK = 2 ** 32 - 1
 segments.write_arg(ids.data, [(ids.low >> (B * i)) & MASK for i in range(4)])
 segments.write_arg(ids.data + 4, [(ids.high >> (B * i)) & MASK for i in range(4)]"#;
 
-pub(crate) const BLAKE2S_ADD_UINT256_BIGEND: &str = r#"B = 32
+pub(crate) const BLAKE2S_ADD_UINT256_BIGEND: &'static str = r#"B = 32
 MASK = 2 ** 32 - 1
 segments.write_arg(ids.data, [(ids.high >> (B * (3 - i))) & MASK for i in range(4)])
 segments.write_arg(ids.data + 4, [(ids.low >> (B * (3 - i))) & MASK for i in range(4)])"#;
 
-pub(crate) const NONDET_BIGINT3: &str = r#"from starkware.cairo.common.cairo_secp.secp_utils import split
+pub(crate) const NONDET_BIGINT3: &'static str = r#"from starkware.cairo.common.cairo_secp.secp_utils import split
 
 segments.write_arg(ids.res.address_, split(value))"#;
 
-pub(crate) const VERIFY_ZERO: &str = r#"from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack
+pub(crate) const VERIFY_ZERO: &'static str = r#"from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack
 
 q, r = divmod(pack(ids.val, PRIME), SECP_P)
 assert r == 0, f"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}."
 ids.q = q % PRIME"#;
 
-pub(crate) const REDUCE: &str = r#"from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack
+pub(crate) const REDUCE: &'static str = r#"from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack
 
 value = pack(ids.x, PRIME) % SECP_P"#;
 
-pub(crate) const UNSAFE_KECCAK: &str = r#"from eth_hash.auto import keccak
+pub(crate) const UNSAFE_KECCAK: &'static str = r#"from eth_hash.auto import keccak
 
 data, length = ids.data, ids.length
 
@@ -377,7 +379,7 @@ hashed = keccak(keccak_input)
 ids.high = int.from_bytes(hashed[:16], 'big')
 ids.low = int.from_bytes(hashed[16:32], 'big')"#;
 
-pub(crate) const UNSAFE_KECCAK_FINALIZE: &str = r#"from eth_hash.auto import keccak
+pub(crate) const UNSAFE_KECCAK_FINALIZE: &'static str = r#"from eth_hash.auto import keccak
 keccak_input = bytearray()
 n_elms = ids.keccak_state.end_ptr - ids.keccak_state.start_ptr
 for word in memory.get_range(ids.keccak_state.start_ptr, n_elms):

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -1584,7 +1584,7 @@ pub fn memcpy_enter_scope(
     ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
-    let len_addr = get_address_from_var_name("len", &ids, vm, hint_ap_tracking)?;
+    let len_addr = get_address_from_var_name("len", ids, vm, hint_ap_tracking)?;
 
     match vm.memory.get(&len_addr) {
         Ok(Some(maybe_rel_len)) => {
@@ -1615,7 +1615,7 @@ pub fn memcpy_continue_copying(
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let continue_copying_addr =
-        get_address_from_var_name("continue_copying", &ids, vm, hint_ap_tracking)?;
+        get_address_from_var_name("continue_copying", ids, vm, hint_ap_tracking)?;
 
     // get `n` variable from vm scope
     let n = match vm.exec_scopes.get_local_variables() {
@@ -1805,7 +1805,10 @@ pub fn assert_lt_felt(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vm::hints::execute_hint::BuiltinHintExecutor;
     use num_bigint::Sign;
+
+    static HINT_EXECUTOR: BuiltinHintExecutor = BuiltinHintExecutor {};
 
     #[test]
     fn get_integer_from_var_name_valid() {
@@ -1813,6 +1816,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         // initialize memory segments
         vm.segments.add(&mut vm.memory, None);
@@ -1859,6 +1863,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         // initialize memory segments
         vm.segments.add(&mut vm.memory, None);
@@ -1907,6 +1912,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         // initialize memory segments
         vm.segments.add(&mut vm.memory, None);
@@ -1931,6 +1937,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
         // initialize memory segments
         vm.segments.add(&mut vm.memory, None);

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -383,7 +383,7 @@ pub fn add_segment(vm: &mut VirtualMachine) -> Result<(), VirtualMachineError> {
 //Implements hint: memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1
 pub fn is_nn(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
@@ -392,7 +392,7 @@ pub fn is_nn(
     } else {
         return Err(VirtualMachineError::IncorrectIds(
             vec![String::from("a")],
-            ids.into_keys().collect(),
+            ids.keys().map(Clone::clone).collect(),
         ));
     };
     //Check that each reference id corresponds to a value in the reference manager
@@ -449,7 +449,7 @@ pub fn is_nn(
 //Implements hint: memory[ap] = 0 if 0 <= ((-ids.a - 1) % PRIME) < range_check_builtin.bound else 1
 pub fn is_nn_out_of_range(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
@@ -458,7 +458,7 @@ pub fn is_nn_out_of_range(
     } else {
         return Err(VirtualMachineError::IncorrectIds(
             vec![String::from("a")],
-            ids.into_keys().collect(),
+            ids.keys().map(Clone::clone).collect(),
         ));
     };
     //Check that each reference id corresponds to a value in the reference manager
@@ -522,7 +522,7 @@ pub fn is_nn_out_of_range(
 //            a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)
 pub fn assert_le_felt(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
@@ -540,7 +540,7 @@ pub fn assert_le_felt(
                     String::from("b"),
                     String::from("small_inputs"),
                 ],
-                ids.into_keys().collect(),
+                ids.keys().map(Clone::clone).collect(),
             ));
         };
     //Check that each reference id corresponds to a value in the reference manager
@@ -621,7 +621,7 @@ pub fn assert_le_felt(
 //    memory[ap] = 0 if (ids.a % PRIME) <= (ids.b % PRIME) else 1
 pub fn is_le_felt(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
@@ -632,7 +632,7 @@ pub fn is_le_felt(
     } else {
         return Err(VirtualMachineError::IncorrectIds(
             vec![String::from("a"), String::from("b")],
-            ids.into_keys().collect(),
+            ids.keys().map(Clone::clone).collect(),
         ));
     };
     //Check that each reference id corresponds to a value in the reference manager
@@ -695,7 +695,7 @@ pub fn is_le_felt(
 //        assert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'
 pub fn assert_not_equal(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
@@ -706,7 +706,7 @@ pub fn assert_not_equal(
     } else {
         return Err(VirtualMachineError::IncorrectIds(
             vec![String::from("a"), String::from("b")],
-            ids.into_keys().collect(),
+            ids.keys().map(Clone::clone).collect(),
         ));
     };
     //Check that each reference id corresponds to a value in the reference manager
@@ -759,7 +759,7 @@ pub fn assert_not_equal(
 // %}
 pub fn assert_nn(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for 'a' variable used by the hint
@@ -768,7 +768,7 @@ pub fn assert_nn(
     } else {
         return Err(VirtualMachineError::IncorrectIds(
             vec![String::from("a")],
-            ids.into_keys().collect(),
+            ids.keys().map(Clone::clone).collect(),
         ));
     };
     //Check that 'a' reference id corresponds to a value in the reference manager
@@ -824,7 +824,7 @@ pub fn assert_nn(
 // %}
 pub fn assert_not_zero(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let value_ref = if let Some(value_ref) = ids.get(&String::from("value")) {
@@ -832,7 +832,7 @@ pub fn assert_not_zero(
     } else {
         return Err(VirtualMachineError::IncorrectIds(
             vec![String::from("value")],
-            ids.into_keys().collect(),
+            ids.keys().map(Clone::clone).collect(),
         ));
     };
     //Check that each reference id corresponds to a value in the reference manager
@@ -870,7 +870,7 @@ pub fn assert_not_zero(
 //Implements hint: assert ids.value == 0, 'split_int(): value is out of range.'
 pub fn split_int_assert_range(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
@@ -879,7 +879,7 @@ pub fn split_int_assert_range(
     } else {
         return Err(VirtualMachineError::IncorrectIds(
             vec![String::from("value")],
-            ids.into_keys().collect(),
+            ids.keys().map(Clone::clone).collect(),
         ));
     };
     //Check that each reference id corresponds to a value in the reference manager
@@ -918,7 +918,7 @@ pub fn split_int_assert_range(
 //        assert res < ids.bound, f'split_int(): Limb {res} is out of range.'
 pub fn split_int(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
@@ -938,7 +938,7 @@ pub fn split_int(
                     String::from("base"),
                     String::from("bound"),
                 ],
-                ids.into_keys().collect(),
+                ids.keys().map(Clone::clone).collect(),
             ));
         };
     //Check that the ids are in memory (except for small_inputs which is local, and should contain None)
@@ -1022,7 +1022,7 @@ pub fn split_int(
 //    value=ids.value, prime=PRIME, rc_bound=range_check_builtin.bound) else 0
 pub fn is_positive(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
@@ -1034,7 +1034,7 @@ pub fn is_positive(
     } else {
         return Err(VirtualMachineError::IncorrectIds(
             vec![String::from("value"), String::from("is_positive")],
-            ids.into_keys().collect(),
+            ids.keys().map(Clone::clone).collect(),
         ));
     };
     //Check that each reference id corresponds to a value in the reference manager
@@ -1114,7 +1114,7 @@ pub fn is_positive(
 // %}
 pub fn split_felt(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for the variables used by the hint
@@ -1131,7 +1131,7 @@ pub fn split_felt(
                 String::from("low"),
                 String::from("value"),
             ],
-            ids.into_keys().collect(),
+            ids.keys().map(Clone::clone).collect(),
         ));
     };
 
@@ -1196,7 +1196,7 @@ pub fn split_felt(
 //        ids.root = isqrt(value)
 pub fn sqrt(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
@@ -1208,7 +1208,7 @@ pub fn sqrt(
     } else {
         return Err(VirtualMachineError::IncorrectIds(
             vec![String::from("value"), String::from("root")],
-            ids.into_keys().collect(),
+            ids.keys().map(Clone::clone).collect(),
         ));
     };
     //Check that each reference id corresponds to a value in the reference manager
@@ -1257,7 +1257,7 @@ pub fn sqrt(
 
 pub fn signed_div_rem(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
@@ -1294,7 +1294,7 @@ pub fn signed_div_rem(
                 String::from("value"),
                 String::from("bound"),
             ],
-            ids.into_keys().collect(),
+            ids.keys().map(Clone::clone).collect(),
         ));
     };
     //Check that each reference id corresponds to a value in the reference manager
@@ -1458,7 +1458,7 @@ ids.q, ids.r = divmod(ids.value, ids.div)
 */
 pub fn unsigned_div_rem(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
@@ -1478,7 +1478,7 @@ pub fn unsigned_div_rem(
                     String::from("div"),
                     String::from("value"),
                 ],
-                ids.into_keys().collect(),
+                ids.keys().map(Clone::clone).collect(),
             ));
         };
     //Check that each reference id corresponds to a value in the reference manager
@@ -1581,7 +1581,7 @@ pub fn exit_scope(vm: &mut VirtualMachine) -> Result<(), VirtualMachineError> {
 //  %{ vm_enter_scope({'n': ids.len}) %}
 pub fn memcpy_enter_scope(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let len_addr = get_address_from_var_name("len", &ids, vm, hint_ap_tracking)?;
@@ -1611,7 +1611,7 @@ pub fn memcpy_enter_scope(
 // %}
 pub fn memcpy_continue_copying(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let continue_copying_addr =
@@ -1660,7 +1660,7 @@ pub fn memcpy_continue_copying(
 //        ids.high, ids.low = divmod(ids.value, ids.SHIFT)
 pub fn assert_250_bit(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Declare constant values
@@ -1680,7 +1680,7 @@ pub fn assert_250_bit(
                 String::from("high"),
                 String::from("low"),
             ],
-            ids.into_keys().collect(),
+            ids.keys().map(Clone::clone).collect(),
         ));
     };
     //Check that each reference id corresponds to a value in the reference manager
@@ -1754,7 +1754,7 @@ Implements hint:
 */
 pub fn assert_lt_felt(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
@@ -1765,7 +1765,7 @@ pub fn assert_lt_felt(
     } else {
         return Err(VirtualMachineError::IncorrectIds(
             vec![String::from("a"), String::from("b")],
-            ids.into_keys().collect(),
+            ids.keys().map(Clone::clone).collect(),
         ));
     };
     //Check that each reference id corresponds to a value in the reference manager

--- a/src/vm/hints/keccak_utils.rs
+++ b/src/vm/hints/keccak_utils.rs
@@ -38,10 +38,10 @@ use std::{cmp, collections::HashMap, ops::Shl};
 */
 pub fn unsafe_keccak(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
-    let length = get_integer_from_var_name("length", &ids, vm, hint_ap_tracking)?.clone();
+    let length = get_integer_from_var_name("length", ids, vm, hint_ap_tracking)?.clone();
 
     if let Some(keccak_max_size) = get_int_from_scope(vm, "__keccak_max_size") {
         if length > keccak_max_size {
@@ -50,10 +50,10 @@ pub fn unsafe_keccak(
     }
 
     // `data` is an array, represented by a pointer to the first element.
-    let data = get_ptr_from_var_name("data", &ids, vm, hint_ap_tracking)?;
+    let data = get_ptr_from_var_name("data", ids, vm, hint_ap_tracking)?;
 
-    let high_addr = get_relocatable_from_var_name("high", &ids, vm, hint_ap_tracking)?;
-    let low_addr = get_relocatable_from_var_name("low", &ids, vm, hint_ap_tracking)?;
+    let high_addr = get_relocatable_from_var_name("high", ids, vm, hint_ap_tracking)?;
+    let low_addr = get_relocatable_from_var_name("low", ids, vm, hint_ap_tracking)?;
 
     // transform to u64 to make ranges cleaner in the for loop below
     let u64_length = length

--- a/src/vm/hints/memset_utils.rs
+++ b/src/vm/hints/memset_utils.rs
@@ -17,7 +17,7 @@ pub fn memset_enter_scope(
     ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
-    let n_addr = get_address_from_var_name("n", &ids, vm, hint_ap_tracking)?;
+    let n_addr = get_address_from_var_name("n", ids, vm, hint_ap_tracking)?;
 
     match vm.memory.get(&n_addr) {
         Ok(Some(maybe_rel_n)) => {
@@ -48,8 +48,7 @@ pub fn memset_continue_loop(
     ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
-    let continue_loop_addr =
-        get_address_from_var_name("continue_loop", &ids, vm, hint_ap_tracking)?;
+    let continue_loop_addr = get_address_from_var_name("continue_loop", ids, vm, hint_ap_tracking)?;
 
     // get `n` variable from vm scope
 
@@ -92,10 +91,12 @@ mod tests {
         types::instruction::Register,
         vm::{
             errors::memory_errors::MemoryError,
-            hints::execute_hint::{execute_hint, HintReference},
+            hints::execute_hint::{BuiltinHintExecutor, HintReference},
         },
     };
     use num_bigint::Sign;
+
+    static HINT_EXECUTOR: BuiltinHintExecutor = BuiltinHintExecutor {};
 
     #[test]
     fn memset_enter_scope_valid() {
@@ -104,6 +105,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
 
         // initialize memory segments
@@ -136,7 +138,10 @@ mod tests {
             },
         )]);
 
-        assert!(execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()).is_ok());
+        assert!(vm
+            .hint_executor
+            .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
+            .is_ok());
     }
 
     #[test]
@@ -146,6 +151,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
 
         // initialize memory segments
@@ -180,7 +186,8 @@ mod tests {
         )]);
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((0, 1))
             ))
@@ -194,6 +201,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
 
         // initialize memory segments
@@ -231,7 +239,10 @@ mod tests {
             },
         )]);
 
-        assert!(execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()).is_ok());
+        assert!(vm
+            .hint_executor
+            .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
+            .is_ok());
 
         // assert ids.continue_loop = 0
         assert_eq!(
@@ -247,6 +258,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
 
         // initialize memory segments
@@ -284,7 +296,10 @@ mod tests {
             },
         )]);
 
-        assert!(execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()).is_ok());
+        assert!(vm
+            .hint_executor
+            .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new())
+            .is_ok());
 
         // assert ids.continue_loop = 1
         assert_eq!(
@@ -300,6 +315,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
 
         // initialize memory segments
@@ -337,7 +353,8 @@ mod tests {
         )]);
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::VariableNotInScopeError(
                 "n".to_string()
             ))
@@ -351,6 +368,7 @@ mod tests {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
             false,
+            &HINT_EXECUTOR,
         );
 
         // initialize memory segments
@@ -389,7 +407,8 @@ mod tests {
         )]);
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((0, 1)),

--- a/src/vm/hints/memset_utils.rs
+++ b/src/vm/hints/memset_utils.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 //  %{ vm_enter_scope({'n': ids.n}) %}
 pub fn memset_enter_scope(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let n_addr = get_address_from_var_name("n", &ids, vm, hint_ap_tracking)?;
@@ -45,7 +45,7 @@ pub fn memset_enter_scope(
 */
 pub fn memset_continue_loop(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let continue_loop_addr =
@@ -99,7 +99,7 @@ mod tests {
 
     #[test]
     fn memset_enter_scope_valid() {
-        let hint_code = "vm_enter_scope({'n': ids.n})".as_bytes();
+        let hint_code = "vm_enter_scope({'n': ids.n})";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -136,12 +136,12 @@ mod tests {
             },
         )]);
 
-        assert!(execute_hint(&mut vm, hint_code, ids, &ApTracking::new()).is_ok());
+        assert!(execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()).is_ok());
     }
 
     #[test]
     fn memset_enter_scope_invalid() {
-        let hint_code = "vm_enter_scope({'n': ids.n})".as_bytes();
+        let hint_code = "vm_enter_scope({'n': ids.n})";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -180,7 +180,7 @@ mod tests {
         )]);
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((0, 1))
             ))
@@ -189,7 +189,7 @@ mod tests {
 
     #[test]
     fn memset_continue_loop_valid_continue_loop_equal_1() {
-        let hint_code = "n -= 1\nids.continue_loop = 1 if n > 0 else 0".as_bytes();
+        let hint_code = "n -= 1\nids.continue_loop = 1 if n > 0 else 0";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -231,7 +231,7 @@ mod tests {
             },
         )]);
 
-        assert!(execute_hint(&mut vm, hint_code, ids, &ApTracking::new()).is_ok());
+        assert!(execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()).is_ok());
 
         // assert ids.continue_loop = 0
         assert_eq!(
@@ -242,7 +242,7 @@ mod tests {
 
     #[test]
     fn memset_continue_loop_valid_continue_loop_equal_5() {
-        let hint_code = "n -= 1\nids.continue_loop = 1 if n > 0 else 0".as_bytes();
+        let hint_code = "n -= 1\nids.continue_loop = 1 if n > 0 else 0";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -284,7 +284,7 @@ mod tests {
             },
         )]);
 
-        assert!(execute_hint(&mut vm, hint_code, ids, &ApTracking::new()).is_ok());
+        assert!(execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()).is_ok());
 
         // assert ids.continue_loop = 1
         assert_eq!(
@@ -295,7 +295,7 @@ mod tests {
 
     #[test]
     fn memset_continue_loop_variable_not_in_scope_error() {
-        let hint_code = "n -= 1\nids.continue_loop = 1 if n > 0 else 0".as_bytes();
+        let hint_code = "n -= 1\nids.continue_loop = 1 if n > 0 else 0";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -337,7 +337,7 @@ mod tests {
         )]);
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::VariableNotInScopeError(
                 "n".to_string()
             ))
@@ -346,7 +346,7 @@ mod tests {
 
     #[test]
     fn memset_continue_loop_insert_error() {
-        let hint_code = "n -= 1\nids.continue_loop = 1 if n > 0 else 0".as_bytes();
+        let hint_code = "n -= 1\nids.continue_loop = 1 if n > 0 else 0";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             Vec::new(),
@@ -389,7 +389,7 @@ mod tests {
         )]);
 
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((0, 1)),

--- a/src/vm/hints/mod.rs
+++ b/src/vm/hints/mod.rs
@@ -4,6 +4,7 @@ pub mod dict_hint_utils;
 pub mod dict_manager;
 pub mod execute_hint;
 pub mod find_element_hint;
+pub mod hint_code;
 pub mod hint_utils;
 pub mod keccak_utils;
 pub mod memset_utils;

--- a/src/vm/hints/pow_utils.rs
+++ b/src/vm/hints/pow_utils.rs
@@ -82,12 +82,14 @@ mod tests {
     use crate::types::instruction::Register;
     use crate::types::relocatable::MaybeRelocatable;
     use crate::vm::errors::memory_errors::MemoryError;
-    use crate::vm::hints::execute_hint::{execute_hint, HintReference};
+    use crate::vm::hints::execute_hint::{BuiltinHintExecutor, HintReference};
     use crate::{bigint, vm::runners::builtin_runner::RangeCheckBuiltinRunner};
     use num_bigint::{BigInt, Sign};
     use num_traits::FromPrimitive;
 
     use super::*;
+
+    static HINT_EXECUTOR: BuiltinHintExecutor = BuiltinHintExecutor {};
 
     #[test]
     fn run_pow_ok() {
@@ -99,6 +101,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -158,7 +161,11 @@ mod tests {
         };
 
         //Execute the hint
-        assert_eq!(execute_hint(&mut vm, hint_code, &ids, &ap_tracking), Ok(()));
+        assert_eq!(
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ap_tracking),
+            Ok(())
+        );
 
         //Check hint memory inserts
         assert_eq!(
@@ -177,6 +184,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -193,7 +201,8 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ap_tracking),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ap_tracking),
             Err(VirtualMachineError::IncorrectIds(
                 vec![String::from("prev_locs"), String::from("locs")],
                 vec![String::from("locs")]
@@ -211,6 +220,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -255,7 +265,8 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ap_tracking),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ap_tracking),
             Err(VirtualMachineError::FailedToGetIds)
         );
     }
@@ -270,6 +281,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -321,7 +333,8 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ap_tracking),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ap_tracking),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((1, 10))
             ))
@@ -338,6 +351,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
@@ -397,7 +411,8 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, &ids, &ap_tracking),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ap_tracking),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((1, 11)),

--- a/src/vm/hints/pow_utils.rs
+++ b/src/vm/hints/pow_utils.rs
@@ -15,7 +15,7 @@ Implements hint:
 */
 pub fn pow(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for the variables used by the hint
@@ -27,7 +27,7 @@ pub fn pow(
     } else {
         return Err(VirtualMachineError::IncorrectIds(
             vec![String::from("prev_locs"), String::from("locs")],
-            ids.into_keys().collect(),
+            ids.keys().map(Clone::clone).collect(),
         ));
     };
 
@@ -91,7 +91,7 @@ mod tests {
 
     #[test]
     fn run_pow_ok() {
-        let hint_code = "ids.locs.bit = (ids.prev_locs.exp % PRIME) & 1".as_bytes();
+        let hint_code = "ids.locs.bit = (ids.prev_locs.exp % PRIME) & 1";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -158,7 +158,7 @@ mod tests {
         };
 
         //Execute the hint
-        assert_eq!(execute_hint(&mut vm, hint_code, ids, &ap_tracking), Ok(()));
+        assert_eq!(execute_hint(&mut vm, hint_code, &ids, &ap_tracking), Ok(()));
 
         //Check hint memory inserts
         assert_eq!(
@@ -169,7 +169,7 @@ mod tests {
 
     #[test]
     fn run_pow_incorrect_ids() {
-        let hint_code = "ids.locs.bit = (ids.prev_locs.exp % PRIME) & 1".as_bytes();
+        let hint_code = "ids.locs.bit = (ids.prev_locs.exp % PRIME) & 1";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -193,7 +193,7 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ap_tracking),
+            execute_hint(&mut vm, hint_code, &ids, &ap_tracking),
             Err(VirtualMachineError::IncorrectIds(
                 vec![String::from("prev_locs"), String::from("locs")],
                 vec![String::from("locs")]
@@ -203,7 +203,7 @@ mod tests {
 
     #[test]
     fn run_pow_incorrect_references() {
-        let hint_code = "ids.locs.bit = (ids.prev_locs.exp % PRIME) & 1".as_bytes();
+        let hint_code = "ids.locs.bit = (ids.prev_locs.exp % PRIME) & 1";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -255,14 +255,14 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ap_tracking),
+            execute_hint(&mut vm, hint_code, &ids, &ap_tracking),
             Err(VirtualMachineError::FailedToGetIds)
         );
     }
 
     #[test]
     fn run_pow_prev_locs_exp_is_not_integer() {
-        let hint_code = "ids.locs.bit = (ids.prev_locs.exp % PRIME) & 1".as_bytes();
+        let hint_code = "ids.locs.bit = (ids.prev_locs.exp % PRIME) & 1";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -321,7 +321,7 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ap_tracking),
+            execute_hint(&mut vm, hint_code, &ids, &ap_tracking),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((1, 10))
             ))
@@ -330,7 +330,7 @@ mod tests {
 
     #[test]
     fn run_pow_invalid_memory_insert() {
-        let hint_code = "ids.locs.bit = (ids.prev_locs.exp % PRIME) & 1".as_bytes();
+        let hint_code = "ids.locs.bit = (ids.prev_locs.exp % PRIME) & 1";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -397,7 +397,7 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ap_tracking),
+            execute_hint(&mut vm, hint_code, &ids, &ap_tracking),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((1, 11)),

--- a/src/vm/hints/secp/bigint_utils.rs
+++ b/src/vm/hints/secp/bigint_utils.rs
@@ -20,7 +20,7 @@ pub fn nondet_bigint3(
     ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
-    let res_reloc = get_relocatable_from_var_name("res", ids, vm, hint_ap_tracking)?;
+    let res_reloc = get_relocatable_from_var_name("res", &ids, vm, hint_ap_tracking)?;
 
     // get `value` variable from vm scope
     let value: &BigInt = match vm
@@ -59,7 +59,7 @@ mod tests {
 
     #[test]
     fn run_nondet_bigint3_ok() {
-        let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import split\n\nsegments.write_arg(ids.res.address_, split(value))".as_bytes();
+        let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import split\n\nsegments.write_arg(ids.res.address_, split(value))";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -113,7 +113,7 @@ mod tests {
         };
 
         //Execute the hint
-        assert_eq!(execute_hint(&mut vm, hint_code, ids, &ap_tracking), Ok(()));
+        assert_eq!(execute_hint(&mut vm, hint_code, &ids, &ap_tracking), Ok(()));
 
         //Check hint memory inserts
         assert_eq!(
@@ -138,7 +138,7 @@ mod tests {
 
     #[test]
     fn run_nondet_bigint3_value_not_in_scope() {
-        let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import split\n\nsegments.write_arg(ids.res.address_, split(value))".as_bytes();
+        let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import split\n\nsegments.write_arg(ids.res.address_, split(value))";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -189,7 +189,7 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ap_tracking),
+            execute_hint(&mut vm, hint_code, &ids, &ap_tracking),
             Err(VirtualMachineError::VariableNotInScopeError(
                 "value".to_string()
             ))
@@ -198,7 +198,7 @@ mod tests {
 
     #[test]
     fn run_nondet_bigint3_split_error() {
-        let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import split\n\nsegments.write_arg(ids.res.address_, split(value))".as_bytes();
+        let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import split\n\nsegments.write_arg(ids.res.address_, split(value))";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -248,7 +248,7 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ap_tracking),
+            execute_hint(&mut vm, hint_code, &ids, &ap_tracking),
             Err(VirtualMachineError::SecpSplitNegative(bigint!(-1)))
         );
     }

--- a/src/vm/hints/secp/field_utils.rs
+++ b/src/vm/hints/secp/field_utils.rs
@@ -30,8 +30,8 @@ pub fn verify_zero(
     ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
-    let q_address = get_address_from_var_name("q", ids, vm, hint_ap_tracking)?;
-    let val_reloc = get_relocatable_from_var_name("val", ids, vm, hint_ap_tracking)?;
+    let q_address = get_address_from_var_name("q", &ids, vm, hint_ap_tracking)?;
+    let val_reloc = get_relocatable_from_var_name("val", &ids, vm, hint_ap_tracking)?;
 
     let val_d0 = get_integer_from_relocatable_plus_offset(&val_reloc, 0, vm)?;
     let val_d1 = get_integer_from_relocatable_plus_offset(&val_reloc, 1, vm)?;
@@ -72,7 +72,7 @@ pub fn reduce(
     ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
-    let x_reloc = get_relocatable_from_var_name("x", ids, vm, hint_ap_tracking)?;
+    let x_reloc = get_relocatable_from_var_name("x", &ids, vm, hint_ap_tracking)?;
 
     let x_d0 = get_integer_from_relocatable_plus_offset(&x_reloc, 0, vm)?;
     let x_d1 = get_integer_from_relocatable_plus_offset(&x_reloc, 1, vm)?;
@@ -106,7 +106,7 @@ mod tests {
 
     #[test]
     fn run_verify_zero_ok() {
-        let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nq, r = divmod(pack(ids.val, PRIME), SECP_P)\nassert r == 0, f\"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}.\"\nids.q = q % PRIME".as_bytes();
+        let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nq, r = divmod(pack(ids.val, PRIME), SECP_P)\nassert r == 0, f\"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}.\"\nids.q = q % PRIME";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -193,7 +193,7 @@ mod tests {
             .unwrap();
 
         //Execute the hint
-        assert_eq!(execute_hint(&mut vm, hint_code, ids, &ap_tracking), Ok(()));
+        assert_eq!(execute_hint(&mut vm, hint_code, &ids, &ap_tracking), Ok(()));
 
         //Check hint memory inserts
         //ids.q
@@ -205,7 +205,7 @@ mod tests {
 
     #[test]
     fn run_verify_zero_error() {
-        let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nq, r = divmod(pack(ids.val, PRIME), SECP_P)\nassert r == 0, f\"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}.\"\nids.q = q % PRIME".as_bytes();
+        let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nq, r = divmod(pack(ids.val, PRIME), SECP_P)\nassert r == 0, f\"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}.\"\nids.q = q % PRIME";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -293,7 +293,7 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ap_tracking),
+            execute_hint(&mut vm, hint_code, &ids, &ap_tracking),
             Err(VirtualMachineError::SecpVerifyZero(
                 bigint!(0),
                 bigint!(0),
@@ -304,7 +304,7 @@ mod tests {
 
     #[test]
     fn run_verify_zero_invalid_memory_insert() {
-        let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nq, r = divmod(pack(ids.val, PRIME), SECP_P)\nassert r == 0, f\"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}.\"\nids.q = q % PRIME".as_bytes();
+        let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nq, r = divmod(pack(ids.val, PRIME), SECP_P)\nassert r == 0, f\"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}.\"\nids.q = q % PRIME";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -400,7 +400,7 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ap_tracking),
+            execute_hint(&mut vm, hint_code, &ids, &ap_tracking),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((1, 9)),
@@ -413,7 +413,7 @@ mod tests {
 
     #[test]
     fn run_reduce_ok() {
-        let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nvalue = pack(ids.x, PRIME) % SECP_P".as_bytes();
+        let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nvalue = pack(ids.x, PRIME) % SECP_P";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -481,7 +481,7 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
 
@@ -496,7 +496,7 @@ mod tests {
 
     #[test]
     fn run_reduce_error() {
-        let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nvalue = pack(ids.x, PRIME) % SECP_P".as_bytes();
+        let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nvalue = pack(ids.x, PRIME) % SECP_P";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -548,7 +548,7 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((1, 20))
             ))

--- a/src/vm/hints/set.rs
+++ b/src/vm/hints/set.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 
 pub fn set_add(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let is_elm_in_set_addr =
@@ -121,7 +121,7 @@ mod tests {
     };
     use num_bigint::Sign;
 
-    const HINT_CODE: &[u8] = "assert ids.elm_size > 0\nassert ids.set_ptr <= ids.set_end_ptr\nelm_list = memory.get_range(ids.elm_ptr, ids.elm_size)\nfor i in range(0, ids.set_end_ptr - ids.set_ptr, ids.elm_size):\n    if memory.get_range(ids.set_ptr + i, ids.elm_size) == elm_list:\n        ids.index = i // ids.elm_size\n        ids.is_elm_in_set = 1\n        break\nelse:\n    ids.is_elm_in_set = 0".as_bytes();
+    const HINT_CODE: &str = "assert ids.elm_size > 0\nassert ids.set_ptr <= ids.set_end_ptr\nelm_list = memory.get_range(ids.elm_ptr, ids.elm_size)\nfor i in range(0, ids.set_end_ptr - ids.set_ptr, ids.elm_size):\n    if memory.get_range(ids.set_ptr + i, ids.elm_size) == elm_list:\n        ids.index = i // ids.elm_size\n        ids.is_elm_in_set = 1\n        break\nelse:\n    ids.is_elm_in_set = 0";
 
     fn init_vm_ids(
         set_ptr: Option<&MaybeRelocatable>,
@@ -302,7 +302,7 @@ mod tests {
         let (mut vm, ids) = init_vm_ids(None, None, None, None);
 
         assert_eq!(
-            execute_hint(&mut vm, HINT_CODE, ids, &ApTracking::new()),
+            execute_hint(&mut vm, HINT_CODE, &ids, &ApTracking::new()),
             Ok(())
         );
 
@@ -322,7 +322,7 @@ mod tests {
         );
 
         assert_eq!(
-            execute_hint(&mut vm, HINT_CODE, ids, &ApTracking::new()),
+            execute_hint(&mut vm, HINT_CODE, &ids, &ApTracking::new()),
             Ok(())
         );
 
@@ -342,7 +342,7 @@ mod tests {
         let (mut vm, ids) = init_vm_ids(None, Some(&MaybeRelocatable::from((7, 8))), None, None);
 
         assert_eq!(
-            execute_hint(&mut vm, HINT_CODE, ids, &ApTracking::new()),
+            execute_hint(&mut vm, HINT_CODE, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((7, 8))
             ))
@@ -356,7 +356,7 @@ mod tests {
             init_vm_ids(None, Some(&MaybeRelocatable::Int(int.clone())), None, None);
 
         assert_eq!(
-            execute_hint(&mut vm, HINT_CODE, ids, &ApTracking::new()),
+            execute_hint(&mut vm, HINT_CODE, &ids, &ApTracking::new()),
             Err(VirtualMachineError::BigintToUsizeFail)
         );
     }
@@ -368,7 +368,7 @@ mod tests {
             init_vm_ids(None, Some(&MaybeRelocatable::Int(int.clone())), None, None);
 
         assert_eq!(
-            execute_hint(&mut vm, HINT_CODE, ids, &ApTracking::new()),
+            execute_hint(&mut vm, HINT_CODE, &ids, &ApTracking::new()),
             Err(VirtualMachineError::ValueNotPositive(int))
         );
     }
@@ -377,7 +377,7 @@ mod tests {
         let (mut vm, ids) = init_vm_ids(Some(&MaybeRelocatable::from((1, 3))), None, None, None);
 
         assert_eq!(
-            execute_hint(&mut vm, HINT_CODE, ids, &ApTracking::new()),
+            execute_hint(&mut vm, HINT_CODE, &ids, &ApTracking::new()),
             Err(VirtualMachineError::InvalidSetRange(
                 MaybeRelocatable::from((1, 3)),
                 MaybeRelocatable::from((1, 2)),
@@ -401,7 +401,7 @@ mod tests {
         );
 
         assert_eq!(
-            execute_hint(&mut vm, HINT_CODE, ids, &ApTracking::new()),
+            execute_hint(&mut vm, HINT_CODE, &ids, &ApTracking::new()),
             Err(VirtualMachineError::FailedToGetIds)
         );
     }
@@ -412,7 +412,7 @@ mod tests {
         _ = vm.builtin_runners.pop();
 
         assert_eq!(
-            execute_hint(&mut vm, HINT_CODE, ids, &ApTracking::new()),
+            execute_hint(&mut vm, HINT_CODE, &ids, &ApTracking::new()),
             Err(VirtualMachineError::NoRangeCheckBuiltin)
         );
     }
@@ -427,7 +427,7 @@ mod tests {
         ));
 
         assert_eq!(
-            execute_hint(&mut vm, HINT_CODE, ids, &ApTracking::new()),
+            execute_hint(&mut vm, HINT_CODE, &ids, &ApTracking::new()),
             Err(VirtualMachineError::NoRangeCheckBuiltin)
         );
     }
@@ -446,6 +446,6 @@ mod tests {
             Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
         ));
 
-        assert!(execute_hint(&mut vm, HINT_CODE, ids, &ApTracking::new()).is_ok());
+        assert!(execute_hint(&mut vm, HINT_CODE, &ids, &ApTracking::new()).is_ok());
     }
 }

--- a/src/vm/hints/squash_dict_utils.rs
+++ b/src/vm/hints/squash_dict_utils.rs
@@ -35,7 +35,7 @@ fn get_access_indices(vm: &mut VirtualMachine) -> Option<HashMap<BigInt, Vec<Big
 */
 pub fn squash_dict_inner_first_iteration(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that access_indices and key are in scope
@@ -82,7 +82,7 @@ pub fn squash_dict_inner_first_iteration(
 // Implements Hint: ids.should_skip_loop = 0 if current_access_indices else 1
 pub fn squash_dict_inner_skip_loop(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that current_access_indices is in scope
@@ -114,7 +114,7 @@ pub fn squash_dict_inner_skip_loop(
 */
 pub fn squash_dict_inner_check_access_index(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that current_access_indices and current_access_index are in scope
@@ -158,7 +158,7 @@ pub fn squash_dict_inner_check_access_index(
 // Implements Hint: ids.loop_temps.should_continue = 1 if current_access_indices else 0
 pub fn squash_dict_inner_continue_loop(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that current_access_indices is in scope
@@ -202,7 +202,7 @@ pub fn squash_dict_inner_len_assert(vm: &mut VirtualMachine) -> Result<(), Virtu
 //Implements hint: assert ids.n_used_accesses == len(access_indices[key]
 pub fn squash_dict_inner_used_accesses_assert(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that access_indices and key are in scope
@@ -259,7 +259,7 @@ pub fn squash_dict_inner_assert_len_keys(
 //  ids.next_key = key = keys.pop()
 pub fn squash_dict_inner_next_key(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that current_access_indices is in scope
@@ -303,7 +303,7 @@ pub fn squash_dict_inner_next_key(
 */
 pub fn squash_dict(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Get necessary variables addresses from ids
@@ -410,7 +410,10 @@ mod tests {
     use crate::serde::deserialize_program::ApTracking;
     use crate::types::exec_scope::PyValueType;
     use crate::types::instruction::Register;
-    use crate::vm::hints::execute_hint::{execute_hint, HintReference};
+    use crate::vm::hints::{
+        execute_hint::{execute_hint, HintReference},
+        hint_code,
+    };
     use crate::vm::runners::builtin_runner::RangeCheckBuiltinRunner;
     use num_bigint::Sign;
     use num_traits::FromPrimitive;
@@ -431,7 +434,7 @@ mod tests {
     const SQUASH_DICT: &str ="dict_access_size = ids.DictAccess.SIZE\naddress = ids.dict_accesses.address_\nassert ids.ptr_diff % dict_access_size == 0, \\\n    'Accesses array size must be divisible by DictAccess.SIZE'\nn_accesses = ids.n_accesses\nif '__squash_dict_max_size' in globals():\n    assert n_accesses <= __squash_dict_max_size, \\\n        f'squash_dict() can only be used with n_accesses<={__squash_dict_max_size}. ' \\\n        f'Got: n_accesses={n_accesses}.'\n# A map from key to the list of indices accessing it.\naccess_indices = {}\nfor i in range(n_accesses):\n    key = memory[address + dict_access_size * i]\n    access_indices.setdefault(key, []).append(i)\n# Descending list of keys.\nkeys = sorted(access_indices.keys(), reverse=True)\n# Are the keys used bigger than range_check bound.\nids.big_keys = 1 if keys[0] >= range_check_builtin.bound else 0\nids.first_key = key = keys.pop()";
     #[test]
     fn squash_dict_inner_first_iteration_valid() {
-        let hint_code = SQUASH_DICT_INNER_FIRST_ITERATION.as_bytes();
+        let hint_code = SQUASH_DICT_INNER_FIRST_ITERATION;
         //Prepare scope variables
         let mut access_indices = HashMap::<BigInt, Vec<BigInt>>::new();
         let current_accessed_indices = vec![bigint!(9), bigint!(3), bigint!(10), bigint!(7)];
@@ -476,7 +479,7 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Ok(())
         );
         //Check scope variables
@@ -498,7 +501,7 @@ mod tests {
 
     #[test]
     fn squash_dict_inner_first_iteration_empty_accessed_indices() {
-        let hint_code = SQUASH_DICT_INNER_FIRST_ITERATION.as_bytes();
+        let hint_code = SQUASH_DICT_INNER_FIRST_ITERATION;
         //Prepare scope variables
         let mut access_indices = HashMap::<BigInt, Vec<BigInt>>::new();
         //Leave current_accessed_indices empty
@@ -544,14 +547,14 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Err(VirtualMachineError::EmptyCurrentAccessIndices)
         );
     }
 
     #[test]
     fn squash_dict_inner_first_iteration_no_local_variables() {
-        let hint_code = SQUASH_DICT_INNER_FIRST_ITERATION.as_bytes();
+        let hint_code = SQUASH_DICT_INNER_FIRST_ITERATION;
         //No scope variables
         //Create vm
         let mut vm = VirtualMachine::new(
@@ -588,7 +591,7 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Err(VirtualMachineError::NoLocalVariable(String::from(
                 "access_indices"
             )))
@@ -597,7 +600,7 @@ mod tests {
 
     #[test]
     fn should_skip_loop_valid_empty_current_access_indices() {
-        let hint_code = SQUASH_DICT_INNER_SKIP_LOOP.as_bytes();
+        let hint_code = SQUASH_DICT_INNER_SKIP_LOOP;
         //Prepare scope variables
         let current_access_indices = vec![];
         //Create vm
@@ -633,7 +636,7 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Ok(())
         );
         //Check the value of ids.should_skip_loop
@@ -645,7 +648,7 @@ mod tests {
 
     #[test]
     fn should_skip_loop_valid_non_empty_current_access_indices() {
-        let hint_code = SQUASH_DICT_INNER_SKIP_LOOP.as_bytes();
+        let hint_code = SQUASH_DICT_INNER_SKIP_LOOP;
         //Prepare scope variables
         let current_access_indices = vec![bigint!(4), bigint!(7)];
         //Create vm
@@ -681,7 +684,7 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Ok(())
         );
         //Check the value of ids.should_skip_loop
@@ -693,7 +696,7 @@ mod tests {
 
     #[test]
     fn squash_dict_inner_check_access_index_valid() {
-        let hint_code = SQUASH_DICT_INNER_CHECK_ACCESS_INDEX.as_bytes();
+        let hint_code = SQUASH_DICT_INNER_CHECK_ACCESS_INDEX;
         //Prepare scope variables
         let current_access_indices = vec![bigint!(10), bigint!(9), bigint!(7), bigint!(5)];
         //Create vm
@@ -731,7 +734,7 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Ok(())
         );
         //Check scope variables
@@ -756,7 +759,7 @@ mod tests {
 
     #[test]
     fn squash_dict_inner_check_access_current_access_addr_empty() {
-        let hint_code = SQUASH_DICT_INNER_CHECK_ACCESS_INDEX.as_bytes();
+        let hint_code = SQUASH_DICT_INNER_CHECK_ACCESS_INDEX;
         //Prepare scope variables
         let current_access_indices = vec![];
         //Create vm
@@ -801,14 +804,14 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Err(VirtualMachineError::EmptyCurrentAccessIndices)
         );
     }
 
     #[test]
     fn should_continue_loop_valid_non_empty_current_access_indices() {
-        let hint_code = SQUASH_DICT_INNER_CONTINUE_LOOP.as_bytes();
+        let hint_code = SQUASH_DICT_INNER_CONTINUE_LOOP;
         //Prepare scope variables
         let current_access_indices = vec![bigint!(4), bigint!(7)];
         //Create vm
@@ -844,7 +847,7 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Ok(())
         );
         //Check the value of ids.loop_temps.should_continue (loop_temps + 3)
@@ -856,7 +859,7 @@ mod tests {
 
     #[test]
     fn should_continue_loop_valid_empty_current_access_indices() {
-        let hint_code = SQUASH_DICT_INNER_CONTINUE_LOOP.as_bytes();
+        let hint_code = SQUASH_DICT_INNER_CONTINUE_LOOP;
         //Prepare scope variables
         let current_access_indices = vec![];
         //Create vm
@@ -892,7 +895,7 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Ok(())
         );
         //Check the value of ids.loop_temps.should_continue (loop_temps + 3)
@@ -904,7 +907,7 @@ mod tests {
 
     #[test]
     fn assert_current_indices_len_is_empty() {
-        let hint_code = SQUASH_DICT_INNER_ASSERT_LEN.as_bytes();
+        let hint_code = SQUASH_DICT_INNER_ASSERT_LEN;
         //Prepare scope variables
         let current_access_indices = vec![];
         //Create vm
@@ -921,14 +924,14 @@ mod tests {
         //Execute the hint
         //Hint should produce an error if assertion fails
         assert_eq!(
-            execute_hint(&mut vm, hint_code, HashMap::new(), &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &HashMap::new(), &ApTracking::default()),
             Ok(())
         );
     }
 
     #[test]
     fn assert_current_indices_len_is_empty_not() {
-        let hint_code = SQUASH_DICT_INNER_ASSERT_LEN.as_bytes();
+        let hint_code = SQUASH_DICT_INNER_ASSERT_LEN;
         //Prepare scope variables
         let current_access_indices = vec![bigint!(29)];
         //Create vm
@@ -945,14 +948,14 @@ mod tests {
         //Execute the hint
         //Hint should produce an error if assertion fails
         assert_eq!(
-            execute_hint(&mut vm, hint_code, HashMap::new(), &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &HashMap::new(), &ApTracking::default()),
             Err(VirtualMachineError::CurrentAccessIndicesNotEmpty)
         );
     }
 
     #[test]
     fn squash_dict_inner_uses_accesses_assert_valid() {
-        let hint_code = SQUASH_DICT_INNER_USED_ACCESSES_ASSERT.as_bytes();
+        let hint_code = SQUASH_DICT_INNER_USED_ACCESSES_ASSERT;
         //Prepare scope variables
         let mut access_indices = HashMap::<BigInt, Vec<BigInt>>::new();
         let current_accessed_indices = vec![bigint!(9), bigint!(3), bigint!(10), bigint!(7)];
@@ -998,14 +1001,14 @@ mod tests {
         //Execute the hint
         //Hint would fail is assertion fails
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Ok(())
         );
     }
 
     #[test]
     fn squash_dict_inner_uses_accesses_assert_wrong_used_access_number() {
-        let hint_code = SQUASH_DICT_INNER_USED_ACCESSES_ASSERT.as_bytes();
+        let hint_code = SQUASH_DICT_INNER_USED_ACCESSES_ASSERT;
         //Prepare scope variables
         let mut access_indices = HashMap::<BigInt, Vec<BigInt>>::new();
         let current_accessed_indices = vec![bigint!(9), bigint!(3), bigint!(10), bigint!(7)];
@@ -1050,7 +1053,7 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Err(VirtualMachineError::NumUsedAccessesAssertFail(
                 bigint!(5),
                 4,
@@ -1061,7 +1064,7 @@ mod tests {
 
     #[test]
     fn squash_dict_inner_uses_accesses_assert_used_access_number_relocatable() {
-        let hint_code = SQUASH_DICT_INNER_USED_ACCESSES_ASSERT.as_bytes();
+        let hint_code = SQUASH_DICT_INNER_USED_ACCESSES_ASSERT;
         //Prepare scope variables
         let mut access_indices = HashMap::<BigInt, Vec<BigInt>>::new();
         let current_accessed_indices = vec![bigint!(9), bigint!(3), bigint!(10), bigint!(7)];
@@ -1106,7 +1109,7 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((0, 0))
             ))
@@ -1115,7 +1118,7 @@ mod tests {
 
     #[test]
     fn squash_dict_assert_len_keys_empty() {
-        let hint_code = SQUASH_DICT_INNER_LEN_KEYS.as_bytes();
+        let hint_code = SQUASH_DICT_INNER_LEN_KEYS;
         //Prepare scope variables
         let keys = vec![];
         //Create vm
@@ -1129,14 +1132,14 @@ mod tests {
             .assign_or_update_variable("keys", PyValueType::List(keys));
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, HashMap::new(), &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &HashMap::new(), &ApTracking::default()),
             Ok(())
         );
     }
 
     #[test]
     fn squash_dict_assert_len_keys_not_empty() {
-        let hint_code = SQUASH_DICT_INNER_LEN_KEYS.as_bytes();
+        let hint_code = SQUASH_DICT_INNER_LEN_KEYS;
         //Prepare scope variables
         let keys = vec![bigint!(3)];
         //Create vm
@@ -1150,14 +1153,14 @@ mod tests {
             .assign_or_update_variable("keys", PyValueType::List(keys));
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, HashMap::new(), &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &HashMap::new(), &ApTracking::default()),
             Err(VirtualMachineError::KeysNotEmpty)
         );
     }
 
     #[test]
     fn squash_dict_assert_len_keys_no_keys() {
-        let hint_code = SQUASH_DICT_INNER_LEN_KEYS.as_bytes();
+        let hint_code = SQUASH_DICT_INNER_LEN_KEYS;
         //Create vm
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -1166,14 +1169,14 @@ mod tests {
         );
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, HashMap::new(), &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &HashMap::new(), &ApTracking::default()),
             Err(VirtualMachineError::NoLocalVariable(String::from("keys")))
         );
     }
 
     #[test]
     fn squash_dict_inner_next_key_keys_non_empty() {
-        let hint_code = SQUASH_DICT_INNER_NEXT_KEY.as_bytes();
+        let hint_code = SQUASH_DICT_INNER_NEXT_KEY;
         //Prepare scope variables
         let keys = vec![bigint!(1), bigint!(3)];
         //Create vm
@@ -1207,7 +1210,7 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Ok(())
         );
         //Check the value of ids.next_key
@@ -1225,7 +1228,7 @@ mod tests {
 
     #[test]
     fn squash_dict_inner_next_key_keys_empty() {
-        let hint_code = SQUASH_DICT_INNER_NEXT_KEY.as_bytes();
+        let hint_code = SQUASH_DICT_INNER_NEXT_KEY;
         //Prepare scope variables
         let keys = vec![];
         //Create vm
@@ -1259,7 +1262,7 @@ mod tests {
         )]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Err(VirtualMachineError::EmptyKeys)
         );
     }
@@ -1267,7 +1270,7 @@ mod tests {
     #[test]
     fn squash_dict_valid_one_key_dict_no_max_size() {
         //Dict = {1: (1,1), 1: (1,2)}
-        let hint_code = SQUASH_DICT.as_bytes();
+        let hint_code = SQUASH_DICT;
         //Create vm
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -1416,7 +1419,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Ok(())
         );
         //Check scope variables
@@ -1447,7 +1450,8 @@ mod tests {
     #[test]
     fn squash_dict_valid_two_key_dict_no_max_size() {
         //Dict = {1: (1,1), 1: (1,2), 2: (10,10), 2: (10,20)}
-        let hint_code = SQUASH_DICT.as_bytes();
+        let hint_code = SQUASH_DICT;
+        assert_eq!(SQUASH_DICT, hint_code::SQUASH_DICT);
         //Create vm
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -1638,7 +1642,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Ok(())
         );
         //Check scope variables
@@ -1672,7 +1676,7 @@ mod tests {
     #[test]
     fn squash_dict_valid_one_key_dict_with_max_size() {
         //Dict = {1: (1,1), 1: (1,2)}
-        let hint_code = SQUASH_DICT.as_bytes();
+        let hint_code = SQUASH_DICT;
         //Create vm
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -1824,7 +1828,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Ok(())
         );
         //Check scope variables
@@ -1855,7 +1859,7 @@ mod tests {
     #[test]
     fn squash_dict_invalid_one_key_dict_with_max_size_exceeded() {
         //Dict = {1: (1,1), 1: (1,2)}
-        let hint_code = SQUASH_DICT.as_bytes();
+        let hint_code = SQUASH_DICT;
         //Create vm
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -2007,7 +2011,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Err(VirtualMachineError::SquashDictMaxSizeExceeded(
                 bigint!(1),
                 bigint!(2)
@@ -2018,7 +2022,7 @@ mod tests {
     #[test]
     fn squash_dict_invalid_one_key_dict_bad_ptr_diff() {
         //Dict = {1: (1,1), 1: (1,2)}
-        let hint_code = SQUASH_DICT.as_bytes();
+        let hint_code = SQUASH_DICT;
         //Create vm
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -2167,14 +2171,14 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Err(VirtualMachineError::PtrDiffNotDivisibleByDictAccessSize)
         );
     }
     #[test]
     fn squash_dict_invalid_one_key_dict_with_n_access_too_big() {
         //Dict = {1: (1,1), 1: (1,2)}
-        let hint_code = SQUASH_DICT.as_bytes();
+        let hint_code = SQUASH_DICT;
         //Create vm
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -2326,7 +2330,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Err(VirtualMachineError::NAccessesTooBig(BigInt::new(
                 Sign::Plus,
                 vec![1, 0, 0, 0, 0, 0, 17, 134217728]
@@ -2337,7 +2341,7 @@ mod tests {
     #[test]
     fn squash_dict_valid_one_key_dict_no_max_size_big_keys() {
         //Dict = {(prime - 1): (1,1), (prime - 1): (1,2)}
-        let hint_code = SQUASH_DICT.as_bytes();
+        let hint_code = SQUASH_DICT;
         //Create vm
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -2492,7 +2496,7 @@ mod tests {
         ]);
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::default()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::default()),
             Ok(())
         );
         //Check scope variables

--- a/src/vm/hints/uint256_utils.rs
+++ b/src/vm/hints/uint256_utils.rs
@@ -25,7 +25,7 @@ Implements hint:
 */
 pub fn uint256_add(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let shift: BigInt = bigint!(2).pow(128);
@@ -76,7 +76,7 @@ Implements hint:
 */
 pub fn split_64(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let a = get_integer_from_var_name("a", &ids, vm, hint_ap_tracking)?;
@@ -108,7 +108,7 @@ Implements hint:
 */
 pub fn uint256_sqrt(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let n_relocatable = get_relocatable_from_var_name("n", &ids, vm, hint_ap_tracking)?;
@@ -152,7 +152,7 @@ Implements hint:
 */
 pub fn uint256_signed_nn(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let a_relocatable = get_relocatable_from_var_name("a", &ids, vm, hint_ap_tracking)?;
@@ -189,7 +189,7 @@ Implements hint:
 */
 pub fn uint256_unsigned_div_rem(
     vm: &mut VirtualMachine,
-    ids: HashMap<String, BigInt>,
+    ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let a_relocatable = get_relocatable_from_var_name("a", &ids, vm, hint_ap_tracking)?;
@@ -265,7 +265,7 @@ mod tests {
 
     #[test]
     fn run_uint256_add_ok() {
-        let hint_code = "sum_low = ids.a.low + ids.b.low\nids.carry_low = 1 if sum_low >= ids.SHIFT else 0\nsum_high = ids.a.high + ids.b.high + ids.carry_low\nids.carry_high = 1 if sum_high >= ids.SHIFT else 0".as_bytes();
+        let hint_code = "sum_low = ids.a.low + ids.b.low\nids.carry_low = 1 if sum_low >= ids.SHIFT else 0\nsum_high = ids.a.high + ids.b.high + ids.carry_low\nids.carry_high = 1 if sum_high >= ids.SHIFT else 0";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -367,7 +367,7 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
 
@@ -384,7 +384,7 @@ mod tests {
 
     #[test]
     fn run_uint256_add_fail_inserts() {
-        let hint_code = "sum_low = ids.a.low + ids.b.low\nids.carry_low = 1 if sum_low >= ids.SHIFT else 0\nsum_high = ids.a.high + ids.b.high + ids.carry_low\nids.carry_high = 1 if sum_high >= ids.SHIFT else 0".as_bytes();
+        let hint_code = "sum_low = ids.a.low + ids.b.low\nids.carry_low = 1 if sum_low >= ids.SHIFT else 0\nsum_high = ids.a.high + ids.b.high + ids.carry_low\nids.carry_high = 1 if sum_high >= ids.SHIFT else 0";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -494,7 +494,7 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((1, 12)),
@@ -507,7 +507,7 @@ mod tests {
 
     #[test]
     fn run_split_64_ok() {
-        let hint_code = "ids.low = ids.a & ((1<<64) - 1)\nids.high = ids.a >> 64".as_bytes();
+        let hint_code = "ids.low = ids.a & ((1<<64) - 1)\nids.high = ids.a >> 64";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -576,7 +576,7 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
 
@@ -599,7 +599,7 @@ mod tests {
 
     #[test]
     fn run_split_64_memory_error() {
-        let hint_code = "ids.low = ids.a & ((1<<64) - 1)\nids.high = ids.a >> 64".as_bytes();
+        let hint_code = "ids.low = ids.a & ((1<<64) - 1)\nids.high = ids.a >> 64";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -676,7 +676,7 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((1, 10)),
@@ -689,7 +689,7 @@ mod tests {
 
     #[test]
     fn run_uint256_sqrt_ok() {
-        let hint_code = "from starkware.python.math_utils import isqrt\nn = (ids.n.high << 128) + ids.n.low\nroot = isqrt(n)\nassert 0 <= root < 2 ** 128\nids.root.low = root\nids.root.high = 0".as_bytes();
+        let hint_code = "from starkware.python.math_utils import isqrt\nn = (ids.n.high << 128) + ids.n.low\nroot = isqrt(n)\nassert 0 <= root < 2 ** 128\nids.root.low = root\nids.root.high = 0";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -754,7 +754,7 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
 
@@ -775,7 +775,7 @@ mod tests {
 
     #[test]
     fn run_uint256_sqrt_assert_error() {
-        let hint_code = "from starkware.python.math_utils import isqrt\nn = (ids.n.high << 128) + ids.n.low\nroot = isqrt(n)\nassert 0 <= root < 2 ** 128\nids.root.low = root\nids.root.high = 0".as_bytes();
+        let hint_code = "from starkware.python.math_utils import isqrt\nn = (ids.n.high << 128) + ids.n.low\nroot = isqrt(n)\nassert 0 <= root < 2 ** 128\nids.root.low = root\nids.root.high = 0";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -840,7 +840,7 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::AssertionFailed(String::from(
                 "assert 0 <= 340282366920938463463374607431768211456 < 2 ** 128"
             )))
@@ -849,7 +849,7 @@ mod tests {
 
     #[test]
     fn run_uint256_invalid_memory_insert() {
-        let hint_code = "from starkware.python.math_utils import isqrt\nn = (ids.n.high << 128) + ids.n.low\nroot = isqrt(n)\nassert 0 <= root < 2 ** 128\nids.root.low = root\nids.root.high = 0".as_bytes();
+        let hint_code = "from starkware.python.math_utils import isqrt\nn = (ids.n.high << 128) + ids.n.low\nroot = isqrt(n)\nassert 0 <= root < 2 ** 128\nids.root.low = root\nids.root.high = 0";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -922,7 +922,7 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((1, 5)),
@@ -935,7 +935,7 @@ mod tests {
 
     #[test]
     fn run_signed_nn_ok_result_one() {
-        let hint_code = "memory[ap] = 1 if 0 <= (ids.a.high % PRIME) < 2 ** 127 else 0".as_bytes();
+        let hint_code = "memory[ap] = 1 if 0 <= (ids.a.high % PRIME) < 2 ** 127 else 0";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -979,7 +979,7 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
 
@@ -993,7 +993,7 @@ mod tests {
 
     #[test]
     fn run_signed_nn_ok_result_zero() {
-        let hint_code = "memory[ap] = 1 if 0 <= (ids.a.high % PRIME) < 2 ** 127 else 0".as_bytes();
+        let hint_code = "memory[ap] = 1 if 0 <= (ids.a.high % PRIME) < 2 ** 127 else 0";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -1037,7 +1037,7 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
 
@@ -1051,7 +1051,7 @@ mod tests {
 
     #[test]
     fn run_signed_nn_ok_invalid_memory_insert() {
-        let hint_code = "memory[ap] = 1 if 0 <= (ids.a.high % PRIME) < 2 ** 127 else 0".as_bytes();
+        let hint_code = "memory[ap] = 1 if 0 <= (ids.a.high % PRIME) < 2 ** 127 else 0";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -1099,7 +1099,7 @@ mod tests {
             .unwrap();
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((1, 5)),
@@ -1112,7 +1112,7 @@ mod tests {
 
     #[test]
     fn run_unsigned_div_rem_ok() {
-        let hint_code = "a = (ids.a.high << 128) + ids.a.low\ndiv = (ids.div.high << 128) + ids.div.low\nquotient, remainder = divmod(a, div)\n\nids.quotient.low = quotient & ((1 << 128) - 1)\nids.quotient.high = quotient >> 128\nids.remainder.low = remainder & ((1 << 128) - 1)\nids.remainder.high = remainder >> 128".as_bytes();
+        let hint_code = "a = (ids.a.high << 128) + ids.a.low\ndiv = (ids.div.high << 128) + ids.div.low\nquotient, remainder = divmod(a, div)\n\nids.quotient.low = quotient & ((1 << 128) - 1)\nids.quotient.high = quotient >> 128\nids.remainder.low = remainder & ((1 << 128) - 1)\nids.remainder.high = remainder >> 128";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -1214,7 +1214,7 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
 
@@ -1243,7 +1243,7 @@ mod tests {
 
     #[test]
     fn run_unsigned_div_rem_invalid_memory_insert() {
-        let hint_code = "a = (ids.a.high << 128) + ids.a.low\ndiv = (ids.div.high << 128) + ids.div.low\nquotient, remainder = divmod(a, div)\n\nids.quotient.low = quotient & ((1 << 128) - 1)\nids.quotient.high = quotient >> 128\nids.remainder.low = remainder & ((1 << 128) - 1)\nids.remainder.high = remainder >> 128".as_bytes();
+        let hint_code = "a = (ids.a.high << 128) + ids.a.low\ndiv = (ids.div.high << 128) + ids.div.low\nquotient, remainder = divmod(a, div)\n\nids.quotient.low = quotient & ((1 << 128) - 1)\nids.quotient.high = quotient >> 128\nids.remainder.low = remainder & ((1 << 128) - 1)\nids.remainder.high = remainder >> 128";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -1352,7 +1352,7 @@ mod tests {
 
         //Execute the hint
         assert_eq!(
-            execute_hint(&mut vm, hint_code, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((1, 10)),

--- a/src/vm/hints/usort.rs
+++ b/src/vm/hints/usort.rs
@@ -175,7 +175,7 @@ mod tests {
 
     #[test]
     fn usort_out_of_range() {
-        let hint = "from collections import defaultdict\n\ninput_ptr = ids.input\ninput_len = int(ids.input_len)\nif __usort_max_size is not None:\n    assert input_len <= __usort_max_size, (\n        f\"usort() can only be used with input_len<={__usort_max_size}. \"\n        f\"Got: input_len={input_len}.\"\n    )\n\npositions_dict = defaultdict(list)\nfor i in range(input_len):\n    val = memory[input_ptr + i]\n    positions_dict[val].append(i)\n\noutput = sorted(positions_dict.keys())\nids.output_len = len(output)\nids.output = segments.gen_arg(output)\nids.multiplicities = segments.gen_arg([len(positions_dict[k]) for k in output])".as_bytes();
+        let hint = "from collections import defaultdict\n\ninput_ptr = ids.input\ninput_len = int(ids.input_len)\nif __usort_max_size is not None:\n    assert input_len <= __usort_max_size, (\n        f\"usort() can only be used with input_len<={__usort_max_size}. \"\n        f\"Got: input_len={input_len}.\"\n    )\n\npositions_dict = defaultdict(list)\nfor i in range(input_len):\n    val = memory[input_ptr + i]\n    positions_dict[val].append(i)\n\noutput = sorted(positions_dict.keys())\nids.output_len = len(output)\nids.output = segments.gen_arg(output)\nids.multiplicities = segments.gen_arg([len(positions_dict[k]) for k in output])";
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![(
@@ -226,7 +226,7 @@ mod tests {
             .assign_or_update_variable("usort_max_size", PyValueType::U64(1));
 
         assert_eq!(
-            execute_hint(&mut vm, hint, ids, &ApTracking::new()),
+            execute_hint(&mut vm, hint, &ids, &ApTracking::new()),
             Err(VirtualMachineError::UsortOutOfRange(1, bigint!(5)))
         );
     }

--- a/src/vm/hints/usort.rs
+++ b/src/vm/hints/usort.rs
@@ -167,11 +167,13 @@ mod tests {
     use crate::{
         types::{instruction::Register, relocatable::MaybeRelocatable},
         vm::{
-            hints::execute_hint::{execute_hint, HintReference},
+            hints::execute_hint::{BuiltinHintExecutor, HintReference},
             runners::builtin_runner::RangeCheckBuiltinRunner,
         },
     };
     use num_bigint::Sign;
+
+    static HINT_EXECUTOR: BuiltinHintExecutor = BuiltinHintExecutor {};
 
     #[test]
     fn usort_out_of_range() {
@@ -183,6 +185,7 @@ mod tests {
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
             )],
             false,
+            &HINT_EXECUTOR,
         );
 
         const FP_OFFSET_START: usize = 1;
@@ -226,7 +229,8 @@ mod tests {
             .assign_or_update_variable("usort_max_size", PyValueType::U64(1));
 
         assert_eq!(
-            execute_hint(&mut vm, hint, &ids, &ApTracking::new()),
+            vm.hint_executor
+                .execute_hint(&mut vm, hint, &ids, &ApTracking::new()),
             Err(VirtualMachineError::UsortOutOfRange(1, bigint!(5)))
         );
     }

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -260,9 +260,9 @@ impl CairoRunner {
                 if let Some(hint_list) = hint_dictionary.get_mut(&key) {
                     //Add hint code to list of hints at given pc
                     hint_list.push(HintData::new(
-                        hint_data.code.clone(),
+                        &hint_data.code,
                         CairoRunner::remove_path_from_reference_ids(
-                            &hint_data.flow_tracking_data.reference_ids.clone(),
+                            &hint_data.flow_tracking_data.reference_ids,
                         )?,
                         hint_data.flow_tracking_data.ap_tracking.clone(),
                     ));
@@ -271,7 +271,7 @@ impl CairoRunner {
                     hint_dictionary.insert(
                         key,
                         vec![HintData::new(
-                            hint_data.code.clone(),
+                            &hint_data.code,
                             CairoRunner::remove_path_from_reference_ids(
                                 &hint_data.flow_tracking_data.reference_ids,
                             )?,

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -33,7 +33,7 @@ struct OperandsAddresses(MaybeRelocatable, MaybeRelocatable, MaybeRelocatable);
 #[derive(Clone, Debug)]
 
 pub struct HintData {
-    pub hint_code: Vec<u8>,
+    pub hint_code: String,
     //Maps the name of the variable to its reference id
     pub ids: HashMap<String, BigInt>,
     pub ap_tracking_data: ApTracking,
@@ -69,12 +69,12 @@ pub struct VirtualMachine {
 
 impl HintData {
     pub fn new(
-        hint_code: Vec<u8>,
+        hint_code: &str,
         ids: HashMap<String, BigInt>,
         ap_tracking_data: ApTracking,
     ) -> HintData {
         HintData {
-            hint_code,
+            hint_code: hint_code.to_string(),
             ids,
             ap_tracking_data,
         }
@@ -494,7 +494,7 @@ impl VirtualMachine {
                 execute_hint(
                     self,
                     &hint_data.hint_code,
-                    hint_data.ids.clone(),
+                    &hint_data.ids,
                     &hint_data.ap_tracking_data,
                 )?
             }
@@ -3590,7 +3590,7 @@ mod tests {
         vm.hints.insert(
             MaybeRelocatable::from((0, 0)),
             vec![HintData::new(
-                "memory[ap] = segments.add()".as_bytes().to_vec(),
+                "memory[ap] = segments.add()",
                 HashMap::new(),
                 ApTracking::new(),
             )],

--- a/tests/bitwise_test.rs
+++ b/tests/bitwise_test.rs
@@ -2,14 +2,18 @@ use std::path::Path;
 
 use cleopatra_cairo::{
     types::program::Program,
-    vm::{runners::cairo_runner::CairoRunner, trace::trace_entry::RelocatedTraceEntry},
+    vm::{
+        hints::execute_hint::BuiltinHintExecutor, runners::cairo_runner::CairoRunner,
+        trace::trace_entry::RelocatedTraceEntry,
+    },
 };
 
+static HINT_EXECUTOR: BuiltinHintExecutor = BuiltinHintExecutor {};
 #[test]
 fn bitwise_integration_test() {
     let program = Program::new(Path::new("cairo_programs/bitwise_builtin_test.json"))
         .expect("Failed to deserialize program");
-    let mut cairo_runner = CairoRunner::new(&program, true);
+    let mut cairo_runner = CairoRunner::new(&program, true, &HINT_EXECUTOR);
     cairo_runner.initialize_segments(None);
     let end = cairo_runner.initialize_main_entrypoint().unwrap();
 

--- a/tests/cairo_run_test.rs
+++ b/tests/cairo_run_test.rs
@@ -395,8 +395,12 @@ fn cairo_run_secp() {
 
 #[test]
 fn cairo_run_secp_ec() {
-    cairo_run::cairo_run(Path::new("cairo_programs/secp_ec.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/secp_ec.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]

--- a/tests/cairo_run_test.rs
+++ b/tests/cairo_run_test.rs
@@ -1,29 +1,48 @@
 use std::path::Path;
 
 use cleopatra_cairo::cairo_run;
+use cleopatra_cairo::vm::hints::execute_hint::BuiltinHintExecutor;
+
+static HINT_EXECUTOR: BuiltinHintExecutor = BuiltinHintExecutor {};
 
 #[test]
 fn cairo_run_test() {
-    cairo_run::cairo_run(Path::new("cairo_programs/fibonacci.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/fibonacci.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_bitwise_output() {
-    cairo_run::cairo_run(Path::new("cairo_programs/bitwise_output.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/bitwise_output.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_bitwise_recursion() {
-    cairo_run::cairo_run(Path::new("cairo_programs/bitwise_recursion.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/bitwise_recursion.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_integration() {
-    cairo_run::cairo_run(Path::new("cairo_programs/integration.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/integration.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
@@ -31,14 +50,19 @@ fn cairo_run_integration_with_alloc_locals() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/integration_with_alloc_locals.json"),
         false,
+        &HINT_EXECUTOR,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_compare_arrays() {
-    cairo_run::cairo_run(Path::new("cairo_programs/compare_arrays.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/compare_arrays.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
@@ -46,20 +70,29 @@ fn cairo_run_compare_greater_array() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/compare_greater_array.json"),
         false,
+        &HINT_EXECUTOR,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_compare_lesser_array() {
-    cairo_run::cairo_run(Path::new("cairo_programs/compare_lesser_array.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/compare_lesser_array.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_assert_le_felt_hint() {
-    cairo_run::cairo_run(Path::new("cairo_programs/assert_le_felt_hint.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/assert_le_felt_hint.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
@@ -67,14 +100,19 @@ fn cairo_run_assert_250_bit_element_array() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/assert_250_bit_element_array.json"),
         false,
+        &HINT_EXECUTOR,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_abs_value() {
-    cairo_run::cairo_run(Path::new("cairo_programs/abs_value_array.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/abs_value_array.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
@@ -82,122 +120,187 @@ fn cairo_run_compare_different_arrays() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/compare_different_arrays.json"),
         false,
+        &HINT_EXECUTOR,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_assert_nn() {
-    cairo_run::cairo_run(Path::new("cairo_programs/assert_nn.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/assert_nn.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_sqrt() {
-    cairo_run::cairo_run(Path::new("cairo_programs/sqrt.json"), false)
+    cairo_run::cairo_run(Path::new("cairo_programs/sqrt.json"), false, &HINT_EXECUTOR)
         .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_assert_not_zero() {
-    cairo_run::cairo_run(Path::new("cairo_programs/assert_not_zero.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/assert_not_zero.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_split_int() {
-    cairo_run::cairo_run(Path::new("cairo_programs/split_int.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/split_int.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_split_int_big() {
-    cairo_run::cairo_run(Path::new("cairo_programs/split_int_big.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/split_int_big.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_split_felt() {
-    cairo_run::cairo_run(Path::new("cairo_programs/split_felt.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/split_felt.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_is_le_felt() {
-    cairo_run::cairo_run(Path::new("cairo_programs/math_cmp_is_le_felt.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/math_cmp_is_le_felt.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_unsigned_div_rem() {
-    cairo_run::cairo_run(Path::new("cairo_programs/unsigned_div_rem.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/unsigned_div_rem.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_signed_div_rem() {
-    cairo_run::cairo_run(Path::new("cairo_programs/signed_div_rem.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/signed_div_rem.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_assert_lt_felt() {
-    cairo_run::cairo_run(Path::new("cairo_programs/assert_lt_felt.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/assert_lt_felt.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_memcpy() {
-    cairo_run::cairo_run(Path::new("cairo_programs/memcpy_test.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/memcpy_test.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_memset() {
-    cairo_run::cairo_run(Path::new("cairo_programs/memset.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/memset.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_pow() {
-    cairo_run::cairo_run(Path::new("cairo_programs/pow.json"), false)
+    cairo_run::cairo_run(Path::new("cairo_programs/pow.json"), false, &HINT_EXECUTOR)
         .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_dict() {
-    cairo_run::cairo_run(Path::new("cairo_programs/dict.json"), false)
+    cairo_run::cairo_run(Path::new("cairo_programs/dict.json"), false, &HINT_EXECUTOR)
         .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_dict_update() {
-    cairo_run::cairo_run(Path::new("cairo_programs/dict_update.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/dict_update.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_uint256() {
-    cairo_run::cairo_run(Path::new("cairo_programs/uint256.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/uint256.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_find_element() {
-    cairo_run::cairo_run(Path::new("cairo_programs/find_element.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/find_element.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_search_sorted_lower() {
-    cairo_run::cairo_run(Path::new("cairo_programs/search_sorted_lower.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/search_sorted_lower.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_usort() {
-    cairo_run::cairo_run(Path::new("cairo_programs/usort.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/usort.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
@@ -205,6 +308,7 @@ fn cairo_run_usort_bad() {
     let err = cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/bad_usort.json"),
         false,
+        &HINT_EXECUTOR,
     );
     assert!(err.is_err());
     assert_eq!(
@@ -217,12 +321,14 @@ fn cairo_run_usort_bad() {
 fn cairo_run_dict_write_bad() {
     assert!(cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/bad_dict_new.json"),
-        false
+        false,
+        &HINT_EXECUTOR,
     )
     .is_err());
     let err = cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/bad_dict_new.json"),
         false,
+        &HINT_EXECUTOR,
     )
     .err();
     assert_eq!(
@@ -235,12 +341,14 @@ fn cairo_run_dict_write_bad() {
 fn cairo_run_dict_update_bad() {
     assert!(cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/bad_dict_update.json"),
-        false
+        false,
+        &HINT_EXECUTOR,
     )
     .is_err());
     let err = cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/bad_dict_update.json"),
         false,
+        &HINT_EXECUTOR,
     )
     .err();
     assert_eq!(
@@ -251,25 +359,37 @@ fn cairo_run_dict_update_bad() {
 
 #[test]
 fn cairo_run_squash_dict() {
-    cairo_run::cairo_run(Path::new("cairo_programs/squash_dict.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/squash_dict.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_dict_squash() {
-    cairo_run::cairo_run(Path::new("cairo_programs/dict_squash.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/dict_squash.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_set_add() {
-    cairo_run::cairo_run(Path::new("cairo_programs/set_add.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/set_add.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_secp() {
-    cairo_run::cairo_run(Path::new("cairo_programs/secp.json"), false)
+    cairo_run::cairo_run(Path::new("cairo_programs/secp.json"), false, &HINT_EXECUTOR)
         .expect("Couldn't run program");
 }
 
@@ -278,25 +398,38 @@ fn cairo_run_blake2s_hello_world_hash() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/blake2s_hello_world_hash.json"),
         false,
+        &HINT_EXECUTOR,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_finalize_blake2s() {
-    cairo_run::cairo_run(Path::new("cairo_programs/finalize_blake2s.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/finalize_blake2s.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 #[test]
 fn cairo_run_unsafe_keccak() {
-    cairo_run::cairo_run(Path::new("cairo_programs/unsafe_keccak.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/unsafe_keccak.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_blake2s_felts() {
-    cairo_run::cairo_run(Path::new("cairo_programs/blake2s_felts.json"), false)
-        .expect("Couldn't run program");
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/blake2s_felts.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
 }
 
 #[test]
@@ -304,6 +437,7 @@ fn cairo_run_unsafe_keccak_finalize() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/unsafe_keccak_finalize.json"),
         false,
+        &HINT_EXECUTOR,
     )
     .expect("Couldn't run program");
 }

--- a/tests/pedersen_test.rs
+++ b/tests/pedersen_test.rs
@@ -1,15 +1,17 @@
 use std::path::Path;
 
 use cleopatra_cairo::{
-    types::program::Program, vm::runners::cairo_runner::CairoRunner,
-    vm::trace::trace_entry::RelocatedTraceEntry,
+    types::program::Program, vm::hints::execute_hint::BuiltinHintExecutor,
+    vm::runners::cairo_runner::CairoRunner, vm::trace::trace_entry::RelocatedTraceEntry,
 };
+
+static HINT_EXECUTOR: BuiltinHintExecutor = BuiltinHintExecutor {};
 
 #[test]
 fn pedersen_integration_test() {
     let program = Program::new(Path::new("cairo_programs/pedersen_test.json"))
         .expect("Failed to deserialize program");
-    let mut cairo_runner = CairoRunner::new(&program, true);
+    let mut cairo_runner = CairoRunner::new(&program, true, &HINT_EXECUTOR);
     cairo_runner.initialize_segments(None);
     let end = cairo_runner.initialize_main_entrypoint().unwrap();
     assert!(cairo_runner.initialize_vm() == Ok(()), "Execution failed");

--- a/tests/struct_test.rs
+++ b/tests/struct_test.rs
@@ -2,14 +2,16 @@ use std::path::Path;
 
 use cleopatra_cairo::{
     types::program::Program,
+    vm::hints::execute_hint::BuiltinHintExecutor,
     vm::{runners::cairo_runner::CairoRunner, trace::trace_entry::RelocatedTraceEntry},
 };
 
+static HINT_EXECUTOR: BuiltinHintExecutor = BuiltinHintExecutor {};
 #[test]
 fn struct_integration_test() {
     let program = Program::new(Path::new("cairo_programs/struct.json"))
         .expect("Failed to deserialize program");
-    let mut cairo_runner = CairoRunner::new(&program, true);
+    let mut cairo_runner = CairoRunner::new(&program, true, &HINT_EXECUTOR);
     cairo_runner.initialize_segments(None);
     let end = cairo_runner.initialize_main_entrypoint().unwrap();
 


### PR DESCRIPTION
## Description

- Create a new trait `HintExecutor` to allow custom behaviors regarding hints
- Refactor the original (now `BuiltinHintExecutor`) code handling hints

Missing:
- Documentation
- Prototype using PyO3 to run regular hints

EDIT: this is a stopgap for experimentation, so it's more efficient to just point to this PR for documentation. The logic is quite brief anyway.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
