### PR TITLE
Add macros and refactor hint tests

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -105,6 +105,17 @@ pub mod test_utils {
         };
     }
     pub(crate) use mayberelocatable;
+
+    macro_rules! references {
+        ($num: expr) => {{
+            let mut references = HashMap::<usize, HintReference>::new();
+            for i in 0..=$num {
+                references.insert(i, HintReference::new_simple((i as i32 - $num - 1)));
+            }
+            references
+        }};
+    }
+    pub(crate) use references;
 }
 
 #[cfg(test)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -116,6 +116,20 @@ pub mod test_utils {
         }};
     }
     pub(crate) use references;
+
+    macro_rules! vm_with_range_check {
+        () => {
+            VirtualMachine::new(
+                BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+                vec![(
+                    "range_check".to_string(),
+                    Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
+                )],
+                false,
+            )
+        };
+    }
+    pub(crate) use vm_with_range_check;
 }
 
 #[cfg(test)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -130,6 +130,29 @@ pub mod test_utils {
         };
     }
     pub(crate) use vm_with_range_check;
+
+    macro_rules! ids {
+        ( $( $name: expr ),* ) => {
+            {
+                let mut ids = HashMap::<String, BigInt>::new();
+                let mut num = -1;
+                $(
+                    num += 1;
+                    ids_inner!($name, num, ids);
+
+                )*
+                ids
+            }
+        };
+    }
+    pub(crate) use ids;
+
+    macro_rules! ids_inner {
+        ( $name: expr, $num: expr, $ids: expr ) => {
+            $ids.insert(String::from($name), bigint!($num))
+        };
+    }
+    pub(crate) use ids_inner;
 }
 
 #[cfg(test)]

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -51,6 +51,19 @@ pub struct HintReference {
     pub immediate: Option<BigInt>,
 }
 
+impl HintReference {
+    pub fn new_simple(offset1: i32) -> Self {
+        HintReference {
+            register: Register::FP,
+            offset1,
+            offset2: 0,
+            inner_dereference: false,
+            ap_tracking_data: None,
+            immediate: None,
+        }
+    }
+}
+
 pub fn get_hint_variables(vm: &mut VirtualMachine) -> HintVisibleVariables {
     HintVisibleVariables {
         memory: &mut vm.memory,

--- a/src/vm/hints/math_utils.rs
+++ b/src/vm/hints/math_utils.rs
@@ -681,9 +681,10 @@ pub fn assert_lt_felt(
 #[cfg(test)]
 mod tests {
     use crate::types::relocatable::Relocatable;
-    use crate::utils::test_utils::{references, vm_with_range_check};
+    use crate::utils::test_utils::*;
     use crate::vm::hints::execute_hint::get_hint_variables;
     use crate::vm::vm_core::VirtualMachine;
+    use crate::vm::vm_memory::memory::Memory;
     use crate::{
         bigint_str, relocatable,
         types::instruction::Register,
@@ -5934,35 +5935,11 @@ mod tests {
         "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\nassert (ids.a % PRIME) < (ids.b % PRIME), \\\n    f'a = {ids.a % PRIME} is not less than b = {ids.b % PRIME}.'"
         .as_bytes();
         let mut vm = vm_with_range_check!();
-        //Initialize memory segements
-        for _ in 0..3 {
-            vm.segments.add(&mut vm.memory, None);
-        }
-
+        vm.memory = memory![((1, 1), (1))];
         //Initialize fp
         vm.run_context.fp = MaybeRelocatable::from((1, 3));
-
-        //Insert ids.a into memory
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 1)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-
-        //Skip insert ids.b into memory
-        // vm.memory
-        //     .insert(
-        //         &MaybeRelocatable::from((1, 2)),
-        //         &MaybeRelocatable::from(bigint!(2)),
-        //     )
-        //     .unwrap();
-
         //Create incorrects ids
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("a"), bigint!(0));
-        ids.insert(String::from("b"), bigint!(1));
-
+        let ids = ids!["a", "b"];
         //Create references
         vm.references = references!(1);
         let variables = get_hint_variables(&mut vm);

--- a/src/vm/hints/math_utils.rs
+++ b/src/vm/hints/math_utils.rs
@@ -681,6 +681,7 @@ pub fn assert_lt_felt(
 #[cfg(test)]
 mod tests {
     use crate::types::relocatable::Relocatable;
+    use crate::utils::test_utils::references;
     use crate::vm::hints::execute_hint::get_hint_variables;
     use crate::vm::vm_core::VirtualMachine;
     use crate::{
@@ -5970,30 +5971,7 @@ mod tests {
         ids.insert(String::from("b"), bigint!(1));
 
         //Create references
-        vm.references = HashMap::from([
-            (
-                0,
-                HintReference {
-                    register: Register::FP,
-                    offset1: -2,
-                    offset2: 0,
-                    inner_dereference: false,
-                    ap_tracking_data: None,
-                    immediate: None,
-                },
-            ),
-            (
-                1,
-                HintReference {
-                    register: Register::FP,
-                    offset1: -1,
-                    offset2: 0,
-                    inner_dereference: false,
-                    ap_tracking_data: None,
-                    immediate: None,
-                },
-            ),
-        ]);
+        vm.references = references!(1);
         let variables = get_hint_variables(&mut vm);
         //Execute the hint
         assert_eq!(

--- a/src/vm/hints/math_utils.rs
+++ b/src/vm/hints/math_utils.rs
@@ -681,7 +681,7 @@ pub fn assert_lt_felt(
 #[cfg(test)]
 mod tests {
     use crate::types::relocatable::Relocatable;
-    use crate::utils::test_utils::references;
+    use crate::utils::test_utils::{references, vm_with_range_check};
     use crate::vm::hints::execute_hint::get_hint_variables;
     use crate::vm::vm_core::VirtualMachine;
     use crate::{
@@ -5933,14 +5933,7 @@ mod tests {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\nassert (ids.a % PRIME) < (ids.b % PRIME), \\\n    f'a = {ids.a % PRIME} is not less than b = {ids.b % PRIME}.'"
         .as_bytes();
-        let mut vm = VirtualMachine::new(
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-            vec![(
-                "range_check".to_string(),
-                Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
-            )],
-            false,
-        );
+        let mut vm = vm_with_range_check!();
         //Initialize memory segements
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);


### PR DESCRIPTION
Add the following macros:

- `references`: Initializes a HintReference hasp given the number of references
- `vm_with_range_check`: Creates a vm with RangeCheckBuiltin
- `ids`: Created an ids dictionary from a list of names
