### PR TITLE
Fix EcUtils::compute_slope

### DIFF
--- a/src/vm/hints/secp/ec_utils.rs
+++ b/src/vm/hints/secp/ec_utils.rs
@@ -135,11 +135,11 @@ pub fn compute_slope(
     );
 
     let value = line_slope(
-        (
+        &(
             pack(point0_x_d0, point0_x_d1, point0_x_d2, &vm.prime),
             pack(point0_y_d0, point0_y_d1, point0_y_d2, &vm.prime),
         ),
-        (
+        &(
             pack(point1_x_d0, point1_x_d1, point1_x_d2, &vm.prime),
             pack(point1_y_d0, point1_y_d1, point1_y_d2, &vm.prime),
         ),


### PR DESCRIPTION
# Fix EcUtils::compute_slope

A minor refactor in the math_utils::line_slope function broke the EcUtils::compute_slope functions

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
