### PR TITLE
Fix uint256 split_64 bug

### DIFF
--- a/cairo_programs/uint256.cairo
+++ b/cairo_programs/uint256.cairo
@@ -44,9 +44,13 @@ func main{range_check_ptr: felt}():
     assert b_quotient = Uint256(1,0)
     assert b_remainder = Uint256(340282366920938463463374607431768211377,0)
     
-    let (mult_low, mult_high) = uint256_mul(Uint256(59,2),  Uint256(10,0))
-    assert mult_low = Uint256(590,20)
-    assert mult_high = Uint256(0,0)
+    let (mult_low_a, mult_high_a) = uint256_mul(Uint256(59,2),  Uint256(10,0))
+    assert mult_low_a = Uint256(590,20)
+    assert mult_high_a = Uint256(0,0)
+
+    let (mult_low_b: Uint256, mult_high_b: Uint256) = uint256_mul(Uint256(271442546951262198976322048597925888860,0), Uint256(271442546951262198976322048597925888860,0))
+    assert mult_low_b = Uint256(42047520920204780886066537579778623760, 216529163594619381764978757921136443390)
+    assert mult_high_b = Uint256(0,0)
 
     let array_length = 100
     let (sum_array : Uint256*) = alloc()

--- a/src/vm/hints/uint256_utils.rs
+++ b/src/vm/hints/uint256_utils.rs
@@ -107,11 +107,16 @@ pub fn split_64(
         hint_ap_tracking,
     )?;
     let mut digits = a.iter_u64_digits();
-    let low = digits.next().unwrap_or(0u64);
-    let high = digits.next().unwrap_or(0u64);
+    let low = bigint!(digits.next().unwrap_or(0u64));
+    let high = if digits.len() <= 1 {
+        bigint!(digits.next().unwrap_or(0u64))
+    } else {
+        a.shr(64_usize)
+    };
+
     insert_value_from_var_name(
         "high",
-        bigint!(high),
+        high,
         ids,
         &mut vm.memory,
         &vm.references,
@@ -120,7 +125,7 @@ pub fn split_64(
     )?;
     insert_value_from_var_name(
         "low",
-        bigint!(low),
+        low,
         ids,
         &mut vm.memory,
         &vm.references,

--- a/src/vm/hints/uint256_utils.rs
+++ b/src/vm/hints/uint256_utils.rs
@@ -439,6 +439,47 @@ mod tests {
     }
 
     #[test]
+    fn run_split_64_with_big_a() {
+        let hint_code = "ids.low = ids.a & ((1<<64) - 1)\nids.high = ids.a >> 64";
+        let mut vm = vm_with_range_check!();
+        for _ in 0..3 {
+            vm.segments.add(&mut vm.memory, None);
+        }
+
+        //Initialize fp
+        vm.run_context.fp = MaybeRelocatable::from((1, 10));
+
+        //Create ids
+        let ids = ids!["a", "high", "low"];
+
+        //Create references
+        vm.references = not_continuous_references!(-3, 1, 0);
+
+        //Insert ids.a into memory
+        vm.memory
+            .insert(
+                &MaybeRelocatable::from((1, 7)),
+                &MaybeRelocatable::from(bigint_str!(b"400066369019890261321163226850167045262")),
+            )
+            .unwrap();
+
+        //Execute the hint
+        assert_eq!(
+            vm.hint_executor
+                .execute_hint(&mut vm, hint_code, &ids, &ApTracking::new()),
+            Ok(())
+        );
+
+        //Check hint memory inserts
+        //ids.low, ids.high
+        check_memory![
+            &vm.memory,
+            ((1, 10), 2279400676465785998_u64),
+            ((1, 11), 21687641321487626429_u128)
+        ];
+    }
+
+    #[test]
     fn run_split_64_memory_error() {
         let hint_code = "ids.low = ids.a & ((1<<64) - 1)\nids.high = ids.a >> 64";
         let mut vm = vm_with_range_check!();


### PR DESCRIPTION
# Fix uint256 split_64 bug

## Description

Bug in split_64 hint:
```
%{
    ids.low = ids.a & ((1<<64) - 1)
    ids.high = ids.a >> 64
%}
```
if the `a` value is too big, the hint inserts a wrong value in the memory.



## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [x] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
