### PR TITLE
Dict hints integration tests

### DIFF
--- a/cairo_programs/benchmarks/dict_integration_benchmark.cairo
+++ b/cairo_programs/benchmarks/dict_integration_benchmark.cairo
@@ -1,7 +1,7 @@
 from dict_integration_tests import test_integration 
 
 func main{range_check_ptr : felt}():
-    test_integration(1000)
+    test_integration(10000)
 
     return ()
 end

--- a/cairo_programs/benchmarks/dict_integration_benchmark.cairo
+++ b/cairo_programs/benchmarks/dict_integration_benchmark.cairo
@@ -1,7 +1,7 @@
-from dict_integration_tests import test_integration 
+from dict_integration_tests import run_tests
 
 func main{range_check_ptr : felt}():
-    test_integration(10000)
+    run_tests(100)
 
     return ()
 end

--- a/cairo_programs/benchmarks/dict_integration_benchmark.cairo
+++ b/cairo_programs/benchmarks/dict_integration_benchmark.cairo
@@ -1,0 +1,7 @@
+from dict_integration_tests import test_integration 
+
+func main{range_check_ptr : felt}():
+    test_integration(1000)
+
+    return ()
+end

--- a/cairo_programs/dict_integration_benchmark.cairo
+++ b/cairo_programs/dict_integration_benchmark.cairo
@@ -1,0 +1,7 @@
+from dict_integration_tests import test_integration 
+
+func main{range_check_ptr : felt}():
+    test_integration(1000)
+
+    return ()
+end

--- a/cairo_programs/dict_integration_benchmark.cairo
+++ b/cairo_programs/dict_integration_benchmark.cairo
@@ -1,7 +1,0 @@
-from dict_integration_tests import test_integration 
-
-func main{range_check_ptr : felt}():
-    test_integration(1000)
-
-    return ()
-end

--- a/cairo_programs/dict_integration_tests.cairo
+++ b/cairo_programs/dict_integration_tests.cairo
@@ -53,8 +53,11 @@ func check_squashed_dictionary{dict_end : DictAccess*}(iter : felt, last : felt,
     return check_squashed_dictionary{dict_end=dict_end}(iter + 1, last, init_base, init_step, final_base, final_step) 
 end
 
-func test_integration{range_check_ptr : felt}(iters : felt) -> ():
+func test_integration{range_check_ptr : felt}(iter : felt, last : felt) -> ():
     alloc_locals
+    if iter == last:
+        return ()
+    end
 
     let init_base = 1
     let init_step = 2
@@ -65,17 +68,23 @@ func test_integration{range_check_ptr : felt}(iters : felt) -> ():
     let (local dict_start : DictAccess*) = default_dict_new(9998789)
     let dict_end = dict_start
 
-    fill_dictionary{dict_start=dict_end}(base=init_base, step=init_step, iter=0, last=iters)
-    update_dictionary{dict_start=dict_end}(base=final_base, step=final_step, iter=0, last=iters)
+    fill_dictionary{dict_start=dict_end}(base=init_base, step=init_step, iter=0, last=last)
+    update_dictionary{dict_start=dict_end}(base=final_base, step=final_step, iter=0, last=last)
 
-    let (_squashed_dict_start, squashed_dict_end) = dict_squash(dict_start, dict_end)
-    check_squashed_dictionary{dict_end=squashed_dict_end}(iter=0, last=iters, init_base=init_base, init_step=init_step, final_base=final_base, final_step=final_step)
+    let (squashed_dict_start, squashed_dict_end) = dict_squash(dict_start, dict_end)
+    check_squashed_dictionary{dict_end=squashed_dict_end}(iter=0, last=last, init_base=init_base, init_step=init_step, final_base=final_base, final_step=final_step)
 
-    return ()
+    return test_integration(iter + 1, last) 
+end
+
+func run_tests{range_check_ptr}(last : felt):
+    test_integration(0, last)
+
+    return()
 end
 
 func main{range_check_ptr : felt}():
-    test_integration(10)
+    run_tests(10)
 
     return ()
 end

--- a/cairo_programs/dict_integration_tests.cairo
+++ b/cairo_programs/dict_integration_tests.cairo
@@ -1,3 +1,5 @@
+%builtins range_check
+
 from starkware.cairo.common.default_dict import default_dict_new
 from starkware.cairo.common.dict_access import DictAccess
 from starkware.cairo.common.dict import dict_read, dict_write, dict_update, dict_squash
@@ -33,18 +35,47 @@ func update_dictionary{dict_start : DictAccess*}(base : felt, step : felt, iter 
     return update_dictionary{dict_start=dict_start}(base, step, iter + 1, last)
 end
 
-func test_integration(iters : felt) -> ():
+func check_squashed_dictionary{dict_end : DictAccess*}(iter : felt, last : felt, init_base : felt, init_step : felt, final_base : felt, final_step : felt):
+    alloc_locals
+    if iter == last:
+        return ()
+    end
+
+    let prev_val : felt = init_base + init_step * iter
+    let new_val : felt = final_base + final_step * iter
+
+    assert dict_end[iter] = DictAccess(key=iter, prev_value=prev_val, new_value=new_val)
+
+    let a = dict_end[iter]
+    let hola = a.prev_value
+    let chau = a.new_value
+
+    return check_squashed_dictionary{dict_end=dict_end}(iter + 1, last, init_base, init_step, final_base, final_step) 
+end
+
+func test_integration{range_check_ptr : felt}(iters : felt) -> ():
     alloc_locals
 
-    let (local my_dict : DictAccess*) = default_dict_new(0)
-    fill_dictionary{dict_start=my_dict}(base=1, step=2, iter=0, last=iters)
-    update_dictionary{dict_start=my_dict}(base=2, step=3, iter=0, last=iters)
+    let init_base = 1
+    let init_step = 2
+
+    let final_base = 2
+    let final_step = 3
+
+    let (local dict_start : DictAccess*) = default_dict_new(9998789)
+    let dict_end = dict_start
+
+    fill_dictionary{dict_start=dict_end}(base=init_base, step=init_step, iter=0, last=iters)
+    update_dictionary{dict_start=dict_end}(base=final_base, step=final_step, iter=0, last=iters)
+
+    let (_squashed_dict_start, squashed_dict_end) = dict_squash(dict_start, dict_end)
+    check_squashed_dictionary{dict_end=squashed_dict_end}(iter=0, last=iters, init_base=init_base, init_step=init_step, final_base=final_base, final_step=final_step)
 
     return ()
 end
 
-func main():
-    test_integration(1000)
+func main{range_check_ptr : felt}():
+    test_integration(10)
 
     return ()
 end

--- a/cairo_programs/dict_integration_tests.cairo
+++ b/cairo_programs/dict_integration_tests.cairo
@@ -1,0 +1,50 @@
+from starkware.cairo.common.default_dict import default_dict_new
+from starkware.cairo.common.dict_access import DictAccess
+from starkware.cairo.common.dict import dict_read, dict_write, dict_update, dict_squash
+
+func fill_dictionary{dict_start : DictAccess*}(base : felt, step : felt, iter : felt, last : felt):
+    alloc_locals
+    if iter == last:
+        return ()
+    end
+
+    let new_val : felt = base + step * iter
+
+    dict_write{dict_ptr=dict_start}(key=iter, new_value=new_val)
+    let (local val : felt) = dict_read{dict_ptr=dict_start}(key=iter)
+    assert val = new_val
+
+    return fill_dictionary{dict_start=dict_start}(base, step, iter + 1, last)
+end
+
+func update_dictionary{dict_start : DictAccess*}(base : felt, step : felt, iter : felt, last : felt):
+    alloc_locals
+    if iter == last:
+        return ()
+    end
+
+    let (local prev_val : felt) = dict_read{dict_ptr=dict_start}(key=iter)
+    let new_val : felt = base + step * iter
+    
+    dict_update{dict_ptr=dict_start}(key=iter, prev_value=prev_val, new_value=new_val)
+    let (local val : felt) = dict_read{dict_ptr=dict_start}(key=iter)
+    assert val = new_val
+
+    return update_dictionary{dict_start=dict_start}(base, step, iter + 1, last)
+end
+
+func test_integration(iters : felt) -> ():
+    alloc_locals
+
+    let (local my_dict : DictAccess*) = default_dict_new(0)
+    fill_dictionary{dict_start=my_dict}(base=1, step=2, iter=0, last=iters)
+    update_dictionary{dict_start=my_dict}(base=2, step=3, iter=0, last=iters)
+
+    return ()
+end
+
+func main():
+    test_integration(1000)
+
+    return ()
+end

--- a/tests/cairo_run_test.rs
+++ b/tests/cairo_run_test.rs
@@ -531,3 +531,13 @@ fn cairo_run_memory_module_integration() {
     )
     .expect("Couldn't run program");
 }
+
+#[test]
+fn cairo_run_dict_integration() {
+    cairo_run::cairo_run(
+        Path::new("cairo_programs/dict_integration_tests.json"),
+        false,
+        &HINT_EXECUTOR,
+    )
+    .expect("Couldn't run program");
+}


### PR DESCRIPTION
# Dict modules integration test

## Description
Integration tests for dict related functions that use hints were added, as well as a cairo program for benchmarking. The number of iterations for the benchmarking program has been set to 100 so that it takes ~900ms to run.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
