### PR TITLE
Separate VM from Hint Execution: Phase 5 (MemoryProxy)

### DIFF
--- a/src/vm/hints/cairo_keccak/keccak_hints.rs
+++ b/src/vm/hints/cairo_keccak/keccak_hints.rs
@@ -43,9 +43,9 @@ pub fn keccak_write_args(
     let high_args = [high & bigint!(u64::MAX), high >> 64];
 
     vm_proxy
-        .segments
+        .memory
         .write_arg(
-            vm_proxy.memory,
+            vm_proxy.segments,
             &inputs_ptr,
             &low_args.to_vec(),
             Some(vm_proxy.prime),
@@ -53,9 +53,9 @@ pub fn keccak_write_args(
         .map_err(VirtualMachineError::MemoryError)?;
 
     vm_proxy
-        .segments
+        .memory
         .write_arg(
-            vm_proxy.memory,
+            vm_proxy.segments,
             &inputs_ptr.add(2)?,
             &high_args.to_vec(),
             Some(vm_proxy.prime),
@@ -86,7 +86,7 @@ pub fn compare_bytes_in_word_nondet(
     // or too big, which also means n_bytes > BYTES_IN_WORD). The other option is to exctract
     // bigint!(BYTES_INTO_WORD) into a lazy_static!
     let value = bigint!((n_bytes < &BYTES_IN_WORD) as usize);
-    insert_value_into_ap(vm_proxy.memory, vm_proxy.run_context, value)
+    insert_value_into_ap(&mut vm_proxy.memory, vm_proxy.run_context, value)
 }
 
 /*
@@ -152,9 +152,9 @@ pub fn block_permutation(
     let bigint_values = u64_array_to_bigint_vec(&u64_values);
 
     vm_proxy
-        .segments
+        .memory
         .write_arg(
-            vm_proxy.memory,
+            vm_proxy.segments,
             &keccak_ptr,
             &bigint_values,
             Some(vm_proxy.prime),
@@ -208,9 +208,9 @@ pub fn cairo_keccak_finalize(
     let keccak_ptr_end = get_ptr_from_var_name("keccak_ptr_end", ids, vm_proxy, hint_ap_tracking)?;
 
     vm_proxy
-        .segments
+        .memory
         .write_arg(
-            vm_proxy.memory,
+            vm_proxy.segments,
             &keccak_ptr_end,
             &padding,
             Some(vm_proxy.prime),

--- a/src/vm/hints/cairo_keccak/keccak_hints.rs
+++ b/src/vm/hints/cairo_keccak/keccak_hints.rs
@@ -105,7 +105,7 @@ pub fn compare_keccak_full_rate_in_bytes_nondet(
     let n_bytes = get_integer_from_var_name("n_bytes", ids, vm_proxy, hint_ap_tracking)?;
 
     let value = bigint!((n_bytes >= &KECCAK_FULL_RATE_IN_BYTES) as usize);
-    insert_value_into_ap(vm_proxy.memory, vm_proxy.run_context, value)
+    insert_value_into_ap(&mut vm_proxy.memory, vm_proxy.run_context, value)
 }
 
 /*

--- a/src/vm/hints/dict_hint_utils.rs
+++ b/src/vm/hints/dict_hint_utils.rs
@@ -57,14 +57,14 @@ pub fn dict_new(
     let base = if let Ok(dict_manager) = exec_scopes_proxy.get_dict_manager() {
         dict_manager
             .borrow_mut()
-            .new_dict(vm_proxy.segments, vm_proxy.memory, initial_dict)?
+            .new_dict(vm_proxy.segments, &mut vm_proxy.memory, initial_dict)?
     } else {
         let mut dict_manager = DictManager::new();
-        let base = dict_manager.new_dict(vm_proxy.segments, vm_proxy.memory, initial_dict)?;
+        let base = dict_manager.new_dict(vm_proxy.segments, &mut vm_proxy.memory, initial_dict)?;
         exec_scopes_proxy.insert_value("dict_manager", Rc::new(RefCell::new(dict_manager)));
         base
     };
-    insert_value_into_ap(vm_proxy.memory, vm_proxy.run_context, base)
+    insert_value_into_ap(&mut vm_proxy.memory, vm_proxy.run_context, base)
 }
 
 /*Implements hint:
@@ -92,7 +92,7 @@ pub fn default_dict_new(
     let base = if let Ok(dict_manager) = exec_scopes_proxy.get_dict_manager() {
         dict_manager.borrow_mut().new_default_dict(
             vm_proxy.segments,
-            vm_proxy.memory,
+            &mut vm_proxy.memory,
             &default_value,
             initial_dict,
         )?
@@ -100,14 +100,14 @@ pub fn default_dict_new(
         let mut dict_manager = DictManager::new();
         let base = dict_manager.new_default_dict(
             vm_proxy.segments,
-            vm_proxy.memory,
+            &mut vm_proxy.memory,
             &default_value,
             initial_dict,
         )?;
         exec_scopes_proxy.insert_value("dict_manager", Rc::new(RefCell::new(dict_manager)));
         base
     };
-    insert_value_into_ap(vm_proxy.memory, vm_proxy.run_context, base)
+    insert_value_into_ap(&mut vm_proxy.memory, vm_proxy.run_context, base)
 }
 
 /* Implements hint:

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -54,6 +54,7 @@ use crate::vm::hints::usort::{
     verify_usort,
 };
 use crate::vm::vm_core::{VMProxy, VirtualMachine};
+use crate::vm::vm_memory::memory::get_memory_proxy;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct HintReference {
@@ -68,7 +69,7 @@ pub struct HintReference {
 
 pub fn get_vm_proxy(vm: &mut VirtualMachine) -> VMProxy {
     VMProxy {
-        memory: &mut vm.memory,
+        memory: get_memory_proxy(&mut vm.memory),
         segments: &mut vm.segments,
         run_context: &mut vm.run_context,
         builtin_runners: &vm.builtin_runners,

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -273,7 +273,7 @@ pub fn get_integer_from_var_name<'a>(
 
 ///Implements hint: memory[ap] = segments.add()
 pub fn add_segment(vm_proxy: &mut VMProxy) -> Result<(), VirtualMachineError> {
-    let new_segment_base = vm_proxy.memory.add(&mut vm_proxy.segments);
+    let new_segment_base = vm_proxy.memory.add_segment(vm_proxy.segments);
     insert_value_into_ap(&mut vm_proxy.memory, vm_proxy.run_context, new_segment_base)
 }
 

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -6,7 +6,7 @@ use crate::types::relocatable::Relocatable;
 use crate::types::{instruction::Register, relocatable::MaybeRelocatable};
 use crate::vm::runners::builtin_runner::BuiltinRunner;
 use crate::vm::vm_core::VMProxy;
-use crate::vm::vm_memory::memory::Memory;
+use crate::vm::vm_memory::memory::MemoryProxy;
 use crate::vm::{
     context::run_context::RunContext, errors::vm_errors::VirtualMachineError,
     hints::execute_hint::HintReference, runners::builtin_runner::RangeCheckBuiltinRunner,
@@ -103,7 +103,7 @@ fn apply_ap_tracking_correction(
 pub fn compute_addr_from_reference(
     hint_reference: &HintReference,
     run_context: &RunContext,
-    memory: &Memory,
+    memory: &MemoryProxy,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<Option<MaybeRelocatable>, VirtualMachineError> {
     let base_addr = match hint_reference.register {
@@ -178,7 +178,7 @@ pub fn get_address_from_reference(
     reference_id: &BigInt,
     references: &HashMap<usize, HintReference>,
     run_context: &RunContext,
-    memory: &Memory,
+    memory: &MemoryProxy,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<Option<MaybeRelocatable>, VirtualMachineError> {
     if let Some(index) = reference_id.to_usize() {
@@ -209,7 +209,7 @@ pub fn get_address_from_var_name(
         var_ref,
         vm_proxy.references,
         vm_proxy.run_context,
-        vm_proxy.memory,
+        &vm_proxy.memory,
         hint_ap_tracking,
     )
     .map_err(|_| VirtualMachineError::FailedToGetIds)?
@@ -229,7 +229,7 @@ pub fn insert_value_from_var_name(
 
 //Inserts value into ap
 pub fn insert_value_into_ap(
-    memory: &mut Memory,
+    memory: &mut MemoryProxy,
     run_context: &RunContext,
     value: impl Into<MaybeRelocatable>,
 ) -> Result<(), VirtualMachineError> {
@@ -273,8 +273,8 @@ pub fn get_integer_from_var_name<'a>(
 
 ///Implements hint: memory[ap] = segments.add()
 pub fn add_segment(vm_proxy: &mut VMProxy) -> Result<(), VirtualMachineError> {
-    let new_segment_base = vm_proxy.segments.add(vm_proxy.memory, None);
-    insert_value_into_ap(vm_proxy.memory, vm_proxy.run_context, new_segment_base)
+    let new_segment_base = vm_proxy.memory.add(&mut vm_proxy.segments);
+    insert_value_into_ap(&mut vm_proxy.memory, vm_proxy.run_context, new_segment_base)
 }
 
 //Implements hint: vm_enter_scope()

--- a/src/vm/hints/keccak_utils.rs
+++ b/src/vm/hints/keccak_utils.rs
@@ -97,19 +97,8 @@ pub fn unsafe_keccak(
     let high = BigInt::from_bytes_be(Sign::Plus, &hashed[..16]);
     let low = BigInt::from_bytes_be(Sign::Plus, &hashed[16..32]);
 
-    match (
-        vm_proxy.memory.insert(
-            &MaybeRelocatable::RelocatableValue(high_addr),
-            &MaybeRelocatable::Int(high),
-        ),
-        vm_proxy.memory.insert(
-            &MaybeRelocatable::RelocatableValue(low_addr),
-            &MaybeRelocatable::Int(low),
-        ),
-    ) {
-        (Ok(_), Ok(_)) => Ok(()),
-        (Err(error), _) | (_, Err(error)) => Err(VirtualMachineError::MemoryError(error)),
-    }
+    vm_proxy.memory.insert_value(&high_addr, &high)?;
+    vm_proxy.memory.insert_value(&low_addr, &low)
 }
 
 /*
@@ -199,19 +188,8 @@ pub fn unsafe_keccak_finalize(
     let high = BigInt::from_bytes_be(Sign::Plus, &hashed[..16]);
     let low = BigInt::from_bytes_be(Sign::Plus, &hashed[16..32]);
 
-    match (
-        vm_proxy.memory.insert(
-            &MaybeRelocatable::RelocatableValue(high_addr),
-            &MaybeRelocatable::Int(high),
-        ),
-        vm_proxy.memory.insert(
-            &MaybeRelocatable::RelocatableValue(low_addr),
-            &MaybeRelocatable::Int(low),
-        ),
-    ) {
-        (Ok(_), Ok(_)) => Ok(()),
-        (Err(error), _) | (_, Err(error)) => Err(VirtualMachineError::MemoryError(error)),
-    }
+    vm_proxy.memory.insert_value(&high_addr, &high)?;
+    vm_proxy.memory.insert_value(&low_addr, &low)
 }
 
 fn left_pad(bytes_vector: &mut [u8], n_zeros: usize) -> Vec<u8> {

--- a/src/vm/hints/math_utils.rs
+++ b/src/vm/hints/math_utils.rs
@@ -35,7 +35,7 @@ pub fn is_nn(
     } else {
         bigint!(1)
     };
-    insert_value_into_ap(vm_proxy.memory, vm_proxy.run_context, value)
+    insert_value_into_ap(&mut vm_proxy.memory, vm_proxy.run_context, value)
 }
 
 //Implements hint: memory[ap] = 0 if 0 <= ((-ids.a - 1) % PRIME) < range_check_builtin.bound else 1
@@ -52,7 +52,7 @@ pub fn is_nn_out_of_range(
     } else {
         bigint!(1)
     };
-    insert_value_into_ap(vm_proxy.memory, vm_proxy.run_context, value)
+    insert_value_into_ap(&mut vm_proxy.memory, vm_proxy.run_context, value)
 }
 //Implements hint:from starkware.cairo.common.math_utils import assert_integer
 //        assert_integer(ids.a)
@@ -99,7 +99,7 @@ pub fn is_le_felt(
     } else {
         bigint!(0)
     };
-    insert_value_into_ap(vm_proxy.memory, vm_proxy.run_context, value)
+    insert_value_into_ap(&mut vm_proxy.memory, vm_proxy.run_context, value)
 }
 
 //Implements hint: from starkware.cairo.lang.vm.relocatable import RelocatableValue

--- a/src/vm/hints/secp/bigint_utils.rs
+++ b/src/vm/hints/secp/bigint_utils.rs
@@ -29,8 +29,8 @@ pub fn nondet_bigint3(
     let value = exec_scopes_proxy.get_int_ref("value")?;
     let arg: Vec<BigInt> = split(value)?.to_vec();
     vm_proxy
-        .segments
-        .write_arg(vm_proxy.memory, &res_reloc, &arg, Some(vm_proxy.prime))
+        .memory
+        .write_arg(vm_proxy.segments, &res_reloc, &arg, Some(vm_proxy.prime))
         .map_err(VirtualMachineError::MemoryError)?;
     Ok(())
 }

--- a/src/vm/hints/secp/ec_utils.rs
+++ b/src/vm/hints/secp/ec_utils.rs
@@ -321,7 +321,7 @@ pub fn ec_mul_inner(
     let scalar = get_integer_from_var_name("scalar", ids, vm_proxy, hint_ap_tracking)?
         .mod_floor(vm_proxy.prime)
         .bitand(bigint!(1));
-    insert_value_into_ap(vm_proxy.memory, vm_proxy.run_context, scalar)
+    insert_value_into_ap(&mut vm_proxy.memory, vm_proxy.run_context, scalar)
 }
 
 #[cfg(test)]

--- a/src/vm/hints/secp/field_utils.rs
+++ b/src/vm/hints/secp/field_utils.rs
@@ -115,7 +115,7 @@ pub fn is_zero_nondet(
     let x = exec_scopes_proxy.get_int("x")?;
 
     let value = bigint!(x.is_zero() as usize);
-    insert_value_into_ap(vm_proxy.memory, vm_proxy.run_context, value)
+    insert_value_into_ap(&mut vm_proxy.memory, vm_proxy.run_context, value)
 }
 
 /*

--- a/src/vm/hints/sha256_utils.rs
+++ b/src/vm/hints/sha256_utils.rs
@@ -72,8 +72,13 @@ pub fn sha256_main(
     let output_base = get_ptr_from_var_name("output", ids, vm_proxy, hint_ap_tracking)?;
 
     vm_proxy
-        .segments
-        .write_arg(vm_proxy.memory, &output_base, &output, Some(vm_proxy.prime))
+        .memory
+        .write_arg(
+            vm_proxy.segments,
+            &output_base,
+            &output,
+            Some(vm_proxy.prime),
+        )
         .map_err(VirtualMachineError::MemoryError)?;
     Ok(())
 }

--- a/src/vm/hints/sha256_utils.rs
+++ b/src/vm/hints/sha256_utils.rs
@@ -110,9 +110,9 @@ pub fn sha256_finalize(
     }
 
     vm_proxy
-        .segments
+        .memory
         .write_arg(
-            vm_proxy.memory,
+            vm_proxy.segments,
             &sha256_ptr_end,
             &padding,
             Some(vm_proxy.prime),

--- a/src/vm/hints/uint256_utils.rs
+++ b/src/vm/hints/uint256_utils.rs
@@ -136,7 +136,7 @@ pub fn uint256_signed_nn(
         } else {
             bigint!(0)
         };
-    insert_value_into_ap(vm_proxy.memory, vm_proxy.run_context, result)
+    insert_value_into_ap(&mut vm_proxy.memory, vm_proxy.run_context, result)
 }
 
 /*

--- a/src/vm/hints/usort.rs
+++ b/src/vm/hints/usort.rs
@@ -68,10 +68,8 @@ pub fn usort_body(
         multiplicities.push(positions_dict[k].len());
     }
     exec_scopes_proxy.insert_value("positions_dict", positions_dict);
-    let output_base = vm_proxy.segments.add(vm_proxy.memory, Some(output.len()));
-    let multiplicities_base = vm_proxy
-        .segments
-        .add(vm_proxy.memory, Some(multiplicities.len()));
+    let output_base = vm_proxy.memory.add_segment(vm_proxy.segments);
+    let multiplicities_base = vm_proxy.memory.add_segment(vm_proxy.segments);
     let output_len = output.len();
 
     for (i, sorted_element) in output.into_iter().enumerate() {

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -18,6 +18,7 @@ use num_traits::ToPrimitive;
 use std::collections::HashMap;
 
 use super::hints::execute_hint::{get_vm_proxy, HintReference};
+use super::vm_memory::memory::MemoryProxy;
 
 #[derive(PartialEq, Debug)]
 pub struct Operands {
@@ -39,7 +40,7 @@ pub struct HintData {
 }
 
 pub struct VMProxy<'a> {
-    pub memory: &'a mut Memory,
+    pub memory: MemoryProxy<'a>,
     pub segments: &'a mut MemorySegmentManager,
     pub run_context: &'a mut RunContext,
     pub builtin_runners: &'a Vec<(String, Box<dyn BuiltinRunner>)>,

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -15,6 +15,10 @@ pub struct Memory {
     pub validation_rules: HashMap<usize, ValidationRule>,
 }
 
+pub struct MemoryProxy<'a> {
+    memory: &'a mut Memory,
+}
+
 impl Memory {
     pub fn new() -> Memory {
         Memory {
@@ -176,6 +180,40 @@ impl Memory {
 impl Default for Memory {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl MemoryProxy<'_> {
+    pub fn insert_value<T: Into<MaybeRelocatable>>(
+        &mut self,
+        key: &Relocatable,
+        val: T,
+    ) -> Result<(), VirtualMachineError> {
+        self.memory.insert_value(key, val)
+    }
+
+    pub fn get_integer(&self, key: &Relocatable) -> Result<&BigInt, VirtualMachineError> {
+        self.memory.get_integer(key)
+    }
+
+    pub fn get_relocatable(&self, key: &Relocatable) -> Result<&Relocatable, VirtualMachineError> {
+        self.memory.get_relocatable(key)
+    }
+
+    pub fn get_range(
+        &self,
+        addr: &MaybeRelocatable,
+        size: usize,
+    ) -> Result<Vec<Option<&MaybeRelocatable>>, MemoryError> {
+        self.memory.get_range(addr, size)
+    }
+
+    pub fn get_integer_range(
+        &self,
+        addr: &Relocatable,
+        size: usize,
+    ) -> Result<Vec<&BigInt>, VirtualMachineError> {
+        self.memory.get_integer_range(addr, size)
     }
 }
 

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -187,9 +187,7 @@ impl Default for Memory {
 }
 
 pub fn get_memory_proxy(memory: &mut Memory) -> MemoryProxy {
-    MemoryProxy {
-        memory: &mut memory,
-    }
+    MemoryProxy { memory }
 }
 
 impl MemoryProxy<'_> {
@@ -242,8 +240,18 @@ impl MemoryProxy<'_> {
         segments.write_arg(self.memory, ptr, arg, prime)
     }
 
-    pub fn add(&mut self, segments: &mut MemorySegmentManager) -> Relocatable {
+    pub fn add_segment(&mut self, segments: &mut MemorySegmentManager) -> Relocatable {
         segments.add(self.memory, None)
+    }
+
+    ///Writes data into the memory at address ptr and returns the first address after the data.
+    pub fn load_data(
+        &mut self,
+        segments: &mut MemorySegmentManager,
+        ptr: &MaybeRelocatable,
+        data: Vec<MaybeRelocatable>,
+    ) -> Result<MaybeRelocatable, MemoryError> {
+        segments.load_data(self.memory, ptr, data)
     }
 }
 

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -183,6 +183,12 @@ impl Default for Memory {
     }
 }
 
+pub fn get_memory_proxy(memory: &mut Memory) -> MemoryProxy {
+    MemoryProxy {
+        memory: &mut memory,
+    }
+}
+
 impl MemoryProxy<'_> {
     pub fn insert_value<T: Into<MaybeRelocatable>>(
         &mut self,


### PR DESCRIPTION
Aims to create a Proxy for Memory that would only allow access to methods, in order to prevent hints from changing VM behavior.

Depends on #365 