### PR TITLE
Fix dereference value in HintReference::new_simple

### DIFF
--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -67,7 +67,7 @@ impl HintReference {
             inner_dereference: false,
             ap_tracking_data: None,
             immediate: None,
-            dereference: false,
+            dereference: true,
         }
     }
 }


### PR DESCRIPTION
Fix HintReference::new_simple() to produce references with dereference `true` instead of `false`
