### PR TITLE
[HINTS]Add implementation for hints on function is_zero (cairo_secp/field.cairo )

### DIFF
--- a/cairo_programs/secp.cairo
+++ b/cairo_programs/secp.cairo
@@ -42,5 +42,8 @@ func main{range_check_ptr: felt}():
     let (v) = is_zero(BigInt3(232113757366008801543585,232113757366008801543585,232113757366008801543585))
     assert v = 0
 
+    let (w) = is_zero(BigInt3(-10,-10,-10))
+    assert w = 0
+
     return()
 end

--- a/cairo_programs/secp.cairo
+++ b/cairo_programs/secp.cairo
@@ -45,5 +45,8 @@ func main{range_check_ptr: felt}():
     let (w) = is_zero(BigInt3(-10,-10,-10))
     assert w = 0
 
+    let (z) = is_zero(BigInt3(1833312543,67523423,8790312))
+    assert z = 0
+
     return()
 end

--- a/cairo_programs/secp.cairo
+++ b/cairo_programs/secp.cairo
@@ -6,7 +6,8 @@ from starkware.cairo.common.cairo_secp.bigint import (
 from starkware.cairo.common.cairo_secp.field import (
     verify_zero,
     UnreducedBigInt3,
-    reduce
+    reduce,
+    is_zero
 )
 func main{range_check_ptr: felt}():
     #verify_zero
@@ -34,6 +35,12 @@ func main{range_check_ptr: felt}():
 
     let r: BigInt3 = reduce(UnreducedBigInt3(-10,-56,-111))
     assert r = BigInt3(77371252455336262886226981,77371252455336267181195207, 19342813113834066795298704)
+
+    # is_zero
+    let (u) = is_zero(BigInt3(0,0,0))
+    assert u = 1
+    let (v) = is_zero(BigInt3(232113757366008801543585,232113757366008801543585,232113757366008801543585))
+    assert v = 0
 
     return()
 end

--- a/src/math_utils.rs
+++ b/src/math_utils.rs
@@ -69,7 +69,7 @@ fn igcdex(num_a: BigInt, num_b: BigInt) -> (BigInt, BigInt, BigInt) {
     }
 }
 ///Finds a nonnegative integer x < p such that (m * x) % p == n.
-fn div_mod(n: BigInt, m: BigInt, p: BigInt) -> BigInt {
+pub fn div_mod(n: BigInt, m: BigInt, p: BigInt) -> BigInt {
     let (a, _, c) = igcdex(m, p.clone());
     assert_eq!(c, bigint!(1));
     (n * a).mod_floor(&p)

--- a/src/math_utils.rs
+++ b/src/math_utils.rs
@@ -69,10 +69,10 @@ fn igcdex(num_a: BigInt, num_b: BigInt) -> (BigInt, BigInt, BigInt) {
     }
 }
 ///Finds a nonnegative integer x < p such that (m * x) % p == n.
-pub fn div_mod(n: BigInt, m: BigInt, p: BigInt) -> BigInt {
+pub fn div_mod(n: BigInt, m: BigInt, p: &BigInt) -> BigInt {
     let (a, _, c) = igcdex(m, p.clone());
     assert_eq!(c, bigint!(1));
-    (n * a).mod_floor(&p)
+    (n * a).mod_floor(p)
 }
 
 /// Gets two points on an elliptic curve mod p and returns their sum.
@@ -92,7 +92,7 @@ pub fn ec_add(
 /// Assumes the points are given in affine form (x, y) and have different x coordinates.
 pub fn line_slope(point_a: (BigInt, BigInt), point_b: (BigInt, BigInt), prime: &BigInt) -> BigInt {
     assert!((point_a.0.clone() - point_b.0.clone()) % prime != bigint!(0));
-    div_mod(point_a.1 - point_b.1, point_a.0 - point_b.0, prime.clone())
+    div_mod(point_a.1 - point_b.1, point_a.0 - point_b.0, prime)
 }
 
 ///  Doubles a point on an elliptic curve with the equation y^2 = x^3 + alpha*x + beta mod p.
@@ -112,7 +112,7 @@ pub fn ec_double_slope(point: (BigInt, BigInt), alpha: &BigInt, prime: &BigInt) 
     div_mod(
         bigint!(3) * point.0.clone() * point.0.clone() + alpha,
         bigint!(2) * point.1,
-        prime.clone(),
+        prime,
     )
 }
 
@@ -147,7 +147,7 @@ mod tests {
             bigint_str!(
                 b"2904750555256547440469454488220756360634457312540595732507835416669695939476"
             ),
-            div_mod(a, b, prime)
+            div_mod(a, b, &prime)
         );
     }
 
@@ -166,7 +166,7 @@ mod tests {
             bigint_str!(
                 b"3601388548860259779932034493250169083811722919049731683411013070523752439691"
             ),
-            div_mod(a, b, prime)
+            div_mod(a, b, &prime)
         );
     }
 
@@ -185,7 +185,7 @@ mod tests {
             bigint_str!(
                 b"1545825591488572374291664030703937603499513742109806697511239542787093258962"
             ),
-            div_mod(a, b, prime)
+            div_mod(a, b, &prime)
         );
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,6 +17,17 @@ macro_rules! bigint_str {
 }
 
 #[macro_export]
+macro_rules! vm_prime {
+    () => {
+        BigInt::parse_bytes(
+            b"3618502788666131213697322783095070105623107215331596699973092056135872020481",
+            10,
+        )
+        .unwrap()
+    };
+}
+
+#[macro_export]
 macro_rules! relocatable {
     ($val1 : expr, $val2 : expr) => {
         Relocatable {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,17 +17,6 @@ macro_rules! bigint_str {
 }
 
 #[macro_export]
-macro_rules! vm_prime {
-    () => {
-        BigInt::parse_bytes(
-            b"3618502788666131213697322783095070105623107215331596699973092056135872020481",
-            10,
-        )
-        .unwrap()
-    };
-}
-
-#[macro_export]
 macro_rules! relocatable {
     ($val1 : expr, $val2 : expr) => {
         Relocatable {
@@ -62,6 +51,16 @@ pub fn to_field_element(num: BigInt, prime: BigInt) -> BigInt {
 #[cfg(test)]
 #[macro_use]
 pub mod test_utils {
+    use lazy_static::lazy_static;
+    use num_bigint::BigInt;
+
+    lazy_static! {
+        pub static ref VM_PRIME: BigInt = BigInt::parse_bytes(
+            b"3618502788666131213697322783095070105623107215331596699973092056135872020481",
+            10,
+        )
+        .unwrap();
+    }
     macro_rules! memory {
         ( $( (($si:expr, $off:expr), $val:tt) ),* ) => {
         {

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -35,7 +35,7 @@ use crate::vm::hints::uint256_utils::{
 
 use crate::vm::hints::secp::{
     bigint_utils::nondet_bigint3,
-    field_utils::{reduce, verify_zero},
+    field_utils::{is_zero_assign_x_inv, is_zero_nondet, is_zero_pack, reduce, verify_zero},
 };
 use crate::vm::hints::usort::{
     usort_body, usort_enter_scope, verify_multiplicity_assert, verify_multiplicity_body,
@@ -165,6 +165,12 @@ pub fn execute_hint(
         ) => unsafe_keccak(vm, ids, None),
         Ok("from eth_hash.auto import keccak\nkeccak_input = bytearray()\nn_elms = ids.keccak_state.end_ptr - ids.keccak_state.start_ptr\nfor word in memory.get_range(ids.keccak_state.start_ptr, n_elms):\n    keccak_input += word.to_bytes(16, 'big')\nhashed = keccak(keccak_input)\nids.high = int.from_bytes(hashed[:16], 'big')\nids.low = int.from_bytes(hashed[16:32], 'big')"
         ) => unsafe_keccak_finalize(vm, &ids, None),
+        Ok("from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nx = pack(ids.x, PRIME) % SECP_P"
+        ) => is_zero_pack(vm, &ids, None),
+        Ok("memory[ap] = to_felt_or_relocatable(x == 0)"
+        ) => is_zero_nondet(vm),
+        Ok("from starkware.cairo.common.cairo_secp.secp_utils import SECP_P\nfrom starkware.python.math_utils import div_mod\n\nvalue = x_inv = div_mod(1, x, SECP_P)"
+        ) => is_zero_assign_x_inv(vm),
         Ok(hint_code) => Err(VirtualMachineError::UnknownHint(String::from(hint_code))),
         Err(_) => Err(VirtualMachineError::InvalidHintEncoding(
             vm.run_context.pc.clone(),

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -35,7 +35,9 @@ use crate::vm::hints::uint256_utils::{
 
 use crate::vm::hints::secp::{
     bigint_utils::nondet_bigint3,
-    field_utils::{is_zero_assign_x_inv, is_zero_nondet, is_zero_pack, reduce, verify_zero},
+    field_utils::{
+        is_zero_assign_scope_variables, is_zero_nondet, is_zero_pack, reduce, verify_zero,
+    },
 };
 use crate::vm::hints::usort::{
     usort_body, usort_enter_scope, verify_multiplicity_assert, verify_multiplicity_body,
@@ -170,7 +172,7 @@ pub fn execute_hint(
         Ok("memory[ap] = to_felt_or_relocatable(x == 0)"
         ) => is_zero_nondet(vm),
         Ok("from starkware.cairo.common.cairo_secp.secp_utils import SECP_P\nfrom starkware.python.math_utils import div_mod\n\nvalue = x_inv = div_mod(1, x, SECP_P)"
-        ) => is_zero_assign_x_inv(vm),
+        ) => is_zero_assign_scope_variables(vm),
         Ok(hint_code) => Err(VirtualMachineError::UnknownHint(String::from(hint_code))),
         Err(_) => Err(VirtualMachineError::InvalidHintEncoding(
             vm.run_context.pc.clone(),

--- a/src/vm/hints/secp/field_utils.rs
+++ b/src/vm/hints/secp/field_utils.rs
@@ -163,7 +163,7 @@ pub fn is_zero_assign_scope_variables(vm: &mut VirtualMachine) -> Result<(), Vir
         }
     };
 
-    let value = div_mod(bigint!(1), x.clone(), SECP_P.clone());
+    let value = div_mod(bigint!(1), x.clone(), &SECP_P);
     vm.exec_scopes
         .assign_or_update_variable("value", PyValueType::BigInt(value.clone()));
 

--- a/src/vm/hints/secp/field_utils.rs
+++ b/src/vm/hints/secp/field_utils.rs
@@ -111,7 +111,12 @@ pub fn is_zero_pack(
     let x_d1 = get_integer_from_relocatable_plus_offset(&x_reloc, 1, vm)?;
     let x_d2 = get_integer_from_relocatable_plus_offset(&x_reloc, 2, vm)?;
 
-    let x = pack(x_d0, x_d1, x_d2, &vm.prime).mod_floor(&vm.prime);
+    //SECP_P = 2**256 - 2**32 - 2**9 - 2**8 - 2**7 - 2**6 - 2**4 - 1
+    let secp_p = bigint_str!(
+        b"115792089237316195423570985008687907853269984665640564039457584007908834671663"
+    );
+
+    let x = (pack(x_d0, x_d1, x_d2, &vm.prime)).mod_floor(&secp_p);
 
     vm.exec_scopes
         .assign_or_update_variable("x", PyValueType::BigInt(x));
@@ -152,9 +157,10 @@ pub fn is_zero_nondet(vm: &mut VirtualMachine) -> Result<(), VirtualMachineError
 /*
 Implements hint:
 %{
-    from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack
+    from starkware.cairo.common.cairo_secp.secp_utils import SECP_P
+    from starkware.python.math_utils import div_mod
 
-    x = pack(ids.x, PRIME) % SECP_P
+    value = x_inv = div_mod(1, x, SECP_P)
 %}
 */
 pub fn is_zero_assign_x_inv(vm: &mut VirtualMachine) -> Result<(), VirtualMachineError> {

--- a/src/vm/hints/secp/field_utils.rs
+++ b/src/vm/hints/secp/field_utils.rs
@@ -176,6 +176,7 @@ pub fn is_zero_assign_scope_variables(vm: &mut VirtualMachine) -> Result<(), Vir
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bigint_str;
     use crate::types::instruction::Register;
     use crate::types::relocatable::MaybeRelocatable;
     use crate::utils::test_utils::*;
@@ -183,13 +184,12 @@ mod tests {
     use crate::vm::hints::execute_hint::{execute_hint, HintReference};
     use crate::vm::runners::builtin_runner::RangeCheckBuiltinRunner;
     use crate::vm::vm_memory::memory::Memory;
-    use crate::{bigint_str, vm_prime};
 
     #[test]
     fn run_verify_zero_ok() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nq, r = divmod(pack(ids.val, PRIME), SECP_P)\nassert r == 0, f\"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}.\"\nids.q = q % PRIME".as_bytes();
         let mut vm = VirtualMachine::new(
-            vm_prime!(),
+            VM_PRIME.clone(),
             vec![(
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
@@ -288,7 +288,7 @@ mod tests {
     fn run_verify_zero_error() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nq, r = divmod(pack(ids.val, PRIME), SECP_P)\nassert r == 0, f\"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}.\"\nids.q = q % PRIME".as_bytes();
         let mut vm = VirtualMachine::new(
-            vm_prime!(),
+            VM_PRIME.clone(),
             vec![(
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
@@ -387,7 +387,7 @@ mod tests {
     fn run_verify_zero_invalid_memory_insert() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nq, r = divmod(pack(ids.val, PRIME), SECP_P)\nassert r == 0, f\"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}.\"\nids.q = q % PRIME".as_bytes();
         let mut vm = VirtualMachine::new(
-            vm_prime!(),
+            VM_PRIME.clone(),
             vec![(
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
@@ -496,7 +496,7 @@ mod tests {
     fn run_reduce_ok() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nvalue = pack(ids.x, PRIME) % SECP_P".as_bytes();
         let mut vm = VirtualMachine::new(
-            vm_prime!(),
+            VM_PRIME.clone(),
             vec![(
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
@@ -579,7 +579,7 @@ mod tests {
     fn run_reduce_error() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nvalue = pack(ids.x, PRIME) % SECP_P".as_bytes();
         let mut vm = VirtualMachine::new(
-            vm_prime!(),
+            VM_PRIME.clone(),
             vec![(
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
@@ -640,7 +640,7 @@ mod tests {
     fn run_is_zero_pack_ok() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nx = pack(ids.x, PRIME) % SECP_P".as_bytes();
         let mut vm = VirtualMachine::new(
-            vm_prime!(),
+            VM_PRIME.clone(),
             vec![(
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
@@ -700,7 +700,7 @@ mod tests {
     fn run_is_zero_pack_error() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nx = pack(ids.x, PRIME) % SECP_P".as_bytes();
         let mut vm = VirtualMachine::new(
-            vm_prime!(),
+            VM_PRIME.clone(),
             vec![(
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
@@ -754,7 +754,7 @@ mod tests {
     fn run_is_zero_nondet_ok_true() {
         let hint_code = "memory[ap] = to_felt_or_relocatable(x == 0)".as_bytes();
         let mut vm = VirtualMachine::new(
-            vm_prime!(),
+            VM_PRIME.clone(),
             vec![(
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
@@ -797,7 +797,7 @@ mod tests {
     fn run_is_zero_nondet_ok_false() {
         let hint_code = "memory[ap] = to_felt_or_relocatable(x == 0)".as_bytes();
         let mut vm = VirtualMachine::new(
-            vm_prime!(),
+            VM_PRIME.clone(),
             vec![(
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
@@ -840,7 +840,7 @@ mod tests {
     fn run_is_zero_nondet_scope_error() {
         let hint_code = "memory[ap] = to_felt_or_relocatable(x == 0)".as_bytes();
         let mut vm = VirtualMachine::new(
-            vm_prime!(),
+            VM_PRIME.clone(),
             vec![(
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
@@ -878,7 +878,7 @@ mod tests {
     fn run_is_zero_nondet_invalid_memory_insert() {
         let hint_code = "memory[ap] = to_felt_or_relocatable(x == 0)".as_bytes();
         let mut vm = VirtualMachine::new(
-            vm_prime!(),
+            VM_PRIME.clone(),
             vec![(
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
@@ -918,7 +918,7 @@ mod tests {
     fn is_zero_assign_scope_variables_ok() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P\nfrom starkware.python.math_utils import div_mod\n\nvalue = x_inv = div_mod(1, x, SECP_P)".as_bytes();
         let mut vm = VirtualMachine::new(
-            vm_prime!(),
+            VM_PRIME.clone(),
             vec![(
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
@@ -966,7 +966,7 @@ mod tests {
     fn is_zero_assign_scope_variables_scope_error() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P\nfrom starkware.python.math_utils import div_mod\n\nvalue = x_inv = div_mod(1, x, SECP_P)".as_bytes();
         let mut vm = VirtualMachine::new(
-            vm_prime!(),
+            VM_PRIME.clone(),
             vec![(
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),

--- a/src/vm/hints/secp/field_utils.rs
+++ b/src/vm/hints/secp/field_utils.rs
@@ -176,7 +176,6 @@ pub fn is_zero_assign_scope_variables(vm: &mut VirtualMachine) -> Result<(), Vir
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bigint_str;
     use crate::types::instruction::Register;
     use crate::types::relocatable::MaybeRelocatable;
     use crate::utils::test_utils::*;
@@ -184,13 +183,13 @@ mod tests {
     use crate::vm::hints::execute_hint::{execute_hint, HintReference};
     use crate::vm::runners::builtin_runner::RangeCheckBuiltinRunner;
     use crate::vm::vm_memory::memory::Memory;
-    use num_bigint::Sign;
+    use crate::{bigint_str, vm_prime};
 
     #[test]
     fn run_verify_zero_ok() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nq, r = divmod(pack(ids.val, PRIME), SECP_P)\nassert r == 0, f\"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}.\"\nids.q = q % PRIME".as_bytes();
         let mut vm = VirtualMachine::new(
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            vm_prime!(),
             vec![(
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
@@ -289,7 +288,7 @@ mod tests {
     fn run_verify_zero_error() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nq, r = divmod(pack(ids.val, PRIME), SECP_P)\nassert r == 0, f\"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}.\"\nids.q = q % PRIME".as_bytes();
         let mut vm = VirtualMachine::new(
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            vm_prime!(),
             vec![(
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
@@ -388,7 +387,7 @@ mod tests {
     fn run_verify_zero_invalid_memory_insert() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nq, r = divmod(pack(ids.val, PRIME), SECP_P)\nassert r == 0, f\"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}.\"\nids.q = q % PRIME".as_bytes();
         let mut vm = VirtualMachine::new(
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            vm_prime!(),
             vec![(
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
@@ -497,7 +496,7 @@ mod tests {
     fn run_reduce_ok() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nvalue = pack(ids.x, PRIME) % SECP_P".as_bytes();
         let mut vm = VirtualMachine::new(
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            vm_prime!(),
             vec![(
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
@@ -580,7 +579,7 @@ mod tests {
     fn run_reduce_error() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nvalue = pack(ids.x, PRIME) % SECP_P".as_bytes();
         let mut vm = VirtualMachine::new(
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            vm_prime!(),
             vec![(
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
@@ -641,7 +640,7 @@ mod tests {
     fn run_is_zero_pack_ok() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nx = pack(ids.x, PRIME) % SECP_P".as_bytes();
         let mut vm = VirtualMachine::new(
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            vm_prime!(),
             vec![(
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
@@ -701,7 +700,7 @@ mod tests {
     fn run_is_zero_pack_error() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nx = pack(ids.x, PRIME) % SECP_P".as_bytes();
         let mut vm = VirtualMachine::new(
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            vm_prime!(),
             vec![(
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
@@ -755,7 +754,7 @@ mod tests {
     fn run_is_zero_nondet_ok_true() {
         let hint_code = "memory[ap] = to_felt_or_relocatable(x == 0)".as_bytes();
         let mut vm = VirtualMachine::new(
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            vm_prime!(),
             vec![(
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
@@ -798,7 +797,7 @@ mod tests {
     fn run_is_zero_nondet_ok_false() {
         let hint_code = "memory[ap] = to_felt_or_relocatable(x == 0)".as_bytes();
         let mut vm = VirtualMachine::new(
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            vm_prime!(),
             vec![(
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
@@ -841,7 +840,7 @@ mod tests {
     fn run_is_zero_nondet_scope_error() {
         let hint_code = "memory[ap] = to_felt_or_relocatable(x == 0)".as_bytes();
         let mut vm = VirtualMachine::new(
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            vm_prime!(),
             vec![(
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
@@ -879,7 +878,7 @@ mod tests {
     fn run_is_zero_nondet_invalid_memory_insert() {
         let hint_code = "memory[ap] = to_felt_or_relocatable(x == 0)".as_bytes();
         let mut vm = VirtualMachine::new(
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            vm_prime!(),
             vec![(
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
@@ -919,7 +918,7 @@ mod tests {
     fn is_zero_assign_scope_variables_ok() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P\nfrom starkware.python.math_utils import div_mod\n\nvalue = x_inv = div_mod(1, x, SECP_P)".as_bytes();
         let mut vm = VirtualMachine::new(
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            vm_prime!(),
             vec![(
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
@@ -967,7 +966,7 @@ mod tests {
     fn is_zero_assign_scope_variables_scope_error() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P\nfrom starkware.python.math_utils import div_mod\n\nvalue = x_inv = div_mod(1, x, SECP_P)".as_bytes();
         let mut vm = VirtualMachine::new(
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            vm_prime!(),
             vec![(
                 "range_check".to_string(),
                 Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),

--- a/src/vm/hints/secp/field_utils.rs
+++ b/src/vm/hints/secp/field_utils.rs
@@ -132,7 +132,7 @@ pub fn is_zero_nondet(vm: &mut VirtualMachine) -> Result<(), VirtualMachineError
         }
     };
 
-    let value = if x.is_zero() { bigint!(1) } else { bigint!(0) };
+    let value = bigint!(x.is_zero() as usize);
 
     vm.memory
         .insert(&vm.run_context.ap, &MaybeRelocatable::from(value))

--- a/src/vm/hints/secp/secp_utils.rs
+++ b/src/vm/hints/secp/secp_utils.rs
@@ -8,7 +8,7 @@ use num_traits::{Signed, Zero};
 lazy_static! {
     pub static ref BASE_86: BigInt = bigint!(1) << 86_usize;
     pub static ref BASE_86_MAX: BigInt = &*BASE_86 - bigint!(1);
-    pub static ref SECP_P: BigInt = (bigint!(2) << (255))
+    pub static ref SECP_P: BigInt = (bigint!(1) << (256))
         - (1_i64 << 32)
         - (1 << 9)
         - (1 << 8)

--- a/src/vm/hints/secp/secp_utils.rs
+++ b/src/vm/hints/secp/secp_utils.rs
@@ -8,6 +8,14 @@ use num_traits::{Signed, Zero};
 lazy_static! {
     pub static ref BASE_86: BigInt = bigint!(1) << 86_usize;
     pub static ref BASE_86_MAX: BigInt = &*BASE_86 - bigint!(1);
+    pub static ref SECP_P: BigInt = (bigint!(2) << (255))
+        - (1_i64 << 32)
+        - (1 << 9)
+        - (1 << 8)
+        - (1 << 7)
+        - (1 << 6)
+        - (1 << 4)
+        - 1;
 }
 
 /*


### PR DESCRIPTION
# [HINTS]Add implementation for hints on function is_zero (cairo_secp/field.cairo )

## Description

[cairo_secp/field.cairo](https://github.com/starkware-libs/cairo-lang/blob/167b28bcd940fd25ea3816204fa882a0b0a49603/src/starkware/cairo/common/cairo_secp/field.cairo#L97)

* Add SECP_P static item to SecpUtils.
* Update MathUtils::div_mod fn `div_mod(a, b, prime) ->  div_mod(a, b, &prime)`


* Hints implementation:

```
is_zero_pack:
%{
    from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack

    x = pack(ids.x, PRIME) % SECP_P
%}
```

```
is_zero_nondet:
if nondet %{ x == 0 %} != 0:
```

```
is_zero_assign_scope_variables:
%{
    from starkware.cairo.common.cairo_secp.secp_utils import SECP_P
    from starkware.python.math_utils import div_mod

    value = x_inv = div_mod(1, x, SECP_P)
%}
```

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [x] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
