### PR TITLE
Separate VM from Hint Execution: Phase 4 (Move DictManager to the ExecutionScopes)

### DIFF
--- a/src/types/exec_scope.rs
+++ b/src/types/exec_scope.rs
@@ -1,6 +1,9 @@
 use crate::{
     any_box,
-    vm::errors::{exec_scope_errors::ExecScopeError, vm_errors::VirtualMachineError},
+    vm::{
+        errors::{exec_scope_errors::ExecScopeError, vm_errors::VirtualMachineError},
+        hints::dict_manager::DictManager,
+    },
 };
 use num_bigint::BigInt;
 use std::{any::Any, collections::HashMap};
@@ -212,6 +215,30 @@ impl ExecutionScopesProxy<'_> {
             }
         }
         val.ok_or_else(|| VirtualMachineError::VariableNotInScopeError(name.to_string()))
+    }
+
+    //Returns a reference to the value in the dict manager
+    pub fn get_dict_manager_ref(&self) -> Result<&DictManager, VirtualMachineError> {
+        let mut val: Option<&DictManager> = None;
+        if let Some(variable) = self.get_local_variables()?.get("dict_manager") {
+            if let Some(dict_manager) = variable.downcast_ref::<DictManager>() {
+                val = Some(dict_manager);
+            }
+        }
+        val.ok_or_else(|| VirtualMachineError::VariableNotInScopeError("dict_manager".to_string()))
+    }
+    //Returns a mutable reference to the dict manager
+    pub fn get_dict_manager_mut(
+        &mut self,
+        name: &str,
+    ) -> Result<&mut DictManager, VirtualMachineError> {
+        let mut val: Option<&mut DictManager> = None;
+        if let Some(variable) = self.get_local_variables_mut()?.get_mut("dict_manager") {
+            if let Some(dict_manager) = variable.downcast_mut::<DictManager>() {
+                val = Some(dict_manager);
+            }
+        }
+        val.ok_or_else(|| VirtualMachineError::VariableNotInScopeError("dict_manager".to_string()))
     }
 
     //Returns a mutable reference to the value in the current execution scope that matches the name and is of type DictBigIntListU64

--- a/src/types/exec_scope.rs
+++ b/src/types/exec_scope.rs
@@ -6,7 +6,7 @@ use crate::{
     },
 };
 use num_bigint::BigInt;
-use std::{any::Any, collections::HashMap};
+use std::{any::Any, cell::RefCell, collections::HashMap, rc::Rc};
 
 pub struct ExecutionScopes {
     pub data: Vec<HashMap<String, Box<dyn Any>>>,
@@ -218,32 +218,11 @@ impl ExecutionScopesProxy<'_> {
     }
 
     //Returns the value in the dict manager
-    pub fn get_dict_manager_copy(&self) -> Result<DictManager, VirtualMachineError> {
-        let mut val: Option<DictManager> = None;
+    pub fn get_dict_manager(&self) -> Result<Rc<RefCell<DictManager>>, VirtualMachineError> {
+        let mut val: Option<Rc<RefCell<DictManager>>> = None;
         if let Some(variable) = self.get_local_variables()?.get("dict_manager") {
-            if let Some(dict_manager) = variable.downcast_ref::<DictManager>() {
+            if let Some(dict_manager) = variable.downcast_ref::<Rc<RefCell<DictManager>>>() {
                 val = Some(dict_manager.clone());
-            }
-        }
-        val.ok_or_else(|| VirtualMachineError::VariableNotInScopeError("dict_manager".to_string()))
-    }
-
-    //Returns a reference to the value in the dict manager
-    pub fn get_dict_manager_ref(&self) -> Result<&DictManager, VirtualMachineError> {
-        let mut val: Option<&DictManager> = None;
-        if let Some(variable) = self.get_local_variables()?.get("dict_manager") {
-            if let Some(dict_manager) = variable.downcast_ref::<DictManager>() {
-                val = Some(dict_manager);
-            }
-        }
-        val.ok_or_else(|| VirtualMachineError::VariableNotInScopeError("dict_manager".to_string()))
-    }
-    //Returns a mutable reference to the dict manager
-    pub fn get_dict_manager_mut(&mut self) -> Result<&mut DictManager, VirtualMachineError> {
-        let mut val: Option<&mut DictManager> = None;
-        if let Some(variable) = self.get_local_variables_mut()?.get_mut("dict_manager") {
-            if let Some(dict_manager) = variable.downcast_mut::<DictManager>() {
-                val = Some(dict_manager);
             }
         }
         val.ok_or_else(|| VirtualMachineError::VariableNotInScopeError("dict_manager".to_string()))

--- a/src/types/exec_scope.rs
+++ b/src/types/exec_scope.rs
@@ -27,7 +27,7 @@ pub fn get_exec_scopes_proxy(exec_scopes: &mut ExecutionScopes) -> ExecutionScop
 
 impl ExecutionScopesProxy<'_> {
     pub fn enter_scope(&mut self, new_scope_locals: HashMap<String, Box<dyn Any>>) {
-        self.scopes.enter_scope(new_scope_locals)
+        self.scopes.enter_scope(new_scope_locals);
     }
 
     pub fn exit_scope(&mut self) -> Result<(), ExecScopeError> {
@@ -215,6 +215,17 @@ impl ExecutionScopesProxy<'_> {
             }
         }
         val.ok_or_else(|| VirtualMachineError::VariableNotInScopeError(name.to_string()))
+    }
+
+    //Returns the value in the dict manager
+    pub fn get_dict_manager_copy(&self) -> Result<DictManager, VirtualMachineError> {
+        let mut val: Option<DictManager> = None;
+        if let Some(variable) = self.get_local_variables()?.get("dict_manager") {
+            if let Some(dict_manager) = variable.downcast_ref::<DictManager>() {
+                val = Some(dict_manager.clone());
+            }
+        }
+        val.ok_or_else(|| VirtualMachineError::VariableNotInScopeError("dict_manager".to_string()))
     }
 
     //Returns a reference to the value in the dict manager

--- a/src/types/exec_scope.rs
+++ b/src/types/exec_scope.rs
@@ -228,10 +228,7 @@ impl ExecutionScopesProxy<'_> {
         val.ok_or_else(|| VirtualMachineError::VariableNotInScopeError("dict_manager".to_string()))
     }
     //Returns a mutable reference to the dict manager
-    pub fn get_dict_manager_mut(
-        &mut self,
-        name: &str,
-    ) -> Result<&mut DictManager, VirtualMachineError> {
+    pub fn get_dict_manager_mut(&mut self) -> Result<&mut DictManager, VirtualMachineError> {
         let mut val: Option<&mut DictManager> = None;
         if let Some(variable) = self.get_local_variables_mut()?.get_mut("dict_manager") {
             if let Some(dict_manager) = variable.downcast_mut::<DictManager>() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -195,6 +195,13 @@ pub mod test_utils {
         };
     }
     pub(crate) use exec_scopes_proxy_ref;
+
+    macro_rules! add_dict_manager {
+        ($es_proxy:expr, $dict:expr) => {
+            $es_proxy.insert_value("dict_manager", $dict)
+        };
+    }
+    pub(crate) use add_dict_manager;
 }
 
 #[cfg(test)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -198,7 +198,7 @@ pub mod test_utils {
 
     macro_rules! add_dict_manager {
         ($es_proxy:expr, $dict:expr) => {
-            $es_proxy.insert_value("dict_manager", $dict)
+            $es_proxy.insert_value("dict_manager", Rc::new(RefCell::new($dict)))
         };
     }
     pub(crate) use add_dict_manager;

--- a/src/vm/hints/dict_hint_utils.rs
+++ b/src/vm/hints/dict_hint_utils.rs
@@ -8,9 +8,12 @@ use crate::{
     vm::{errors::vm_errors::VirtualMachineError, vm_core::VMProxy},
 };
 
-use super::hint_utils::{
-    get_integer_from_var_name, get_ptr_from_var_name, insert_value_from_var_name,
-    insert_value_into_ap,
+use super::{
+    dict_manager::DictManager,
+    hint_utils::{
+        get_integer_from_var_name, get_ptr_from_var_name, insert_value_from_var_name,
+        insert_value_into_ap,
+    },
 };
 //DictAccess struct has three memebers, so the size of DictAccess* is 3
 pub const DICT_ACCESS_SIZE: usize = 3;
@@ -49,9 +52,15 @@ pub fn dict_new(
     //Get initial dictionary from scope (defined by an earlier hint)
     let initial_dict =
         copy_initial_dict(exec_scopes_proxy).ok_or(VirtualMachineError::NoInitialDict)?;
-    let base = vm_proxy
-        .dict_manager
-        .new_dict(vm_proxy.segments, vm_proxy.memory, initial_dict)?;
+    //Check if there is a dict manager in scope, create it if there isnt one
+    let base = if let Ok(dict_manager) = exec_scopes_proxy.get_dict_manager_mut() {
+        dict_manager.new_dict(vm_proxy.segments, vm_proxy.memory, initial_dict)?
+    } else {
+        let mut dict_manager = DictManager::new();
+        let base = dict_manager.new_dict(vm_proxy.segments, vm_proxy.memory, initial_dict)?;
+        exec_scopes_proxy.insert_value("dict_manager", dict_manager);
+        base
+    };
     insert_value_into_ap(vm_proxy.memory, vm_proxy.run_context, base)
 }
 
@@ -76,13 +85,25 @@ pub fn default_dict_new(
         get_integer_from_var_name("default_value", ids, vm_proxy, hint_ap_tracking)?.clone();
     //Get initial dictionary from scope (defined by an earlier hint) if available
     let initial_dict = copy_initial_dict(exec_scopes_proxy);
-
-    let base = vm_proxy.dict_manager.new_default_dict(
-        vm_proxy.segments,
-        vm_proxy.memory,
-        &default_value,
-        initial_dict,
-    )?;
+    //Check if there is a dict manager in scope, create it if there isnt one
+    let base = if let Ok(dict_manager) = exec_scopes_proxy.get_dict_manager_mut() {
+        dict_manager.new_default_dict(
+            vm_proxy.segments,
+            vm_proxy.memory,
+            &default_value,
+            initial_dict,
+        )?
+    } else {
+        let mut dict_manager = DictManager::new();
+        let base = dict_manager.new_default_dict(
+            vm_proxy.segments,
+            vm_proxy.memory,
+            &default_value,
+            initial_dict,
+        )?;
+        exec_scopes_proxy.insert_value("dict_manager", dict_manager);
+        base
+    };
     insert_value_into_ap(vm_proxy.memory, vm_proxy.run_context, base)
 }
 
@@ -93,12 +114,15 @@ pub fn default_dict_new(
 */
 pub fn dict_read(
     vm_proxy: &mut VMProxy,
+    exec_scopes_proxy: &mut ExecutionScopesProxy,
     ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let key = get_integer_from_var_name("key", ids, vm_proxy, hint_ap_tracking)?.clone();
     let dict_ptr = get_ptr_from_var_name("dict_ptr", ids, vm_proxy, hint_ap_tracking)?;
-    let tracker = vm_proxy.dict_manager.get_tracker(&dict_ptr)?;
+    let tracker = exec_scopes_proxy
+        .get_dict_manager_mut()?
+        .get_tracker(&dict_ptr)?;
     tracker.current_ptr.offset += DICT_ACCESS_SIZE;
     let value = tracker.get_value(&key)?;
     insert_value_from_var_name("value", value.clone(), ids, vm_proxy, hint_ap_tracking)
@@ -112,6 +136,7 @@ pub fn dict_read(
 */
 pub fn dict_write(
     vm_proxy: &mut VMProxy,
+    exec_scopes_proxy: &mut ExecutionScopesProxy,
     ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
@@ -120,7 +145,9 @@ pub fn dict_write(
         get_integer_from_var_name("new_value", ids, vm_proxy, hint_ap_tracking)?.clone();
     let dict_ptr = get_ptr_from_var_name("dict_ptr", ids, vm_proxy, hint_ap_tracking)?;
     //Get tracker for dictionary
-    let tracker = vm_proxy.dict_manager.get_tracker(&dict_ptr)?;
+    let tracker = exec_scopes_proxy
+        .get_dict_manager_mut()?
+        .get_tracker(&dict_ptr)?;
     //dict_ptr is a pointer to a struct, with the ordered fields (key, prev_value, new_value),
     //dict_ptr.prev_value will be equal to dict_ptr + 1
     let dict_ptr_prev_value = dict_ptr + 1;
@@ -151,6 +178,7 @@ pub fn dict_write(
 */
 pub fn dict_update(
     vm_proxy: &mut VMProxy,
+    exec_scopes_proxy: &mut ExecutionScopesProxy,
     ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
@@ -162,7 +190,9 @@ pub fn dict_update(
     let dict_ptr = get_ptr_from_var_name("dict_ptr", ids, vm_proxy, hint_ap_tracking)?;
 
     //Get tracker for dictionary
-    let tracker = vm_proxy.dict_manager.get_tracker(&dict_ptr)?;
+    let tracker = exec_scopes_proxy
+        .get_dict_manager_mut()?
+        .get_tracker(&dict_ptr)?;
     //Check that prev_value is equal to the current value at the given key
     let current_value = tracker.get_value(&key)?;
     if current_value != &prev_value {
@@ -197,8 +227,8 @@ pub fn dict_squash_copy_dict(
     let dict_accesses_end =
         get_ptr_from_var_name("dict_accesses_end", ids, vm_proxy, hint_ap_tracking)?;
     let dict_copy: Box<dyn Any> = Box::new(
-        vm_proxy
-            .dict_manager
+        exec_scopes_proxy
+            .get_dict_manager_mut()?
             .get_tracker(&dict_accesses_end)?
             .get_dictionary_copy(),
     );
@@ -214,6 +244,7 @@ pub fn dict_squash_copy_dict(
 */
 pub fn dict_squash_update_ptr(
     vm_proxy: &mut VMProxy,
+    exec_scopes_proxy: &mut ExecutionScopesProxy,
     ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
@@ -221,8 +252,8 @@ pub fn dict_squash_update_ptr(
         get_ptr_from_var_name("squashed_dict_start", ids, vm_proxy, hint_ap_tracking)?;
     let squashed_dict_end =
         get_ptr_from_var_name("squashed_dict_end", ids, vm_proxy, hint_ap_tracking)?;
-    vm_proxy
-        .dict_manager
+    exec_scopes_proxy
+        .get_dict_manager_mut()?
         .get_tracker(&squashed_dict_start)?
         .current_ptr = squashed_dict_end;
     Ok(())
@@ -283,7 +314,11 @@ mod tests {
         //Check the dict manager has a tracker for segment 0,
         //and that tracker contains the ptr (0,0) and an empty dict
         assert_eq!(
-            vm.dict_manager.trackers.get(&0),
+            exec_scopes_proxy
+                .get_dict_manager_mut()
+                .unwrap()
+                .trackers
+                .get(&0),
             Some(&DictTracker::new_empty(&relocatable!(0, 0)))
         );
     }
@@ -347,19 +382,21 @@ mod tests {
         //Create manager
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(1, tracker);
-        vm.dict_manager = dict_manager;
         //Insert ids into memory
         vm.memory = memory![((0, 0), 5), ((0, 2), (1, 0))];
         vm.segments.add(&mut vm.memory, None);
         //Create ids
         let ids = ids!["key", "value", "dict_ptr"];
+        let mut exec_scopes = ExecutionScopes::new();
+        let mut exec_scopes_proxy = get_exec_scopes_proxy(&mut exec_scopes);
+        add_dict_manager!(exec_scopes_proxy, dict_manager);
         vm.references = references!(3);
         //Execute the hint
         let vm_proxy = &mut get_vm_proxy(&mut vm);
         assert_eq!(
             HINT_EXECUTOR.execute_hint(
                 vm_proxy,
-                exec_scopes_proxy_ref!(),
+                &mut exec_scopes_proxy,
                 hint_code,
                 &ids,
                 &ApTracking::new()
@@ -373,7 +410,13 @@ mod tests {
         );
         //Check that the tracker's current_ptr has moved accordingly
         assert_eq!(
-            vm.dict_manager.trackers.get(&1).unwrap().current_ptr,
+            exec_scopes_proxy
+                .get_dict_manager_mut()
+                .unwrap()
+                .trackers
+                .get(&1)
+                .unwrap()
+                .current_ptr,
             relocatable!(1, 3)
         );
     }
@@ -393,7 +436,6 @@ mod tests {
         //Create manager
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(1, tracker);
-        vm.dict_manager = dict_manager;
         //Insert ids into memory
         vm.memory = memory![((0, 0), 6), ((0, 2), (1, 0))];
         //Create ids
@@ -401,11 +443,14 @@ mod tests {
         //Create references
         vm.references = references!(3);
         //Execute the hint
+        let mut exec_scopes = ExecutionScopes::new();
+        let mut exec_scopes_proxy = get_exec_scopes_proxy(&mut exec_scopes);
+        add_dict_manager!(exec_scopes_proxy, dict_manager);
         let vm_proxy = &mut get_vm_proxy(&mut vm);
         assert_eq!(
             HINT_EXECUTOR.execute_hint(
                 vm_proxy,
-                exec_scopes_proxy_ref!(),
+                &mut exec_scopes_proxy,
                 hint_code,
                 &ids,
                 &ApTracking::new()
@@ -415,14 +460,15 @@ mod tests {
     }
     #[test]
     fn run_dict_read_no_tracker() {
-        let hint_code = "dict_tracker = __dict_manager.get_tracker(ids.dict_ptr)\ndict_tracker.current_ptr += ids.DictAccess.SIZE\nids.value = dict_tracker.data[ids.key]"
-            ;
+        let hint_code = "dict_tracker = __dict_manager.get_tracker(ids.dict_ptr)\ndict_tracker.current_ptr += ids.DictAccess.SIZE\nids.value = dict_tracker.data[ids.key]";
         let mut vm = vm!();
         //Initialize fp
         vm.run_context.fp = MaybeRelocatable::from((0, 3));
         //Create manager
         let dict_manager = DictManager::new();
-        vm.dict_manager = dict_manager;
+        let mut exec_scopes = ExecutionScopes::new();
+        let mut exec_scopes_proxy = get_exec_scopes_proxy(&mut exec_scopes);
+        add_dict_manager!(exec_scopes_proxy, dict_manager);
         //Insert ids into memory
         vm.memory = memory![((0, 0), 6), ((0, 2), (1, 0))];
         vm.segments.add(&mut vm.memory, None);
@@ -435,7 +481,7 @@ mod tests {
         assert_eq!(
             HINT_EXECUTOR.execute_hint(
                 vm_proxy,
-                exec_scopes_proxy_ref!(),
+                &mut exec_scopes_proxy,
                 hint_code,
                 &ids,
                 &ApTracking::new()
@@ -456,11 +502,13 @@ mod tests {
         let ids = ids!["default_value"];
         //Create references
         vm.references = references!(1);
+        let mut exec_scopes = ExecutionScopes::new();
+        let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
         let vm_proxy = &mut get_vm_proxy(&mut vm);
         HINT_EXECUTOR
             .execute_hint(
                 vm_proxy,
-                exec_scopes_proxy_ref!(),
+                exec_scopes_proxy,
                 hint_code,
                 &ids,
                 &ApTracking::new(),
@@ -476,7 +524,11 @@ mod tests {
         //Check the dict manager has a tracker for segment 0,
         //and that tracker contains the ptr (0,0) and an empty dict
         assert_eq!(
-            vm.dict_manager.trackers.get(&0),
+            exec_scopes_proxy
+                .get_dict_manager_mut()
+                .unwrap()
+                .trackers
+                .get(&0),
             Some(&DictTracker::new_default_dict(
                 &relocatable!(0, 0),
                 &bigint!(17),
@@ -522,7 +574,9 @@ mod tests {
         //Create manager
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(1, tracker);
-        vm.dict_manager = dict_manager;
+        let mut exec_scopes = ExecutionScopes::new();
+        let mut exec_scopes_proxy = get_exec_scopes_proxy(&mut exec_scopes);
+        add_dict_manager!(exec_scopes_proxy, dict_manager);
         //Insert ids into memory
         vm.memory = memory![((0, 0), 5), ((0, 1), 17)];
         vm.segments.add(&mut vm.memory, None);
@@ -546,7 +600,7 @@ mod tests {
         assert_eq!(
             HINT_EXECUTOR.execute_hint(
                 vm_proxy,
-                exec_scopes_proxy_ref!(),
+                &mut exec_scopes_proxy,
                 hint_code,
                 &ids,
                 &ApTracking::new()
@@ -555,7 +609,9 @@ mod tests {
         );
         //Check that the dictionary was updated with the new key-value pair (5, 17)
         assert_eq!(
-            vm.dict_manager
+            exec_scopes_proxy
+                .get_dict_manager_mut()
+                .unwrap()
                 .trackers
                 .get_mut(&1)
                 .unwrap()
@@ -564,7 +620,13 @@ mod tests {
         );
         //Check that the tracker's current_ptr has moved accordingly
         assert_eq!(
-            vm.dict_manager.trackers.get(&1).unwrap().current_ptr,
+            exec_scopes_proxy
+                .get_dict_manager_mut()
+                .unwrap()
+                .trackers
+                .get(&1)
+                .unwrap()
+                .current_ptr,
             relocatable!(1, 3)
         );
         //Check the value of dict_ptr.prev_value, should be equal to the default_value (2)
@@ -588,7 +650,9 @@ mod tests {
         //Create manager
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(1, tracker);
-        vm.dict_manager = dict_manager;
+        let mut exec_scopes = ExecutionScopes::new();
+        let mut exec_scopes_proxy = get_exec_scopes_proxy(&mut exec_scopes);
+        add_dict_manager!(exec_scopes_proxy, dict_manager);
         //Insert ids into memory
         vm.memory = memory![((0, 0), 5), ((0, 1), 17), ((0, 2), (1, 0))];
         vm.segments.add(&mut vm.memory, None);
@@ -606,7 +670,7 @@ mod tests {
         assert_eq!(
             HINT_EXECUTOR.execute_hint(
                 vm_proxy,
-                exec_scopes_proxy_ref!(),
+                &mut exec_scopes_proxy,
                 hint_code,
                 &ids,
                 &ApTracking::new()
@@ -615,7 +679,9 @@ mod tests {
         );
         //Check that the dictionary was updated with the new key-value pair (5, 17)
         assert_eq!(
-            vm.dict_manager
+            exec_scopes_proxy
+                .get_dict_manager_mut()
+                .unwrap()
                 .trackers
                 .get_mut(&1)
                 .unwrap()
@@ -624,7 +690,13 @@ mod tests {
         );
         //Check that the tracker's current_ptr has moved accordingly
         assert_eq!(
-            vm.dict_manager.trackers.get(&1).unwrap().current_ptr,
+            exec_scopes_proxy
+                .get_dict_manager_mut()
+                .unwrap()
+                .trackers
+                .get(&1)
+                .unwrap()
+                .current_ptr,
             relocatable!(1, 3)
         );
         //Check the value of dict_ptr.prev_value, should be equal to the previously inserted value (10)
@@ -648,7 +720,9 @@ mod tests {
         //Create manager
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(1, tracker);
-        vm.dict_manager = dict_manager;
+        let mut exec_scopes = ExecutionScopes::new();
+        let mut exec_scopes_proxy = get_exec_scopes_proxy(&mut exec_scopes);
+        add_dict_manager!(exec_scopes_proxy, dict_manager);
         //Insert ids into memory
         vm.memory = memory![((0, 0), 5), ((0, 1), 17), ((0, 2), (1, 0))];
         vm.segments.add(&mut vm.memory, None);
@@ -666,7 +740,7 @@ mod tests {
         assert_eq!(
             HINT_EXECUTOR.execute_hint(
                 vm_proxy,
-                exec_scopes_proxy_ref!(),
+                &mut exec_scopes_proxy,
                 hint_code,
                 &ids,
                 &ApTracking::new()
@@ -675,7 +749,9 @@ mod tests {
         );
         //Check that the dictionary was updated with the new key-value pair (5, 17)
         assert_eq!(
-            vm.dict_manager
+            exec_scopes_proxy
+                .get_dict_manager_mut()
+                .unwrap()
                 .trackers
                 .get_mut(&1)
                 .unwrap()
@@ -684,7 +760,13 @@ mod tests {
         );
         //Check that the tracker's current_ptr has moved accordingly
         assert_eq!(
-            vm.dict_manager.trackers.get(&1).unwrap().current_ptr,
+            exec_scopes_proxy
+                .get_dict_manager_mut()
+                .unwrap()
+                .trackers
+                .get(&1)
+                .unwrap()
+                .current_ptr,
             relocatable!(1, 3)
         );
         //Check the value of dict_ptr.prev_value, should be equal to the previously inserted value (10)
@@ -706,7 +788,9 @@ mod tests {
         //Create manager
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(1, tracker);
-        vm.dict_manager = dict_manager;
+        let mut exec_scopes = ExecutionScopes::new();
+        let mut exec_scopes_proxy = get_exec_scopes_proxy(&mut exec_scopes);
+        add_dict_manager!(exec_scopes_proxy, dict_manager);
         //Insert ids into memory
         vm.memory = memory![((0, 0), 5), ((0, 1), 17), ((0, 2), (1, 0))];
         vm.segments.add(&mut vm.memory, None);
@@ -724,7 +808,7 @@ mod tests {
         assert_eq!(
             HINT_EXECUTOR.execute_hint(
                 vm_proxy,
-                exec_scopes_proxy_ref!(),
+                &mut exec_scopes_proxy,
                 hint_code,
                 &ids,
                 &ApTracking::new()
@@ -747,7 +831,9 @@ mod tests {
         //Create manager
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(1, tracker);
-        vm.dict_manager = dict_manager;
+        let mut exec_scopes = ExecutionScopes::new();
+        let mut exec_scopes_proxy = get_exec_scopes_proxy(&mut exec_scopes);
+        add_dict_manager!(exec_scopes_proxy, dict_manager);
         //Insert ids into memory
         vm.memory = memory![((0, 0), 5), ((0, 1), 10), ((0, 2), 20), ((0, 3), (1, 0))];
         vm.segments.add(&mut vm.memory, None);
@@ -764,7 +850,7 @@ mod tests {
         assert_eq!(
             HINT_EXECUTOR.execute_hint(
                 vm_proxy,
-                exec_scopes_proxy_ref!(),
+                &mut exec_scopes_proxy,
                 hint_code,
                 &ids,
                 &ApTracking::new()
@@ -773,7 +859,9 @@ mod tests {
         );
         //Check that the dictionary was updated with the new key-value pair (5, 20)
         assert_eq!(
-            vm.dict_manager
+            exec_scopes_proxy
+                .get_dict_manager_mut()
+                .unwrap()
                 .trackers
                 .get_mut(&1)
                 .unwrap()
@@ -782,7 +870,13 @@ mod tests {
         );
         //Check that the tracker's current_ptr has moved accordingly
         assert_eq!(
-            vm.dict_manager.trackers.get(&1).unwrap().current_ptr,
+            exec_scopes_proxy
+                .get_dict_manager_mut()
+                .unwrap()
+                .trackers
+                .get(&1)
+                .unwrap()
+                .current_ptr,
             relocatable!(1, 3)
         );
     }
@@ -801,7 +895,9 @@ mod tests {
         //Create manager
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(1, tracker);
-        vm.dict_manager = dict_manager;
+        let mut exec_scopes = ExecutionScopes::new();
+        let mut exec_scopes_proxy = get_exec_scopes_proxy(&mut exec_scopes);
+        add_dict_manager!(exec_scopes_proxy, dict_manager);
         //Insert ids into memory
         vm.memory = memory![((0, 0), 5), ((0, 1), 10), ((0, 2), 10), ((0, 3), (1, 0))];
         vm.segments.add(&mut vm.memory, None);
@@ -818,7 +914,7 @@ mod tests {
         assert_eq!(
             HINT_EXECUTOR.execute_hint(
                 vm_proxy,
-                exec_scopes_proxy_ref!(),
+                &mut exec_scopes_proxy,
                 hint_code,
                 &ids,
                 &ApTracking::new()
@@ -827,7 +923,9 @@ mod tests {
         );
         //Check that the dictionary was updated with the new key-value pair (5, 20)
         assert_eq!(
-            vm.dict_manager
+            exec_scopes_proxy
+                .get_dict_manager_mut()
+                .unwrap()
                 .trackers
                 .get_mut(&1)
                 .unwrap()
@@ -836,7 +934,13 @@ mod tests {
         );
         //Check that the tracker's current_ptr has moved accordingly
         assert_eq!(
-            vm.dict_manager.trackers.get(&1).unwrap().current_ptr,
+            exec_scopes_proxy
+                .get_dict_manager_mut()
+                .unwrap()
+                .trackers
+                .get(&1)
+                .unwrap()
+                .current_ptr,
             relocatable!(1, 3)
         );
     }
@@ -855,7 +959,9 @@ mod tests {
         //Create manager
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(1, tracker);
-        vm.dict_manager = dict_manager;
+        let mut exec_scopes = ExecutionScopes::new();
+        let mut exec_scopes_proxy = get_exec_scopes_proxy(&mut exec_scopes);
+        add_dict_manager!(exec_scopes_proxy, dict_manager);
         //Insert ids into memory
         vm.memory = memory![((0, 0), 5), ((0, 1), 11), ((0, 2), 20), ((0, 3), (1, 0))];
         vm.segments.add(&mut vm.memory, None);
@@ -872,7 +978,7 @@ mod tests {
         assert_eq!(
             HINT_EXECUTOR.execute_hint(
                 vm_proxy,
-                exec_scopes_proxy_ref!(),
+                &mut exec_scopes_proxy,
                 hint_code,
                 &ids,
                 &ApTracking::new()
@@ -900,7 +1006,9 @@ mod tests {
         //Create manager
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(1, tracker);
-        vm.dict_manager = dict_manager;
+        let mut exec_scopes = ExecutionScopes::new();
+        let mut exec_scopes_proxy = get_exec_scopes_proxy(&mut exec_scopes);
+        add_dict_manager!(exec_scopes_proxy, dict_manager);
         //Insert ids into memory
         vm.memory = memory![((0, 0), 6), ((0, 1), 10), ((0, 2), 10), ((0, 3), (1, 0))];
         vm.segments.add(&mut vm.memory, None);
@@ -917,7 +1025,7 @@ mod tests {
         assert_eq!(
             HINT_EXECUTOR.execute_hint(
                 vm_proxy,
-                exec_scopes_proxy_ref!(),
+                &mut exec_scopes_proxy,
                 hint_code,
                 &ids,
                 &ApTracking::new()
@@ -941,7 +1049,9 @@ mod tests {
         //Create manager
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(1, tracker);
-        vm.dict_manager = dict_manager;
+        let mut exec_scopes = ExecutionScopes::new();
+        let mut exec_scopes_proxy = get_exec_scopes_proxy(&mut exec_scopes);
+        add_dict_manager!(exec_scopes_proxy, dict_manager);
         //Insert ids into memory
         vm.memory = memory![((0, 0), 5), ((0, 1), 10), ((0, 2), 20), ((0, 3), (1, 0))];
         vm.segments.add(&mut vm.memory, None);
@@ -958,7 +1068,7 @@ mod tests {
         assert_eq!(
             HINT_EXECUTOR.execute_hint(
                 vm_proxy,
-                exec_scopes_proxy_ref!(),
+                &mut exec_scopes_proxy,
                 hint_code,
                 &ids,
                 &ApTracking::new()
@@ -967,7 +1077,9 @@ mod tests {
         );
         //Check that the dictionary was updated with the new key-value pair (5, 20)
         assert_eq!(
-            vm.dict_manager
+            exec_scopes_proxy
+                .get_dict_manager_mut()
+                .unwrap()
                 .trackers
                 .get_mut(&1)
                 .unwrap()
@@ -976,7 +1088,13 @@ mod tests {
         );
         //Check that the tracker's current_ptr has moved accordingly
         assert_eq!(
-            vm.dict_manager.trackers.get(&1).unwrap().current_ptr,
+            exec_scopes_proxy
+                .get_dict_manager_mut()
+                .unwrap()
+                .trackers
+                .get(&1)
+                .unwrap()
+                .current_ptr,
             relocatable!(1, 3)
         );
     }
@@ -996,7 +1114,9 @@ mod tests {
         //Create manager
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(1, tracker);
-        vm.dict_manager = dict_manager;
+        let mut exec_scopes = ExecutionScopes::new();
+        let mut exec_scopes_proxy = get_exec_scopes_proxy(&mut exec_scopes);
+        add_dict_manager!(exec_scopes_proxy, dict_manager);
         //Insert ids into memory
         vm.memory = memory![((0, 0), 5), ((0, 1), 10), ((0, 2), 10), ((0, 3), (1, 0))];
         vm.segments.add(&mut vm.memory, None);
@@ -1013,7 +1133,7 @@ mod tests {
         assert_eq!(
             HINT_EXECUTOR.execute_hint(
                 vm_proxy,
-                exec_scopes_proxy_ref!(),
+                &mut exec_scopes_proxy,
                 hint_code,
                 &ids,
                 &ApTracking::new()
@@ -1022,7 +1142,9 @@ mod tests {
         );
         //Check that the dictionary was updated with the new key-value pair (5, 20)
         assert_eq!(
-            vm.dict_manager
+            exec_scopes_proxy
+                .get_dict_manager_mut()
+                .unwrap()
                 .trackers
                 .get_mut(&1)
                 .unwrap()
@@ -1031,7 +1153,13 @@ mod tests {
         );
         //Check that the tracker's current_ptr has moved accordingly
         assert_eq!(
-            vm.dict_manager.trackers.get(&1).unwrap().current_ptr,
+            exec_scopes_proxy
+                .get_dict_manager_mut()
+                .unwrap()
+                .trackers
+                .get(&1)
+                .unwrap()
+                .current_ptr,
             relocatable!(1, 3)
         );
     }
@@ -1051,7 +1179,9 @@ mod tests {
         //Create manager
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(1, tracker);
-        vm.dict_manager = dict_manager;
+        let mut exec_scopes = ExecutionScopes::new();
+        let mut exec_scopes_proxy = get_exec_scopes_proxy(&mut exec_scopes);
+        add_dict_manager!(exec_scopes_proxy, dict_manager);
         //Insert ids into memory
         vm.memory = memory![((0, 0), 5), ((0, 1), 11), ((0, 2), 10), ((0, 3), (1, 0))];
         vm.segments.add(&mut vm.memory, None);
@@ -1068,7 +1198,7 @@ mod tests {
         assert_eq!(
             HINT_EXECUTOR.execute_hint(
                 vm_proxy,
-                exec_scopes_proxy_ref!(),
+                &mut exec_scopes_proxy,
                 hint_code,
                 &ids,
                 &ApTracking::new()
@@ -1096,7 +1226,9 @@ mod tests {
         //Create manager
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(1, tracker);
-        vm.dict_manager = dict_manager;
+        let mut exec_scopes = ExecutionScopes::new();
+        let mut exec_scopes_proxy = get_exec_scopes_proxy(&mut exec_scopes);
+        add_dict_manager!(exec_scopes_proxy, dict_manager);
         //Insert ids into memory
         vm.memory = memory![((0, 0), 6), ((0, 1), 10), ((0, 2), 10), ((0, 3), (1, 0))];
         vm.segments.add(&mut vm.memory, None);
@@ -1113,7 +1245,7 @@ mod tests {
         assert_eq!(
             HINT_EXECUTOR.execute_hint(
                 vm_proxy,
-                exec_scopes_proxy_ref!(),
+                &mut exec_scopes_proxy,
                 hint_code,
                 &ids,
                 &ApTracking::new()
@@ -1139,7 +1271,9 @@ mod tests {
         //Create manager
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(1, tracker);
-        vm.dict_manager = dict_manager;
+        let mut exec_scopes = ExecutionScopes::new();
+        let mut exec_scopes_proxy = get_exec_scopes_proxy(&mut exec_scopes);
+        add_dict_manager!(exec_scopes_proxy, dict_manager);
         //Insert ids into memory
         vm.memory = memory![((0, 0), 5), ((0, 1), 17), ((0, 2), 20), ((0, 3), (1, 0))];
         vm.segments.add(&mut vm.memory, None);
@@ -1156,7 +1290,7 @@ mod tests {
         assert_eq!(
             HINT_EXECUTOR.execute_hint(
                 vm_proxy,
-                exec_scopes_proxy_ref!(),
+                &mut exec_scopes_proxy,
                 hint_code,
                 &ids,
                 &ApTracking::new()
@@ -1165,7 +1299,9 @@ mod tests {
         );
         //Check that the dictionary was updated with the new key-value pair (5, 20)
         assert_eq!(
-            vm.dict_manager
+            exec_scopes_proxy
+                .get_dict_manager_mut()
+                .unwrap()
                 .trackers
                 .get_mut(&1)
                 .unwrap()
@@ -1174,7 +1310,13 @@ mod tests {
         );
         //Check that the tracker's current_ptr has moved accordingly
         assert_eq!(
-            vm.dict_manager.trackers.get(&1).unwrap().current_ptr,
+            exec_scopes_proxy
+                .get_dict_manager_mut()
+                .unwrap()
+                .trackers
+                .get(&1)
+                .unwrap()
+                .current_ptr,
             relocatable!(1, 3)
         );
     }
@@ -1193,7 +1335,6 @@ mod tests {
         //Create manager
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(1, tracker);
-        vm.dict_manager = dict_manager;
         //ids.dict_access
         vm.memory = memory![((0, 0), (1, 0))];
         vm.segments.add(&mut vm.memory, None);
@@ -1205,6 +1346,7 @@ mod tests {
         let vm_proxy = &mut get_vm_proxy(&mut vm);
         let mut exec_scopes = ExecutionScopes::new();
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
+        add_dict_manager!(exec_scopes_proxy, dict_manager);
         assert_eq!(
             HINT_EXECUTOR.execute_hint(
                 vm_proxy,
@@ -1246,7 +1388,6 @@ mod tests {
         //Create manager
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(1, tracker);
-        vm.dict_manager = dict_manager;
         vm.memory = memory![((0, 0), (1, 0))];
         vm.segments.add(&mut vm.memory, None);
         //Create ids
@@ -1257,6 +1398,7 @@ mod tests {
         let vm_proxy = &mut get_vm_proxy(&mut vm);
         let mut exec_scopes = ExecutionScopes::new();
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
+        add_dict_manager!(exec_scopes_proxy, dict_manager);
         assert_eq!(
             HINT_EXECUTOR.execute_hint(
                 vm_proxy,
@@ -1293,7 +1435,9 @@ mod tests {
         vm.run_context.fp = MaybeRelocatable::from((0, 1));
         //Create manager
         let dict_manager = DictManager::new();
-        vm.dict_manager = dict_manager;
+        let mut exec_scopes = ExecutionScopes::new();
+        let mut exec_scopes_proxy = get_exec_scopes_proxy(&mut exec_scopes);
+        add_dict_manager!(exec_scopes_proxy, dict_manager);
         vm.memory = memory![((0, 0), (1, 0))];
         vm.segments.add(&mut vm.memory, None);
         //Create ids
@@ -1305,7 +1449,7 @@ mod tests {
         assert_eq!(
             HINT_EXECUTOR.execute_hint(
                 vm_proxy,
-                exec_scopes_proxy_ref!(),
+                &mut exec_scopes_proxy,
                 hint_code,
                 &ids,
                 &ApTracking::new()
@@ -1322,7 +1466,9 @@ mod tests {
         vm.run_context.fp = MaybeRelocatable::from((0, 2));
         //Create manager
         let dict_manager = DictManager::new();
-        vm.dict_manager = dict_manager;
+        let mut exec_scopes = ExecutionScopes::new();
+        let mut exec_scopes_proxy = get_exec_scopes_proxy(&mut exec_scopes);
+        add_dict_manager!(exec_scopes_proxy, dict_manager);
         vm.memory = memory![((0, 0), (1, 0)), ((0, 1), (1, 3))];
         vm.segments.add(&mut vm.memory, None);
         //Create ids
@@ -1334,7 +1480,7 @@ mod tests {
         assert_eq!(
             HINT_EXECUTOR.execute_hint(
                 vm_proxy,
-                exec_scopes_proxy_ref!(),
+                &mut exec_scopes_proxy,
                 hint_code,
                 &ids,
                 &ApTracking::new()
@@ -1358,7 +1504,9 @@ mod tests {
         //Create manager
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(1, tracker);
-        vm.dict_manager = dict_manager;
+        let mut exec_scopes = ExecutionScopes::new();
+        let mut exec_scopes_proxy = get_exec_scopes_proxy(&mut exec_scopes);
+        add_dict_manager!(exec_scopes_proxy, dict_manager);
         //ids.squash_dict_start
         vm.memory = memory![((0, 0), (1, 0)), ((0, 1), (1, 3))];
         vm.segments.add(&mut vm.memory, None);
@@ -1371,7 +1519,7 @@ mod tests {
         assert_eq!(
             HINT_EXECUTOR.execute_hint(
                 vm_proxy,
-                exec_scopes_proxy_ref!(),
+                &mut exec_scopes_proxy,
                 hint_code,
                 &ids,
                 &ApTracking::new()
@@ -1380,7 +1528,9 @@ mod tests {
         );
         //Check the updated pointer
         assert_eq!(
-            vm.dict_manager
+            exec_scopes_proxy
+                .get_dict_manager_mut()
+                .unwrap()
                 .get_tracker(&relocatable!(1, 3))
                 .unwrap()
                 .current_ptr,
@@ -1403,7 +1553,9 @@ mod tests {
         //Create manager
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(1, tracker);
-        vm.dict_manager = dict_manager;
+        let mut exec_scopes = ExecutionScopes::new();
+        let mut exec_scopes_proxy = get_exec_scopes_proxy(&mut exec_scopes);
+        add_dict_manager!(exec_scopes_proxy, dict_manager);
         vm.memory = memory![((0, 0), (1, 3)), ((0, 1), (1, 6))];
         vm.segments.add(&mut vm.memory, None);
         //Create ids
@@ -1415,7 +1567,7 @@ mod tests {
         assert_eq!(
             HINT_EXECUTOR.execute_hint(
                 vm_proxy,
-                exec_scopes_proxy_ref!(),
+                &mut exec_scopes_proxy,
                 hint_code,
                 &ids,
                 &ApTracking::new()

--- a/src/vm/hints/dict_hint_utils.rs
+++ b/src/vm/hints/dict_hint_utils.rs
@@ -127,7 +127,7 @@ pub fn dict_read(
     let mut dict = dict_manager_ref.borrow_mut();
     let tracker = dict.get_tracker_mut(&dict_ptr)?;
     tracker.current_ptr.offset += DICT_ACCESS_SIZE;
-    let value = tracker.get_value(&key)?;
+    let value = tracker.get_value(key)?;
     insert_value_from_var_name("value", value.clone(), ids, vm_proxy, hint_ap_tracking)
 }
 
@@ -156,9 +156,9 @@ pub fn dict_write(
     //Tracker set to track next dictionary entry
     tracker.current_ptr.offset += DICT_ACCESS_SIZE;
     //Get previous value
-    let prev_value = tracker.get_value(&key)?.clone();
+    let prev_value = tracker.get_value(key)?.clone();
     //Insert new value into tracker
-    tracker.insert_value(&key, &new_value);
+    tracker.insert_value(key, new_value);
     //Insert previous value into dict_ptr.prev_value
     //Addres for dict_ptr.prev_value should be dict_ptr* + 1 (defined above)
     vm_proxy
@@ -194,7 +194,7 @@ pub fn dict_update(
     let mut dict = dict_manager_ref.borrow_mut();
     let tracker = dict.get_tracker_mut(&dict_ptr)?;
     //Check that prev_value is equal to the current value at the given key
-    let current_value = tracker.get_value(&key)?;
+    let current_value = tracker.get_value(key)?;
     if current_value != prev_value {
         return Err(VirtualMachineError::WrongPrevValue(
             prev_value.clone(),
@@ -203,7 +203,7 @@ pub fn dict_update(
         ));
     }
     //Update Value
-    tracker.insert_value(&key, &new_value);
+    tracker.insert_value(key, new_value);
     tracker.current_ptr.offset += DICT_ACCESS_SIZE;
     Ok(())
 }

--- a/src/vm/hints/dict_hint_utils.rs
+++ b/src/vm/hints/dict_hint_utils.rs
@@ -121,7 +121,7 @@ pub fn dict_read(
     ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
-    let key = get_integer_from_var_name("key", ids, vm_proxy, hint_ap_tracking)?.clone();
+    let key = get_integer_from_var_name("key", ids, vm_proxy, hint_ap_tracking)?;
     let dict_ptr = get_ptr_from_var_name("dict_ptr", ids, vm_proxy, hint_ap_tracking)?;
     let dict_manager_ref = exec_scopes_proxy.get_dict_manager()?;
     let mut dict = dict_manager_ref.borrow_mut();
@@ -143,9 +143,8 @@ pub fn dict_write(
     ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
-    let key = get_integer_from_var_name("key", ids, vm_proxy, hint_ap_tracking)?.clone();
-    let new_value =
-        get_integer_from_var_name("new_value", ids, vm_proxy, hint_ap_tracking)?.clone();
+    let key = get_integer_from_var_name("key", ids, vm_proxy, hint_ap_tracking)?;
+    let new_value = get_integer_from_var_name("new_value", ids, vm_proxy, hint_ap_tracking)?;
     let dict_ptr = get_ptr_from_var_name("dict_ptr", ids, vm_proxy, hint_ap_tracking)?;
     //Get tracker for dictionary
     let dict_manager_ref = exec_scopes_proxy.get_dict_manager()?;
@@ -185,11 +184,9 @@ pub fn dict_update(
     ids: &HashMap<String, BigInt>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
-    let key = get_integer_from_var_name("key", ids, vm_proxy, hint_ap_tracking)?.clone();
-    let prev_value =
-        get_integer_from_var_name("prev_value", ids, vm_proxy, hint_ap_tracking)?.clone();
-    let new_value =
-        get_integer_from_var_name("new_value", ids, vm_proxy, hint_ap_tracking)?.clone();
+    let key = get_integer_from_var_name("key", ids, vm_proxy, hint_ap_tracking)?;
+    let prev_value = get_integer_from_var_name("prev_value", ids, vm_proxy, hint_ap_tracking)?;
+    let new_value = get_integer_from_var_name("new_value", ids, vm_proxy, hint_ap_tracking)?;
     let dict_ptr = get_ptr_from_var_name("dict_ptr", ids, vm_proxy, hint_ap_tracking)?;
 
     //Get tracker for dictionary
@@ -198,9 +195,9 @@ pub fn dict_update(
     let tracker = dict.get_tracker_mut(&dict_ptr)?;
     //Check that prev_value is equal to the current value at the given key
     let current_value = tracker.get_value(&key)?;
-    if current_value != &prev_value {
+    if current_value != prev_value {
         return Err(VirtualMachineError::WrongPrevValue(
-            prev_value,
+            prev_value.clone(),
             current_value.clone(),
             key.clone(),
         ));

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -70,7 +70,6 @@ pub fn get_vm_proxy(vm: &mut VirtualMachine) -> VMProxy {
         memory: &mut vm.memory,
         segments: &mut vm.segments,
         run_context: &mut vm.run_context,
-        dict_manager: &mut vm.dict_manager,
         builtin_runners: &vm.builtin_runners,
         references: &vm.references,
         prime: &vm.prime,
@@ -150,8 +149,8 @@ impl HintExecutor for BuiltinHintExecutor {
             hint_code::POW => pow(vm_proxy, ids, Some(ap_tracking)),
             hint_code::SET_ADD => set_add(vm_proxy, ids, None),
             hint_code::DICT_NEW => dict_new(vm_proxy, exec_scopes_proxy),
-            hint_code::DICT_READ => dict_read(vm_proxy, ids, None),
-            hint_code::DICT_WRITE => dict_write(vm_proxy, ids, None),
+            hint_code::DICT_READ => dict_read(vm_proxy, exec_scopes_proxy, ids, None),
+            hint_code::DICT_WRITE => dict_write(vm_proxy, exec_scopes_proxy, ids, None),
             hint_code::DEFAULT_DICT_NEW => {
                 default_dict_new(vm_proxy, exec_scopes_proxy, ids, Some(ap_tracking))
             }
@@ -218,12 +217,12 @@ impl HintExecutor for BuiltinHintExecutor {
                 squash_dict(vm_proxy, exec_scopes_proxy, ids, Some(ap_tracking))
             }
             hint_code::VM_ENTER_SCOPE => enter_scope(exec_scopes_proxy),
-            hint_code::DICT_UPDATE => dict_update(vm_proxy, ids, None),
+            hint_code::DICT_UPDATE => dict_update(vm_proxy, exec_scopes_proxy, ids, None),
             hint_code::DICT_SQUASH_COPY_DICT => {
                 dict_squash_copy_dict(vm_proxy, exec_scopes_proxy, ids, Some(ap_tracking))
             }
             hint_code::DICT_SQUASH_UPDATE_PTR => {
-                dict_squash_update_ptr(vm_proxy, ids, Some(ap_tracking))
+                dict_squash_update_ptr(vm_proxy, exec_scopes_proxy, ids, Some(ap_tracking))
             }
             hint_code::UINT256_ADD => uint256_add(vm_proxy, ids, None),
             hint_code::SPLIT_64 => split_64(vm_proxy, ids, None),

--- a/src/vm/hints/squash_dict_utils.rs
+++ b/src/vm/hints/squash_dict_utils.rs
@@ -173,16 +173,16 @@ pub fn squash_dict_inner_used_accesses_assert(
 ) -> Result<(), VirtualMachineError> {
     let key = exec_scopes_proxy.get_int("key")?;
     let n_used_accesses =
-        get_integer_from_var_name("n_used_accesses", ids, vm_proxy, hint_ap_tracking)?.clone();
+        get_integer_from_var_name("n_used_accesses", ids, vm_proxy, hint_ap_tracking)?;
     let access_indices = get_access_indices(exec_scopes_proxy)?;
     //Main Logic
     let access_indices_at_key = access_indices
         .get(&key)
         .ok_or_else(|| VirtualMachineError::NoKeyInAccessIndices(key.clone()))?;
 
-    if n_used_accesses != bigint!(access_indices_at_key.len()) {
+    if n_used_accesses != &bigint!(access_indices_at_key.len()) {
         return Err(VirtualMachineError::NumUsedAccessesAssertFail(
-            n_used_accesses,
+            n_used_accesses.clone(),
             access_indices_at_key.len(),
             key,
         ));
@@ -280,7 +280,7 @@ pub fn squash_dict(
     //A map from key to the list of indices accessing it.
     let mut access_indices = HashMap::<BigInt, Vec<BigInt>>::new();
     for i in 0..n_accesses_usize {
-        let key_addr = address.clone() + DICT_ACCESS_SIZE * i;
+        let key_addr = &address + DICT_ACCESS_SIZE * i;
         let key = vm_proxy
             .memory
             .get_integer(&key_addr)

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -496,7 +496,6 @@ impl VirtualMachine {
             for hint_data in hint_list.clone().iter() {
                 let mut exec_scopes_proxy = get_exec_scopes_proxy(exec_scopes);
                 let mut vm_proxy = get_vm_proxy(self);
-                println!("HintCode: {:?}", hint_data.hint_code);
                 hint_executor.execute_hint(
                     &mut vm_proxy,
                     &mut exec_scopes_proxy,

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -9,7 +9,6 @@ use crate::vm::context::run_context::RunContext;
 use crate::vm::decoding::decoder::decode_instruction;
 use crate::vm::errors::runner_errors::RunnerError;
 use crate::vm::errors::vm_errors::VirtualMachineError;
-use crate::vm::hints::dict_manager::DictManager;
 use crate::vm::runners::builtin_runner::BuiltinRunner;
 use crate::vm::trace::trace_entry::TraceEntry;
 use crate::vm::vm_memory::memory::Memory;
@@ -43,7 +42,6 @@ pub struct VMProxy<'a> {
     pub memory: &'a mut Memory,
     pub segments: &'a mut MemorySegmentManager,
     pub run_context: &'a mut RunContext,
-    pub dict_manager: &'a mut DictManager,
     pub builtin_runners: &'a Vec<(String, Box<dyn BuiltinRunner>)>,
     pub references: &'a HashMap<usize, HintReference>,
     pub prime: &'a BigInt,
@@ -68,7 +66,6 @@ pub struct VirtualMachine {
     pub trace: Option<Vec<TraceEntry>>,
     current_step: usize,
     skip_instruction_execution: bool,
-    pub dict_manager: DictManager,
 }
 
 impl HintData {
@@ -117,7 +114,6 @@ impl VirtualMachine {
             current_step: 0,
             skip_instruction_execution: false,
             segments: MemorySegmentManager::new(),
-            dict_manager: DictManager::new(),
         }
     }
     ///Returns the encoded instruction (the value at pc) and the immediate value (the value at pc + 1, if it exists in the memory).
@@ -2462,7 +2458,6 @@ mod tests {
             current_step: 1,
             skip_instruction_execution: false,
             segments: MemorySegmentManager::new(),
-            dict_manager: DictManager::new(),
         };
 
         let error = vm.opcode_assertions(&instruction, &operands);

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -496,6 +496,7 @@ impl VirtualMachine {
             for hint_data in hint_list.clone().iter() {
                 let mut exec_scopes_proxy = get_exec_scopes_proxy(exec_scopes);
                 let mut vm_proxy = get_vm_proxy(self);
+                println!("HintCode: {:?}", hint_data.hint_code);
                 hint_executor.execute_hint(
                     &mut vm_proxy,
                     &mut exec_scopes_proxy,


### PR DESCRIPTION
This PR aims to remove DictManager from the VM structure, and instead create it and store it inside the current execution scope when needed.

- [x] Remove DictManager from VM and VMProxy
- [x] Add helpers to ExecScopeProxy to get references to stored dict_manager
- [x] Fix affected hint functions and tests
- [x] Remove some clones that will no longer be needed

Depends on #361 
