### PR TITLE
Add macros for testing: check_memory, check_memory_address and  not_continuous_references macros for testing

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -152,7 +152,7 @@ pub mod test_utils {
     }
     pub(crate) use references;
 
-    macro_rules! no_continues_references {
+    macro_rules! not_continuous_references {
         ( $( $offset:expr ),*) => {
             {
             let mut references = HashMap::<usize, HintReference>::new();
@@ -166,7 +166,7 @@ pub mod test_utils {
         }
     };
     }
-    pub(crate) use no_continues_references;
+    pub(crate) use not_continuous_references;
 
     macro_rules! vm_with_range_check {
         () => {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -127,6 +127,22 @@ pub mod test_utils {
     }
     pub(crate) use references;
 
+    macro_rules! no_continues_references {
+        ( $( $offset:expr ),*) => {
+            {
+            let mut references = HashMap::<usize, HintReference>::new();
+            let mut index = -1;
+
+            $(
+                index += 1;
+                references.insert(index as usize, HintReference::new_simple(($offset)));
+            )*
+        references
+        }
+    };
+    }
+    pub(crate) use no_continues_references;
+
     macro_rules! vm_with_range_check {
         () => {
             VirtualMachine::new(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -106,6 +106,31 @@ pub mod test_utils {
     }
     pub(crate) use memory_inner;
 
+    macro_rules! check_memory {
+        ( $mem: expr, $( (($si:expr, $off:expr), $val:tt) ),* ) => {
+            $(
+                check_memory_address!($mem, ($si, $off), $val);
+            )*
+        };
+    }
+    pub(crate) use check_memory;
+
+    macro_rules! check_memory_address {
+        ($mem:expr, ($si:expr, $off:expr), ($sival:expr, $offval: expr)) => {
+            assert_eq!(
+                $mem.get(&mayberelocatable!($si, $off)),
+                Ok(Some(&mayberelocatable!($sival, $offval)))
+            )
+        };
+        ($mem:expr, ($si:expr, $off:expr), $val:expr) => {
+            assert_eq!(
+                $mem.get(&mayberelocatable!($si, $off)),
+                Ok(Some(&mayberelocatable!($val)))
+            )
+        };
+    }
+    pub(crate) use check_memory_address;
+
     macro_rules! mayberelocatable {
         ($val1 : expr, $val2 : expr) => {
             MaybeRelocatable::from(($val1, $val2))

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -221,9 +221,13 @@ pub mod test_utils {
 
 #[cfg(test)]
 mod test {
+
     use super::*;
+    use crate::types::instruction::Register;
     use crate::vm::errors::memory_errors::MemoryError;
+    use crate::vm::hints::execute_hint::HintReference;
     use crate::{types::relocatable::MaybeRelocatable, vm::vm_memory::memory::Memory};
+    use std::collections::HashMap;
 
     #[test]
     fn to_field_element_no_change_a() {
@@ -309,5 +313,84 @@ mod test {
             .unwrap();
         let mem = memory![((1, 2), 1), ((1, 1), (1, 0))];
         assert_eq!(memory.data, mem.data);
+    }
+
+    #[test]
+    fn check_memory_macro_test() {
+        let mut memory = Memory::new();
+        for _ in 0..2 {
+            memory.data.push(Vec::new());
+        }
+        memory
+            .insert(
+                &MaybeRelocatable::from((1, 1)),
+                &MaybeRelocatable::from((1, 0)),
+            )
+            .unwrap();
+
+        memory
+            .insert(
+                &MaybeRelocatable::from((1, 2)),
+                &MaybeRelocatable::from(bigint!(1)),
+            )
+            .unwrap();
+
+        check_memory![memory, ((1, 1), (1, 0)), ((1, 2), 1)];
+    }
+
+    #[test]
+    fn check_memory_address_macro_test() {
+        let mut memory = Memory::new();
+        for _ in 0..2 {
+            memory.data.push(Vec::new());
+        }
+        memory
+            .insert(
+                &MaybeRelocatable::from((1, 1)),
+                &MaybeRelocatable::from((1, 0)),
+            )
+            .unwrap();
+
+        memory
+            .insert(
+                &MaybeRelocatable::from((1, 2)),
+                &MaybeRelocatable::from(bigint!(1)),
+            )
+            .unwrap();
+
+        check_memory_address!(memory, (1, 1), (1, 0));
+        check_memory_address!(memory, (1, 2), 1);
+    }
+
+    #[test]
+    fn check_not_continuous_references_macro_test() {
+        let references = HashMap::from([
+            (
+                0,
+                HintReference {
+                    register: Register::FP,
+                    offset1: -10,
+                    offset2: 0,
+                    inner_dereference: false,
+                    ap_tracking_data: None,
+                    immediate: None,
+                    dereference: true,
+                },
+            ),
+            (
+                1,
+                HintReference {
+                    register: Register::FP,
+                    offset1: -23,
+                    offset2: 0,
+                    inner_dereference: false,
+                    ap_tracking_data: None,
+                    immediate: None,
+                    dereference: true,
+                },
+            ),
+        ]);
+
+        assert_eq!(references, not_continuous_references![-10, -23])
     }
 }

--- a/src/vm/hints/secp/bigint_utils.rs
+++ b/src/vm/hints/secp/bigint_utils.rs
@@ -115,24 +115,12 @@ mod tests {
             Ok(())
         );
         //Check hint memory inserts
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 11))),
-            Ok(Some(&MaybeRelocatable::from(bigint_str!(
-                b"773712524553362"
-            ))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 12))),
-            Ok(Some(&MaybeRelocatable::from(bigint_str!(
-                b"57408430697461422066401280"
-            ))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 13))),
-            Ok(Some(&MaybeRelocatable::from(bigint_str!(
-                b"1292469707114105"
-            ))))
-        );
+        check_memory![
+            &vm.memory,
+            ((1, 11), 773712524553362_u64),
+            ((1, 12), 57408430697461422066401280_u128),
+            ((1, 13), 1292469707114105_u64)
+        ];
     }
 
     #[test]

--- a/src/vm/hints/secp/ec_utils.rs
+++ b/src/vm/hints/secp/ec_utils.rs
@@ -408,7 +408,6 @@ mod tests {
     use super::*;
     use crate::bigint_str;
     use crate::types::exec_scope::PyValueType;
-    use crate::types::instruction::Register;
     use crate::types::relocatable::MaybeRelocatable;
     use crate::utils::test_utils::*;
     use crate::vm::errors::memory_errors::MemoryError;
@@ -538,38 +537,7 @@ mod tests {
         let ids = ids!["point0", "point1"];
 
         //Create references
-        vm.references = HashMap::from([
-            (
-                0,
-                HintReference {
-                    register: Register::FP,
-                    offset1: -14,
-                    offset2: 0,
-                    dereference: false,
-                    inner_dereference: false,
-                    immediate: None,
-                    ap_tracking_data: Some(ApTracking {
-                        group: 1,
-                        offset: 0,
-                    }),
-                },
-            ),
-            (
-                1,
-                HintReference {
-                    register: Register::FP,
-                    offset1: -8,
-                    offset2: 0,
-                    dereference: false,
-                    inner_dereference: false,
-                    immediate: None,
-                    ap_tracking_data: Some(ApTracking {
-                        group: 1,
-                        offset: 0,
-                    }),
-                },
-            ),
-        ]);
+        vm.references = no_continues_references![-14, -8];
 
         //Check 'value' is not defined in the vm scope
         assert_eq!(
@@ -628,51 +596,11 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = MaybeRelocatable::from((1, 10));
 
-        //Initialize ap
-        vm.run_context.ap = MaybeRelocatable::from((1, 10));
-
         //Create ids
         let ids = ids!["point", "slope"];
 
         //Create references
-        vm.references = HashMap::from([
-            (
-                0,
-                HintReference {
-                    register: Register::FP,
-                    offset1: -10,
-                    offset2: 0,
-                    dereference: false,
-                    inner_dereference: false,
-                    immediate: None,
-                    ap_tracking_data: Some(ApTracking {
-                        group: 1,
-                        offset: 0,
-                    }),
-                },
-            ),
-            (
-                1,
-                HintReference {
-                    register: Register::AP,
-                    offset1: -4,
-                    offset2: 0,
-                    dereference: false,
-                    inner_dereference: false,
-                    immediate: None,
-                    ap_tracking_data: Some(ApTracking {
-                        group: 1,
-                        offset: 0,
-                    }),
-                },
-            ),
-        ]);
-
-        //Create ap tracking
-        let ap_tracking = ApTracking {
-            group: 1,
-            offset: 0,
-        };
+        vm.references = no_continues_references![-10, -4];
 
         //Check 'slope' is not defined in the vm scope
         assert_eq!(
@@ -701,7 +629,7 @@ mod tests {
         //Execute the hint
         assert_eq!(
             vm.hint_executor
-                .execute_hint(&mut vm, &hint_code, &ids, &ap_tracking),
+                .execute_hint(&mut vm, &hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
 
@@ -851,59 +779,7 @@ mod tests {
         let ids = ids!["point0", "point1", "slope"];
 
         //Create references
-        vm.references = HashMap::from([
-            (
-                0,
-                HintReference {
-                    register: Register::FP,
-                    offset1: -15,
-                    offset2: 0,
-                    dereference: false,
-                    inner_dereference: false,
-                    immediate: None,
-                    ap_tracking_data: Some(ApTracking {
-                        group: 1,
-                        offset: 0,
-                    }),
-                },
-            ),
-            (
-                1,
-                HintReference {
-                    register: Register::FP,
-                    offset1: -9,
-                    offset2: 0,
-                    dereference: false,
-                    inner_dereference: false,
-                    immediate: None,
-                    ap_tracking_data: Some(ApTracking {
-                        group: 1,
-                        offset: 0,
-                    }),
-                },
-            ),
-            (
-                2,
-                HintReference {
-                    register: Register::AP,
-                    offset1: -11,
-                    offset2: 0,
-                    dereference: false,
-                    inner_dereference: false,
-                    immediate: None,
-                    ap_tracking_data: Some(ApTracking {
-                        group: 1,
-                        offset: 0,
-                    }),
-                },
-            ),
-        ]);
-
-        //Create ap tracking
-        let ap_tracking = ApTracking {
-            group: 1,
-            offset: 0,
-        };
+        vm.references = no_continues_references![-15, -9, -6];
 
         //Check 'value' is not defined in the vm scope
         assert_eq!(
@@ -920,7 +796,7 @@ mod tests {
         //Execute the hint
         assert_eq!(
             vm.hint_executor
-                .execute_hint(&mut vm, &hint_code, &ids, &ap_tracking),
+                .execute_hint(&mut vm, &hint_code, &ids, &ApTracking::new()),
             Ok(())
         );
 

--- a/src/vm/hints/secp/ec_utils.rs
+++ b/src/vm/hints/secp/ec_utils.rs
@@ -917,9 +917,6 @@ mod tests {
         );
 
         //Check hint memory inserts
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 2))),
-            Ok(Some(&MaybeRelocatable::from(bigint_str!(b"0"))))
-        );
+        check_memory![&vm.memory, ((1, 2), 0)];
     }
 }

--- a/src/vm/hints/secp/ec_utils.rs
+++ b/src/vm/hints/secp/ec_utils.rs
@@ -537,7 +537,7 @@ mod tests {
         let ids = ids!["point0", "point1"];
 
         //Create references
-        vm.references = no_continues_references![-14, -8];
+        vm.references = not_continuous_references![-14, -8];
 
         //Check 'value' is not defined in the vm scope
         assert_eq!(
@@ -600,7 +600,7 @@ mod tests {
         let ids = ids!["point", "slope"];
 
         //Create references
-        vm.references = no_continues_references![-10, -4];
+        vm.references = not_continuous_references![-10, -4];
 
         //Check 'slope' is not defined in the vm scope
         assert_eq!(
@@ -779,7 +779,7 @@ mod tests {
         let ids = ids!["point0", "point1", "slope"];
 
         //Create references
-        vm.references = no_continues_references![-15, -9, -6];
+        vm.references = not_continuous_references![-15, -9, -6];
 
         //Check 'value' is not defined in the vm scope
         assert_eq!(

--- a/src/vm/hints/uint256_utils.rs
+++ b/src/vm/hints/uint256_utils.rs
@@ -348,14 +348,7 @@ mod tests {
         );
 
         //Check hint memory inserts
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 12))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 13))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(1))))
-        );
+        check_memory![&vm.memory, ((1, 12), 0), ((1, 13), 1)];
     }
 
     #[test]
@@ -437,20 +430,12 @@ mod tests {
         );
 
         //Check hint memory inserts
-        //ids.low
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 10))),
-            Ok(Some(&MaybeRelocatable::from(bigint_str!(
-                b"7249717543555297151"
-            ))))
-        );
-        //ids.high
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 11))),
-            Ok(Some(&MaybeRelocatable::from(bigint_str!(
-                b"46131785404667"
-            ))))
-        );
+        //ids.low, ids.high
+        check_memory![
+            &vm.memory,
+            ((1, 10), 7249717543555297151_u64),
+            ((1, 11), 46131785404667_u64)
+        ];
     }
 
     #[test]
@@ -532,18 +517,8 @@ mod tests {
         );
 
         //Check hint memory inserts
-        //ids.root.low
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 5))),
-            Ok(Some(&MaybeRelocatable::from(bigint_str!(
-                b"48805497317890012913"
-            ))))
-        );
-        //ids.root.high
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 6))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
+        //ids.root.low, ids.root.high
+        check_memory![&vm.memory, ((1, 5), 48805497317890012913_u128), ((1, 6), 0)];
     }
 
     #[test]
@@ -653,10 +628,7 @@ mod tests {
 
         //Check hint memory insert
         //memory[ap] = 1 if 0 <= (ids.a.high % PRIME) < 2 ** 127 else 0
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 5))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(1))))
-        );
+        check_memory![&vm.memory, ((1, 5), 1)];
     }
 
     #[test]
@@ -694,10 +666,7 @@ mod tests {
 
         //Check hint memory insert
         //memory[ap] = 1 if 0 <= (ids.a.high % PRIME) < 2 ** 127 else 0
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 5))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
+        check_memory![&vm.memory, ((1, 5), 0)];
     }
 
     #[test]
@@ -770,26 +739,15 @@ mod tests {
         );
 
         //Check hint memory inserts
-        //ids.quotient.low
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 10))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(10))))
-        );
-        //ids.quotient.high
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 11))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        //ids.remainder.low
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 12))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(59))))
-        );
-        //ids.remainder.high
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 13))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(2))))
-        );
+        //ids.quotient.low, ids.quotient.high, ids.remainder.low, ids.remainder.high
+
+        check_memory![
+            &vm.memory,
+            ((1, 10), 10),
+            ((1, 11), 0),
+            ((1, 12), 59),
+            ((1, 13), 2)
+        ];
     }
 
     #[test]


### PR DESCRIPTION
# Add macros for testing: check_memory, check_memory_address and  not_continuous_references macros for testing

## Description

Add the following macros to avoid boilerplate code in testing:
* check_memory: Asserts memory addresses and values
* check_memory_address: Asserts memory address and value
* not_continuous_references: Create hint references with no continuous offset


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
