### PR TITLE
Add macros for vm, ids, references + example

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -115,6 +115,67 @@ pub mod test_utils {
         };
     }
     pub(crate) use mayberelocatable;
+
+    macro_rules! references {
+        ($num: expr) => {{
+            let mut references = HashMap::<usize, HintReference>::new();
+            for i in 0..$num {
+                references.insert(i, HintReference::new_simple((i as i32 - $num)));
+            }
+            references
+        }};
+    }
+    pub(crate) use references;
+
+    macro_rules! vm_with_range_check {
+        () => {
+            VirtualMachine::new(
+                BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+                vec![(
+                    "range_check".to_string(),
+                    Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
+                )],
+                false,
+                &HINT_EXECUTOR,
+            )
+        };
+    }
+    pub(crate) use vm_with_range_check;
+
+    macro_rules! vm {
+        () => {
+            VirtualMachine::new(
+                BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+                vec![],
+                false,
+                &HINT_EXECUTOR,
+            )
+        };
+    }
+    pub(crate) use vm;
+
+    macro_rules! ids {
+        ( $( $name: expr ),* ) => {
+            {
+                let mut ids = HashMap::<String, BigInt>::new();
+                let mut num = -1;
+                $(
+                    num += 1;
+                    ids_inner!($name, num, ids);
+
+                )*
+                ids
+            }
+        };
+    }
+    pub(crate) use ids;
+
+    macro_rules! ids_inner {
+        ( $name: expr, $num: expr, $ids: expr ) => {
+            $ids.insert(String::from($name), bigint!($num))
+        };
+    }
+    pub(crate) use ids_inner;
 }
 
 #[cfg(test)]

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -58,6 +58,19 @@ pub struct HintReference {
     pub immediate: Option<BigInt>,
 }
 
+impl HintReference {
+    pub fn new_simple(offset1: i32) -> Self {
+        HintReference {
+            register: Register::FP,
+            offset1,
+            offset2: 0,
+            inner_dereference: false,
+            ap_tracking_data: None,
+            immediate: None,
+            dereference: false,
+        }
+    }
+}
 pub struct BuiltinHintExecutor {}
 
 impl HintExecutor for BuiltinHintExecutor {

--- a/src/vm/hints/uint256_utils.rs
+++ b/src/vm/hints/uint256_utils.rs
@@ -257,6 +257,7 @@ mod tests {
     use crate::bigint_str;
     use crate::types::instruction::Register;
     use crate::types::relocatable::MaybeRelocatable;
+    use crate::utils::test_utils::vm_with_range_check;
     use crate::vm::errors::memory_errors::MemoryError;
     use crate::vm::hints::execute_hint::{BuiltinHintExecutor, HintReference};
     use crate::{bigint, vm::runners::builtin_runner::RangeCheckBuiltinRunner};
@@ -267,22 +268,13 @@ mod tests {
     #[test]
     fn run_uint256_add_ok() {
         let hint_code = "sum_low = ids.a.low + ids.b.low\nids.carry_low = 1 if sum_low >= ids.SHIFT else 0\nsum_high = ids.a.high + ids.b.high + ids.carry_low\nids.carry_high = 1 if sum_high >= ids.SHIFT else 0";
-        let mut vm = VirtualMachine::new(
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-            vec![(
-                "range_check".to_string(),
-                Box::new(RangeCheckBuiltinRunner::new(true, bigint!(8), 8)),
-            )],
-            false,
-            &HINT_EXECUTOR,
-        );
+        let mut vm = vm_with_range_check!();
         for _ in 0..3 {
             vm.segments.add(&mut vm.memory, None);
         }
 
         //Initialize fp
         vm.run_context.fp = MaybeRelocatable::from((1, 10));
-
         //Create ids
         let mut ids = HashMap::<String, BigInt>::new();
         ids.insert(String::from("a"), bigint!(0));


### PR DESCRIPTION
Add the following macros:

- `references`: Initializes a HintReference hasp given the number of references
- `ids`: Creates an ids dictionary from a list of names
- `vm_with_range_check`: Creates a VM with RangeCheckBuiltin
- `vm`: Creates a VM

Adds use example in dict_hint_utils.rs (Test `run_dict_read_valid`)

