### PR TITLE
Refactor reference_ids from HashMap<String, BigInt> to HashMap<String, usize>

### DIFF
--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -30,7 +30,7 @@ pub struct HintParams {
 #[derive(Deserialize, Debug, Clone, PartialEq)]
 pub struct FlowTrackingData {
     pub ap_tracking: ApTracking,
-    #[serde(deserialize_with = "deserialize_map_to_string_and_bigint_hashmap")]
+    #[serde(deserialize_with = "deserialize_map_to_string_and_uint_hashmap")]
     pub reference_ids: HashMap<String, usize>,
 }
 
@@ -226,7 +226,7 @@ pub fn deserialize_array_of_bigint_hex<'de, D: Deserializer<'de>>(
     d.deserialize_seq(MaybeRelocatableVisitor)
 }
 
-pub fn deserialize_map_to_string_and_bigint_hashmap<'de, D: Deserializer<'de>>(
+pub fn deserialize_map_to_string_and_uint_hashmap<'de, D: Deserializer<'de>>(
     d: D,
 ) -> Result<HashMap<String, usize>, D::Error> {
     d.deserialize_map(ReferenceIdsVisitor)

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -30,7 +30,7 @@ pub struct HintParams {
 #[derive(Deserialize, Debug, Clone, PartialEq)]
 pub struct FlowTrackingData {
     pub ap_tracking: ApTracking,
-    #[serde(deserialize_with = "deserialize_map_to_string_and_uint_hashmap")]
+    #[serde(deserialize_with = "deserialize_map_to_string_and_usize_hashmap")]
     pub reference_ids: HashMap<String, usize>,
 }
 
@@ -226,7 +226,7 @@ pub fn deserialize_array_of_bigint_hex<'de, D: Deserializer<'de>>(
     d.deserialize_seq(MaybeRelocatableVisitor)
 }
 
-pub fn deserialize_map_to_string_and_uint_hashmap<'de, D: Deserializer<'de>>(
+pub fn deserialize_map_to_string_and_usize_hashmap<'de, D: Deserializer<'de>>(
     d: D,
 ) -> Result<HashMap<String, usize>, D::Error> {
     d.deserialize_map(ReferenceIdsVisitor)

--- a/src/types/hint_executor.rs
+++ b/src/types/hint_executor.rs
@@ -1,7 +1,6 @@
 use crate::serde::deserialize_program::ApTracking;
 use crate::vm::errors::vm_errors::VirtualMachineError;
 use crate::vm::vm_core::VMProxy;
-use num_bigint::BigInt;
 use std::collections::HashMap;
 
 pub trait HintExecutor {
@@ -9,7 +8,7 @@ pub trait HintExecutor {
         &self,
         vm: &mut VMProxy,
         hint_code: &str,
-        ref_ids: &HashMap<String, BigInt>,
+        ref_ids: &HashMap<String, usize>,
         ap_tracking: &ApTracking,
     ) -> Result<(), VirtualMachineError>;
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -198,12 +198,12 @@ pub mod test_utils {
     macro_rules! ids {
         ( $( $name: expr ),* ) => {
             {
-                let mut ids = HashMap::<String, BigInt>::new();
+                let mut ids = HashMap::<String, usize>::new();
+                //let mut num = -1;
                 let mut num = -1;
                 $(
                     num += 1;
-                    ids_inner!($name, num, ids);
-
+                    ids_inner!($name, num.try_into().unwrap(), ids);
                 )*
                 ids
             }
@@ -213,7 +213,7 @@ pub mod test_utils {
 
     macro_rules! ids_inner {
         ( $name: expr, $num: expr, $ids: expr ) => {
-            $ids.insert(String::from($name), bigint!($num))
+            $ids.insert(String::from($name), $num)
         };
     }
     pub(crate) use ids_inner;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -199,7 +199,6 @@ pub mod test_utils {
         ( $( $name: expr ),* ) => {
             {
                 let mut ids = HashMap::<String, usize>::new();
-                //let mut num = -1;
                 let mut num = -1;
                 $(
                     num += 1;

--- a/src/vm/hints/blake2s_utils.rs
+++ b/src/vm/hints/blake2s_utils.rs
@@ -72,7 +72,7 @@ fn compute_blake2s_func(
 */
 pub fn compute_blake2s(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let output = get_ptr_from_var_name("output", ids, vm_proxy, hint_ap_tracking)?;
@@ -103,7 +103,7 @@ pub fn compute_blake2s(
 */
 pub fn finalize_blake2s(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     const N_PACKED_INSTANCES: usize = 7;
@@ -142,7 +142,7 @@ pub fn finalize_blake2s(
 */
 pub fn blake2s_add_uint256(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Get variables from ids
@@ -198,7 +198,7 @@ pub fn blake2s_add_uint256(
 */
 pub fn blake2s_add_uint256_bigend(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Get variables from ids

--- a/src/vm/hints/cairo_keccak/keccak_hints.rs
+++ b/src/vm/hints/cairo_keccak/keccak_hints.rs
@@ -31,7 +31,7 @@ Implements hint:
 */
 pub fn keccak_write_args(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let inputs_ptr = get_ptr_from_var_name("inputs", ids, vm_proxy, hint_ap_tracking)?;
@@ -75,7 +75,7 @@ Implements hint:
 */
 pub fn compare_bytes_in_word_nondet(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let n_bytes = get_integer_from_var_name("n_bytes", ids, vm_proxy, hint_ap_tracking)?;
@@ -99,7 +99,7 @@ Implements hint:
 */
 pub fn compare_keccak_full_rate_in_bytes_nondet(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let n_bytes = get_integer_from_var_name("n_bytes", ids, vm_proxy, hint_ap_tracking)?;
@@ -122,7 +122,7 @@ Implements hint:
 */
 pub fn block_permutation(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     // these checks may not make sense now, but will when constants are
@@ -178,7 +178,7 @@ pub fn block_permutation(
 */
 pub fn cairo_keccak_finalize(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     // these checks may not make sense now, but will when constants are

--- a/src/vm/hints/dict_hint_utils.rs
+++ b/src/vm/hints/dict_hint_utils.rs
@@ -58,7 +58,7 @@ is not available, an empty dict is created always
 */
 pub fn default_dict_new(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
@@ -83,7 +83,7 @@ pub fn default_dict_new(
 */
 pub fn dict_read(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let key = get_integer_from_var_name("key", ids, vm_proxy, hint_ap_tracking)?.clone();
@@ -102,7 +102,7 @@ pub fn dict_read(
 */
 pub fn dict_write(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let key = get_integer_from_var_name("key", ids, vm_proxy, hint_ap_tracking)?.clone();
@@ -141,7 +141,7 @@ pub fn dict_write(
 */
 pub fn dict_update(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let key = get_integer_from_var_name("key", ids, vm_proxy, hint_ap_tracking)?.clone();
@@ -180,7 +180,7 @@ pub fn dict_update(
 */
 pub fn dict_squash_copy_dict(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let dict_accesses_end =
@@ -204,7 +204,7 @@ pub fn dict_squash_copy_dict(
 */
 pub fn dict_squash_update_ptr(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let squashed_dict_start =

--- a/src/vm/hints/execute_hint.rs
+++ b/src/vm/hints/execute_hint.rs
@@ -109,7 +109,7 @@ impl HintExecutor for BuiltinHintExecutor {
         &self,
         vm_proxy: &mut VMProxy,
         code: &str,
-        ids: &HashMap<String, BigInt>,
+        ids: &HashMap<String, usize>,
         ap_tracking: &ApTracking,
     ) -> Result<(), VirtualMachineError> {
         match code {
@@ -372,8 +372,8 @@ mod tests {
             )
             .unwrap();
 
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("len"), bigint!(0));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("len"), 0);
 
         //Create references
         vm.references = HashMap::from([(0, HintReference::new_simple(-2))]);
@@ -404,8 +404,8 @@ mod tests {
             )
             .unwrap();
 
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("len"), bigint!(0));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("len"), 0);
 
         // create references
         vm.references = HashMap::from([(0, HintReference::new_simple(-2))]);
@@ -442,8 +442,8 @@ mod tests {
             )
             .unwrap();
 
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("continue_copying"), bigint!(0));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("continue_copying"), 0);
 
         // create references
         vm.references = HashMap::from([(0, HintReference::new_simple(-2))]);
@@ -478,8 +478,8 @@ mod tests {
             )
             .unwrap();
 
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("continue_copying"), bigint!(0));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("continue_copying"), 0);
 
         // create references
         vm.references = HashMap::from([(0, HintReference::new_simple(-2))]);
@@ -516,8 +516,8 @@ mod tests {
             )
             .unwrap();
 
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("continue_copying"), bigint!(0));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("continue_copying"), 0);
 
         // create references
         vm.references = HashMap::from([(0, HintReference::new_simple(-2))]);
@@ -662,11 +662,11 @@ mod tests {
             )
             .unwrap();
 
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("length"), bigint!(0));
-        ids.insert(String::from("data"), bigint!(1));
-        ids.insert(String::from("high"), bigint!(2));
-        ids.insert(String::from("low"), bigint!(3));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("length"), 0);
+        ids.insert(String::from("data"), 1);
+        ids.insert(String::from("high"), 2);
+        ids.insert(String::from("low"), 3);
 
         vm.exec_scopes
             .assign_or_update_variable("__keccak_max_size", PyValueType::BigInt(bigint!(500)));
@@ -766,11 +766,11 @@ mod tests {
             )
             .unwrap();
 
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("length"), bigint!(0));
-        ids.insert(String::from("data"), bigint!(1));
-        ids.insert(String::from("high"), bigint!(2));
-        ids.insert(String::from("low"), bigint!(3));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("length"), 0);
+        ids.insert(String::from("data"), 1);
+        ids.insert(String::from("high"), 2);
+        ids.insert(String::from("low"), 3);
 
         vm.exec_scopes
             .assign_or_update_variable("__keccak_max_size", PyValueType::BigInt(bigint!(2)));
@@ -870,11 +870,11 @@ mod tests {
             )
             .unwrap();
 
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("length"), bigint!(0));
-        ids.insert(String::from("data"), bigint!(1));
-        ids.insert(String::from("high"), bigint!(2));
-        ids.insert(String::from("low"), bigint!(3));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("length"), 0);
+        ids.insert(String::from("data"), 1);
+        ids.insert(String::from("high"), 2);
+        ids.insert(String::from("low"), 3);
 
         //Create references
         vm.references = HashMap::from([
@@ -971,11 +971,11 @@ mod tests {
             )
             .unwrap();
 
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("length"), bigint!(0));
-        ids.insert(String::from("data"), bigint!(1));
-        ids.insert(String::from("high"), bigint!(2));
-        ids.insert(String::from("low"), bigint!(3));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("length"), 0);
+        ids.insert(String::from("data"), 1);
+        ids.insert(String::from("high"), 2);
+        ids.insert(String::from("low"), 3);
 
         vm.exec_scopes
             .assign_or_update_variable("__keccak_max_size", PyValueType::BigInt(bigint!(10)));
@@ -1076,10 +1076,10 @@ mod tests {
             )
             .unwrap();
 
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("keccak_state"), bigint!(0));
-        ids.insert(String::from("high"), bigint!(1));
-        ids.insert(String::from("low"), bigint!(2));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("keccak_state"), 0);
+        ids.insert(String::from("high"), 1);
+        ids.insert(String::from("low"), 2);
 
         //Create references
         vm.references = HashMap::from([
@@ -1169,10 +1169,10 @@ mod tests {
             )
             .unwrap();
 
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("keccak_state"), bigint!(0));
-        ids.insert(String::from("high"), bigint!(1));
-        ids.insert(String::from("low"), bigint!(2));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("keccak_state"), 0);
+        ids.insert(String::from("high"), 1);
+        ids.insert(String::from("low"), 2);
 
         //Create references
         vm.references = HashMap::from([
@@ -1270,10 +1270,10 @@ mod tests {
             )
             .unwrap();
 
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("keccak_state"), bigint!(0));
-        ids.insert(String::from("high"), bigint!(1));
-        ids.insert(String::from("low"), bigint!(2));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("keccak_state"), 0);
+        ids.insert(String::from("high"), 1);
+        ids.insert(String::from("low"), 2);
 
         //Create references
         vm.references = HashMap::from([

--- a/src/vm/hints/find_element_hint.rs
+++ b/src/vm/hints/find_element_hint.rs
@@ -18,7 +18,7 @@ use super::hint_utils::insert_value_from_var_name;
 
 pub fn find_element(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let key = get_integer_from_var_name("key", ids, vm_proxy, hint_ap_tracking)?;
@@ -100,7 +100,7 @@ pub fn find_element(
 
 pub fn search_sorted_lower(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let find_element_max_size = get_int_from_scope(vm_proxy.exec_scopes, "find_element_max_size");
@@ -172,7 +172,7 @@ mod tests {
 
     fn init_vm_ids(
         values_to_override: HashMap<String, MaybeRelocatable>,
-    ) -> (VirtualMachine, HashMap<String, BigInt>) {
+    ) -> (VirtualMachine, HashMap<String, usize>) {
         let mut vm = VirtualMachine::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             vec![],
@@ -243,12 +243,12 @@ mod tests {
             );
         }
 
-        let mut ids = HashMap::<String, BigInt>::new();
+        let mut ids = HashMap::<String, usize>::new();
         for (i, s) in ["array_ptr", "elm_size", "n_elms", "index", "key"]
             .iter()
             .enumerate()
         {
-            ids.insert(s.to_string(), bigint!(i));
+            ids.insert(s.to_string(), i);
         }
 
         (vm, ids)
@@ -354,12 +354,12 @@ mod tests {
             );
         }
 
-        let mut ids = HashMap::<String, BigInt>::new();
+        let mut ids = HashMap::<String, usize>::new();
         for (i, s) in ["array_ptr", "elm_size", "n_elms", "index", "key"]
             .iter()
             .enumerate()
         {
-            ids.insert(s.to_string(), bigint!(i as i32));
+            ids.insert(s.to_string(), i);
         }
         let mut vm_proxy = get_vm_proxy(&mut vm);
         assert_eq!(
@@ -562,12 +562,12 @@ mod tests {
             );
         }
 
-        let mut ids = HashMap::<String, BigInt>::new();
+        let mut ids = HashMap::<String, usize>::new();
         for (i, s) in ["array_ptr", "elm_size", "n_elms", "index", "key"]
             .iter()
             .enumerate()
         {
-            ids.insert(s.to_string(), bigint!(i as i32));
+            ids.insert(s.to_string(), i);
         }
 
         let mut vm_proxy = get_vm_proxy(&mut vm);

--- a/src/vm/hints/hint_utils.rs
+++ b/src/vm/hints/hint_utils.rs
@@ -194,7 +194,7 @@ pub fn get_range_check_builtin(
 
 pub fn get_ptr_from_var_name(
     var_name: &str,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     vm_proxy: &VMProxy,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<Relocatable, VirtualMachineError> {
@@ -323,7 +323,7 @@ pub fn compute_addr_from_reference(
 
 ///Computes the memory address given by the reference id
 pub fn get_address_from_reference(
-    reference_id: &BigInt,
+    reference_id: &usize,
     references: &HashMap<usize, HintReference>,
     run_context: &RunContext,
     memory: &Memory,
@@ -346,7 +346,7 @@ pub fn get_address_from_reference(
 
 pub fn get_address_from_var_name(
     var_name: &str,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     vm_proxy: &VMProxy,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<MaybeRelocatable, VirtualMachineError> {
@@ -367,7 +367,7 @@ pub fn get_address_from_var_name(
 pub fn insert_value_from_var_name(
     var_name: &str,
     value: impl Into<MaybeRelocatable>,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     vm_proxy: &mut VMProxy,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
@@ -396,7 +396,7 @@ pub fn insert_value_into_ap(
 //else raises Err
 pub fn get_relocatable_from_var_name(
     var_name: &str,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     vm_proxy: &VMProxy,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<Relocatable, VirtualMachineError> {
@@ -411,7 +411,7 @@ pub fn get_relocatable_from_var_name(
 //else raises Err
 pub fn get_integer_from_var_name<'a>(
     var_name: &str,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     vm_proxy: &'a VMProxy,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<&'a BigInt, VirtualMachineError> {
@@ -444,7 +444,7 @@ pub fn exit_scope(vm_proxy: &mut VMProxy) -> Result<(), VirtualMachineError> {
 //  %{ vm_enter_scope({'n': ids.len}) %}
 pub fn memcpy_enter_scope(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let len = get_integer_from_var_name("len", ids, vm_proxy, hint_ap_tracking)?.clone();
@@ -462,7 +462,7 @@ pub fn memcpy_enter_scope(
 // %}
 pub fn memcpy_continue_copying(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     // get `n` variable from vm scope
@@ -517,8 +517,8 @@ mod tests {
         let var_name: &str = "variable";
 
         //Create ids
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("variable"), bigint!(0));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("variable"), 0);
 
         //Insert ids.prev_locs.exp into memory
         vm.memory
@@ -549,8 +549,8 @@ mod tests {
         let var_name: &str = "variable";
 
         //Create ids
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("variable"), bigint!(0));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("variable"), 0);
 
         //Insert ids.variable into memory as a RelocatableValue
         vm.memory

--- a/src/vm/hints/keccak_utils.rs
+++ b/src/vm/hints/keccak_utils.rs
@@ -39,7 +39,7 @@ use std::{cmp, collections::HashMap, ops::Shl};
 */
 pub fn unsafe_keccak(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let length = get_integer_from_var_name("length", ids, vm_proxy, hint_ap_tracking)?;
@@ -127,7 +127,7 @@ Implements hint:
  */
 pub fn unsafe_keccak_finalize(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     /* -----------------------------

--- a/src/vm/hints/math_utils.rs
+++ b/src/vm/hints/math_utils.rs
@@ -22,7 +22,7 @@ use crate::{
 //Implements hint: memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1
 pub fn is_nn(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let a = get_integer_from_var_name("a", ids, vm_proxy, hint_ap_tracking)?;
@@ -41,7 +41,7 @@ pub fn is_nn(
 //Implements hint: memory[ap] = 0 if 0 <= ((-ids.a - 1) % PRIME) < range_check_builtin.bound else 1
 pub fn is_nn_out_of_range(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let a = get_integer_from_var_name("a", ids, vm_proxy, hint_ap_tracking)?;
@@ -64,7 +64,7 @@ pub fn is_nn_out_of_range(
 //            a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)
 pub fn assert_le_felt(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let a = get_integer_from_var_name("a", ids, vm_proxy, hint_ap_tracking)?;
@@ -87,7 +87,7 @@ pub fn assert_le_felt(
 //    memory[ap] = 0 if (ids.a % PRIME) <= (ids.b % PRIME) else 1
 pub fn is_le_felt(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let a_mod =
@@ -112,7 +112,7 @@ pub fn is_le_felt(
 //        assert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'
 pub fn assert_not_equal(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let a_addr = get_address_from_var_name("a", ids, vm_proxy, hint_ap_tracking)?;
@@ -158,7 +158,7 @@ pub fn assert_not_equal(
 // %}
 pub fn assert_nn(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let a = get_integer_from_var_name("a", ids, vm_proxy, hint_ap_tracking)?;
@@ -179,7 +179,7 @@ pub fn assert_nn(
 // %}
 pub fn assert_not_zero(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let value = get_integer_from_var_name("value", ids, vm_proxy, hint_ap_tracking)?;
@@ -195,7 +195,7 @@ pub fn assert_not_zero(
 //Implements hint: assert ids.value == 0, 'split_int(): value is out of range.'
 pub fn split_int_assert_range(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let value = get_integer_from_var_name("value", ids, vm_proxy, hint_ap_tracking)?;
@@ -210,7 +210,7 @@ pub fn split_int_assert_range(
 //        assert res < ids.bound, f'split_int(): Limb {res} is out of range.'
 pub fn split_int(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let value = get_integer_from_var_name("value", ids, vm_proxy, hint_ap_tracking)?;
@@ -230,7 +230,7 @@ pub fn split_int(
 //    value=ids.value, prime=PRIME, rc_bound=range_check_builtin.bound) else 0
 pub fn is_positive(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let value = get_integer_from_var_name("value", ids, vm_proxy, hint_ap_tracking)?;
@@ -259,7 +259,7 @@ pub fn is_positive(
 // %}
 pub fn split_felt(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let value = get_integer_from_var_name("value", ids, vm_proxy, hint_ap_tracking)?;
@@ -280,7 +280,7 @@ pub fn split_felt(
 //        ids.root = isqrt(value)
 pub fn sqrt(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let mod_value = get_integer_from_var_name("value", ids, vm_proxy, hint_ap_tracking)?
@@ -294,7 +294,7 @@ pub fn sqrt(
 
 pub fn signed_div_rem(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let div = get_integer_from_var_name("div", ids, vm_proxy, hint_ap_tracking)?;
@@ -337,7 +337,7 @@ ids.q, ids.r = divmod(ids.value, ids.div)
 */
 pub fn unsigned_div_rem(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let div = get_integer_from_var_name("div", ids, vm_proxy, hint_ap_tracking)?;
@@ -363,7 +363,7 @@ pub fn unsigned_div_rem(
 //        ids.high, ids.low = divmod(ids.value, ids.SHIFT)
 pub fn assert_250_bit(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Declare constant values
@@ -392,7 +392,7 @@ Implements hint:
 */
 pub fn assert_lt_felt(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let a = get_integer_from_var_name("a", ids, vm_proxy, hint_ap_tracking)?;
@@ -776,8 +776,8 @@ mod tests {
         //Insert ids into memory
         vm.memory = memory![((0, 0), (-1))];
         //Create ids
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("a"), bigint!(2));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("a"), 2);
         //Create references
         vm.references = HashMap::from([(0, HintReference::new_simple(10))]);
         //Execute the hint
@@ -1260,8 +1260,8 @@ mod tests {
         //Insert ids into memory
         vm.memory = memory![((0, 0), 5)];
         //Create invalid id value
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("value"), bigint!(10));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("value"), 10);
         let mut vm_proxy = get_vm_proxy(&mut vm);
         assert_eq!(
             HINT_EXECUTOR.execute_hint(&mut vm_proxy, &hint_code, &ids, &ApTracking::new()),
@@ -2037,8 +2037,8 @@ mod tests {
             .unwrap();
 
         //Create incomplete ids
-        let mut incomplete_ids = HashMap::<String, BigInt>::new();
-        incomplete_ids.insert(String::from("value"), bigint!(0));
+        let mut incomplete_ids = HashMap::<String, usize>::new();
+        incomplete_ids.insert(String::from("value"), 0);
 
         //Create references
         vm.references = HashMap::from([

--- a/src/vm/hints/memset_utils.rs
+++ b/src/vm/hints/memset_utils.rs
@@ -16,7 +16,7 @@ use super::hint_utils::insert_value_from_var_name;
 //  %{ vm_enter_scope({'n': ids.n}) %}
 pub fn memset_enter_scope(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let n = get_integer_from_var_name("n", ids, vm_proxy, hint_ap_tracking)?.clone();
@@ -34,7 +34,7 @@ pub fn memset_enter_scope(
 */
 pub fn memset_continue_loop(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     // get `n` variable from vm scope
@@ -125,8 +125,8 @@ mod tests {
         // initialize ids.continue_loop
         // we create a memory gap so that there is None in (0, 1), the actual addr of continue_loop
         vm.memory = memory![((0, 2), 5)];
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("continue_loop"), bigint!(0));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("continue_loop"), 0);
 
         // create references
         vm.references = HashMap::from([(0, HintReference::new_simple(-2))]);
@@ -157,8 +157,8 @@ mod tests {
         // we create a memory gap so that there is None in (0, 1), the actual addr of continue_loop
         vm.memory = memory![((0, 2), 5)];
 
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("continue_loop"), bigint!(0));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("continue_loop"), 0);
 
         // create references
         vm.references = HashMap::from([(0, HintReference::new_simple(-2))]);
@@ -188,8 +188,8 @@ mod tests {
         // initialize ids.continue_loop
         // we create a memory gap so that there is None in (0, 1), the actual addr of continue_loop
         vm.memory = memory![((0, 2), 5)];
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("continue_loop"), bigint!(0));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("continue_loop"), 0);
 
         // create references
         vm.references = HashMap::from([(0, HintReference::new_simple(-2))]);
@@ -215,8 +215,8 @@ mod tests {
         // initialize ids.continue_loop
         // a value is written in the address so the hint cant insert value there
         vm.memory = memory![((0, 1), 5)];
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("continue_loop"), bigint!(0));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("continue_loop"), 0);
         // create references
         vm.references = HashMap::from([(0, HintReference::new_simple(-2))]);
         let mut vm_proxy = get_vm_proxy(&mut vm);

--- a/src/vm/hints/pow_utils.rs
+++ b/src/vm/hints/pow_utils.rs
@@ -14,7 +14,7 @@ Implements hint:
 */
 pub fn pow(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let prev_locs_addr =

--- a/src/vm/hints/secp/bigint_utils.rs
+++ b/src/vm/hints/secp/bigint_utils.rs
@@ -22,7 +22,7 @@ Implements hint:
 
 pub fn nondet_bigint3(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let res_reloc = get_relocatable_from_var_name("res", ids, vm_proxy, hint_ap_tracking)?;
@@ -39,7 +39,7 @@ pub fn nondet_bigint3(
 // %{ ids.low = (ids.x.d0 + ids.x.d1 * ids.BASE) & ((1 << 128) - 1) %}
 pub fn bigint_to_uint256(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let x_struct = get_relocatable_from_var_name("x", ids, vm_proxy, hint_ap_tracking)?;

--- a/src/vm/hints/secp/ec_utils.rs
+++ b/src/vm/hints/secp/ec_utils.rs
@@ -26,7 +26,7 @@ Implements hint:
 */
 pub fn ec_negate(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //ids.point
@@ -57,7 +57,7 @@ Implements hint:
 */
 pub fn compute_doubling_slope(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //ids.point
@@ -101,7 +101,7 @@ Implements hint:
 */
 pub fn compute_slope(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //ids.point0
@@ -158,7 +158,7 @@ Implements hint:
 */
 pub fn ec_double_assign_new_x(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //ids.slope
@@ -231,7 +231,7 @@ Implements hint:
 */
 pub fn fast_ec_add_assign_new_x(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //ids.slope
@@ -327,7 +327,7 @@ Implements hint:
 */
 pub fn ec_mul_inner(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //(ids.scalar % PRIME) % 2
@@ -659,7 +659,7 @@ mod tests {
             HINT_EXECUTOR.execute_hint(
                 &mut vm_proxy,
                 hint_code,
-                &HashMap::<String, BigInt>::new(),
+                &HashMap::<String, usize>::new(),
                 &ApTracking::new()
             ),
             Ok(())
@@ -803,7 +803,7 @@ mod tests {
             HINT_EXECUTOR.execute_hint(
                 &mut vm_proxy,
                 hint_code,
-                &HashMap::<String, BigInt>::new(),
+                &HashMap::<String, usize>::new(),
                 &ApTracking::new()
             ),
             Ok(())

--- a/src/vm/hints/secp/field_utils.rs
+++ b/src/vm/hints/secp/field_utils.rs
@@ -27,7 +27,7 @@ Implements hint:
 */
 pub fn verify_zero(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let val_reloc = get_relocatable_from_var_name("val", ids, vm_proxy, hint_ap_tracking)?;
@@ -66,7 +66,7 @@ Implements hint:
 */
 pub fn reduce(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let value = pack_from_var_name("x", ids, vm_proxy, hint_ap_tracking)?.mod_floor(&SECP_P);
@@ -84,7 +84,7 @@ Implements hint:
 */
 pub fn is_zero_pack(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let x_reloc = get_relocatable_from_var_name("x", ids, vm_proxy, hint_ap_tracking)?;
@@ -608,8 +608,8 @@ mod tests {
         vm.run_context.fp = MaybeRelocatable::from((1, 15));
 
         //Create ids
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("x"), bigint!(0i32));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("x"), 0);
 
         //Create references
         vm.references = HashMap::from([(
@@ -671,7 +671,7 @@ mod tests {
             HINT_EXECUTOR.execute_hint(
                 &mut vm_proxy,
                 hint_code,
-                &HashMap::<String, BigInt>::new(),
+                &HashMap::<String, usize>::new(),
                 &ApTracking::new()
             ),
             Ok(())
@@ -708,7 +708,7 @@ mod tests {
             HINT_EXECUTOR.execute_hint(
                 &mut vm_proxy,
                 hint_code,
-                &HashMap::<String, BigInt>::new(),
+                &HashMap::<String, usize>::new(),
                 &ApTracking::new()
             ),
             Ok(())
@@ -745,7 +745,7 @@ mod tests {
             HINT_EXECUTOR.execute_hint(
                 &mut vm_proxy,
                 hint_code,
-                &HashMap::<String, BigInt>::new(),
+                &HashMap::<String, usize>::new(),
                 &ApTracking::new()
             ),
             Err(VirtualMachineError::VariableNotInScopeError(
@@ -775,7 +775,7 @@ mod tests {
             HINT_EXECUTOR.execute_hint(
                 &mut vm_proxy,
                 hint_code,
-                &HashMap::<String, BigInt>::new(),
+                &HashMap::<String, usize>::new(),
                 &ApTracking::new()
             ),
             Err(VirtualMachineError::MemoryError(
@@ -807,7 +807,7 @@ mod tests {
             HINT_EXECUTOR.execute_hint(
                 &mut vm_proxy,
                 hint_code,
-                &HashMap::<String, BigInt>::new(),
+                &HashMap::<String, usize>::new(),
                 &ApTracking::new()
             ),
             Ok(())
@@ -845,7 +845,7 @@ mod tests {
             HINT_EXECUTOR.execute_hint(
                 &mut vm_proxy,
                 hint_code,
-                &HashMap::<String, BigInt>::new(),
+                &HashMap::<String, usize>::new(),
                 &ApTracking::new()
             ),
             Err(VirtualMachineError::VariableNotInScopeError(

--- a/src/vm/hints/secp/secp_utils.rs
+++ b/src/vm/hints/secp/secp_utils.rs
@@ -66,7 +66,7 @@ pub fn pack(d0: &BigInt, d1: &BigInt, d2: &BigInt, prime: &BigInt) -> BigInt {
 
 pub fn pack_from_var_name(
     name: &str,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     vm_proxy: &VMProxy,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<BigInt, VirtualMachineError> {

--- a/src/vm/hints/secp/signature.rs
+++ b/src/vm/hints/secp/signature.rs
@@ -12,7 +12,6 @@ use crate::{
         vm_core::VMProxy,
     },
 };
-use num_bigint::BigInt;
 use std::collections::HashMap;
 
 /* Implements hint:
@@ -25,7 +24,7 @@ value = res = div_mod(a, b, N)
 */
 pub fn div_mod_n_packed_divmod(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let a = pack_from_var_name("a", ids, vm_proxy, hint_ap_tracking)?;
@@ -54,7 +53,7 @@ pub fn div_mod_n_safe_div(vm_proxy: &mut VMProxy) -> Result<(), VirtualMachineEr
 
 pub fn get_point_from_x(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let x_cube_int = pack_from_var_name("x_cube", ids, vm_proxy, hint_ap_tracking)? % &*SECP_P;
@@ -83,7 +82,7 @@ mod tests {
             vm_memory::memory::Memory,
         },
     };
-    use num_bigint::Sign;
+    use num_bigint::{BigInt, Sign};
 
     #[test]
     fn safe_div_ok() {
@@ -115,10 +114,8 @@ mod tests {
             );
         }
 
-        let ids: HashMap<String, BigInt> = HashMap::from([
-            ("a".to_string(), bigint!(0_i32)),
-            ("b".to_string(), bigint!(3_i32)),
-        ]);
+        let ids: HashMap<String, usize> =
+            HashMap::from([("a".to_string(), 0), ("b".to_string(), 3)]);
         let mut vm_proxy = get_vm_proxy(&mut vm);
         assert_eq!(div_mod_n_packed_divmod(&mut vm_proxy, &ids, None), Ok(()));
         assert_eq!(div_mod_n_safe_div(&mut vm_proxy), Ok(()));
@@ -166,10 +163,8 @@ mod tests {
             );
         }
 
-        let ids: HashMap<String, BigInt> = HashMap::from([
-            ("v".to_string(), bigint!(0_i32)),
-            ("x_cube".to_string(), bigint!(1_i32)),
-        ]);
+        let ids: HashMap<String, usize> =
+            HashMap::from([("v".to_string(), 0), ("x_cube".to_string(), 1)]);
         let mut vm_proxy = get_vm_proxy(&mut vm);
         assert!(get_point_from_x(&mut vm_proxy, &ids, None).is_ok());
     }

--- a/src/vm/hints/set.rs
+++ b/src/vm/hints/set.rs
@@ -12,7 +12,7 @@ use super::hint_utils::{
 
 pub fn set_add(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let set_ptr = get_ptr_from_var_name("set_ptr", ids, vm_proxy, hint_ap_tracking)?;
@@ -88,7 +88,7 @@ mod tests {
         elm_size: Option<&MaybeRelocatable>,
         elm_a: Option<&MaybeRelocatable>,
         elm_b: Option<&MaybeRelocatable>,
-    ) -> (VirtualMachine, HashMap<String, BigInt>) {
+    ) -> (VirtualMachine, HashMap<String, usize>) {
         let mut vm = vm_with_range_check!();
 
         for _ in 0..3 {
@@ -205,7 +205,7 @@ mod tests {
             (5, HintReference::new_simple(0)),
         ]);
 
-        let mut ids = HashMap::<String, BigInt>::new();
+        let mut ids = HashMap::<String, usize>::new();
         for (i, s) in [
             "is_elm_in_set",
             "index",
@@ -217,7 +217,7 @@ mod tests {
         .iter()
         .enumerate()
         {
-            ids.insert(s.to_string(), bigint!(i as i32));
+            ids.insert(s.to_string(), i);
         }
 
         (vm, ids)

--- a/src/vm/hints/sha256_utils.rs
+++ b/src/vm/hints/sha256_utils.rs
@@ -26,7 +26,7 @@ const IV: [u32; SHA256_STATE_SIZE_FELTS] = [
 
 pub fn sha256_input(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let n_bytes = get_integer_from_var_name("n_bytes", ids, vm_proxy, hint_ap_tracking)?;
@@ -46,7 +46,7 @@ pub fn sha256_input(
 
 pub fn sha256_main(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let input_ptr = get_ptr_from_var_name("sha256_start", ids, vm_proxy, hint_ap_tracking)?;
@@ -80,7 +80,7 @@ pub fn sha256_main(
 
 pub fn sha256_finalize(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let message: Vec<u8> = vec![0; 64];

--- a/src/vm/hints/squash_dict_utils.rs
+++ b/src/vm/hints/squash_dict_utils.rs
@@ -44,7 +44,7 @@ fn get_access_indices(
 */
 pub fn squash_dict_inner_first_iteration(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that access_indices and key are in scope
@@ -81,7 +81,7 @@ pub fn squash_dict_inner_first_iteration(
 // Implements Hint: ids.should_skip_loop = 0 if current_access_indices else 1
 pub fn squash_dict_inner_skip_loop(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that current_access_indices is in scope
@@ -109,7 +109,7 @@ pub fn squash_dict_inner_skip_loop(
 */
 pub fn squash_dict_inner_check_access_index(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that current_access_indices and current_access_index are in scope
@@ -146,7 +146,7 @@ pub fn squash_dict_inner_check_access_index(
 // Implements Hint: ids.loop_temps.should_continue = 1 if current_access_indices else 0
 pub fn squash_dict_inner_continue_loop(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that ids contains the reference id for each variable used by the hint
@@ -184,7 +184,7 @@ pub fn squash_dict_inner_len_assert(vm_proxy: &mut VMProxy) -> Result<(), Virtua
 //Implements hint: assert ids.n_used_accesses == len(access_indices[key]
 pub fn squash_dict_inner_used_accesses_assert(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let key = get_int_from_scope(vm_proxy.exec_scopes, "key")?;
@@ -223,7 +223,7 @@ pub fn squash_dict_inner_assert_len_keys(
 //  ids.next_key = key = keys.pop()
 pub fn squash_dict_inner_next_key(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Check that current_access_indices is in scope
@@ -265,7 +265,7 @@ pub fn squash_dict_inner_next_key(
 */
 pub fn squash_dict(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     //Get necessary variables addresses from ids
@@ -381,8 +381,8 @@ mod tests {
             )
             .unwrap();
         //Create ids
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("range_check_ptr"), bigint!(0));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("range_check_ptr"), 0);
         //Create references
         vm.references = references!(1);
         //Execute the hint
@@ -436,8 +436,8 @@ mod tests {
             )
             .unwrap();
         //Create ids
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("range_check_ptr"), bigint!(0));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("range_check_ptr"), 0);
         //Create references
         vm.references = references!(1);
         //Execute the hint
@@ -467,8 +467,8 @@ mod tests {
             )
             .unwrap();
         //Create ids
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("range_check_ptr"), bigint!(0));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("range_check_ptr"), 0);
         //Create references
         vm.references = references!(1);
         //Execute the hint
@@ -499,8 +499,8 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = MaybeRelocatable::from((0, 1));
         //Create ids
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("should_skip_loop"), bigint!(0));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("should_skip_loop"), 0);
         //Create references
         vm.references = references!(1);
         //Execute the hint
@@ -534,8 +534,8 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = MaybeRelocatable::from((0, 1));
         //Create ids
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("should_skip_loop"), bigint!(0));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("should_skip_loop"), 0);
         //Create references
         vm.references = references!(1);
         //Execute the hint
@@ -571,8 +571,8 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = MaybeRelocatable::from((0, 1));
         //Create ids
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("loop_temps"), bigint!(0));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("loop_temps"), 0);
         //Create references
         vm.references = references!(1);
         //Execute the hint
@@ -628,8 +628,8 @@ mod tests {
             )
             .unwrap();
         //Create ids
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("loop_temps"), bigint!(0));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("loop_temps"), 0);
         //Create references
         vm.references = references!(1);
         //Execute the hint
@@ -658,8 +658,8 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = MaybeRelocatable::from((0, 1));
         //Create ids
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("loop_temps"), bigint!(0));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("loop_temps"), 0);
         //Create references
         vm.references = references!(1);
         //Execute the hint
@@ -693,8 +693,8 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = MaybeRelocatable::from((0, 1));
         //Create ids
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("loop_temps"), bigint!(0));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("loop_temps"), 0);
         //Create references
         vm.references = references!(1);
         //Execute the hint
@@ -789,8 +789,8 @@ mod tests {
             )
             .unwrap();
         //Create ids
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("n_used_accesses"), bigint!(0));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("n_used_accesses"), 0);
         //Create references
         vm.references = references!(1);
         //Execute the hint
@@ -829,8 +829,8 @@ mod tests {
             )
             .unwrap();
         //Create ids
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("n_used_accesses"), bigint!(0));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("n_used_accesses"), 0);
         //Create references
         vm.references = references!(1);
         //Execute the hint
@@ -872,8 +872,8 @@ mod tests {
             )
             .unwrap();
         //Create ids
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("n_used_accesses"), bigint!(0));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("n_used_accesses"), 0);
         //Create references
         vm.references = references!(1);
         //Execute the hint
@@ -968,8 +968,8 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = MaybeRelocatable::from((0, 1));
         //Create ids
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("next_key"), bigint!(0));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("next_key"), 0);
         //Create references
         vm.references = references!(1);
         //Execute the hint
@@ -1007,8 +1007,8 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = MaybeRelocatable::from((0, 1));
         //Create ids
-        let mut ids = HashMap::<String, BigInt>::new();
-        ids.insert(String::from("next_key"), bigint!(0));
+        let mut ids = HashMap::<String, usize>::new();
+        ids.insert(String::from("next_key"), 0);
         //Create references
         vm.references = references!(1);
         //Execute the hint

--- a/src/vm/hints/uint256_utils.rs
+++ b/src/vm/hints/uint256_utils.rs
@@ -23,7 +23,7 @@ Implements hint:
 */
 pub fn uint256_add(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let shift: BigInt = bigint!(2).pow(128);
@@ -65,7 +65,7 @@ Implements hint:
 */
 pub fn split_64(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let a = get_integer_from_var_name("a", ids, vm_proxy, hint_ap_tracking)?;
@@ -93,7 +93,7 @@ Implements hint:
 */
 pub fn uint256_sqrt(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let n_addr = get_relocatable_from_var_name("n", ids, vm_proxy, hint_ap_tracking)?;
@@ -127,7 +127,7 @@ Implements hint:
 */
 pub fn uint256_signed_nn(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let a_addr = get_relocatable_from_var_name("a", ids, vm_proxy, hint_ap_tracking)?;
@@ -158,7 +158,7 @@ Implements hint:
 */
 pub fn uint256_unsigned_div_rem(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let a_addr = get_relocatable_from_var_name("a", ids, vm_proxy, hint_ap_tracking)?;

--- a/src/vm/hints/usort.rs
+++ b/src/vm/hints/usort.rs
@@ -30,7 +30,7 @@ pub fn usort_enter_scope(vm_proxy: &mut VMProxy) -> Result<(), VirtualMachineErr
 
 pub fn usort_body(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let input_arr_start_ptr =
@@ -114,7 +114,7 @@ pub fn usort_body(
 
 pub fn verify_usort(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let value = get_integer_from_var_name("value", ids, vm_proxy, hint_ap_tracking)?.clone();
@@ -144,7 +144,7 @@ pub fn verify_multiplicity_assert(vm_proxy: &mut VMProxy) -> Result<(), VirtualM
 
 pub fn verify_multiplicity_body(
     vm_proxy: &mut VMProxy,
-    ids: &HashMap<String, BigInt>,
+    ids: &HashMap<String, usize>,
     hint_ap_tracking: Option<&ApTracking>,
 ) -> Result<(), VirtualMachineError> {
     let current_pos = get_list_u64_from_scope_mut(vm_proxy.exec_scopes, "positions")?

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -294,12 +294,12 @@ impl CairoRunner {
     }
 
     fn remove_path_from_reference_ids(
-        referece_ids: &HashMap<String, BigInt>,
-    ) -> Result<HashMap<String, BigInt>, RunnerError> {
-        let mut reference_ids_new = HashMap::<String, BigInt>::new();
+        referece_ids: &HashMap<String, usize>,
+    ) -> Result<HashMap<String, usize>, RunnerError> {
+        let mut reference_ids_new = HashMap::<String, usize>::new();
         for (path, value) in referece_ids {
             if let Some(name) = path.rsplit('.').next() {
-                reference_ids_new.insert(name.to_string(), value.clone());
+                reference_ids_new.insert(name.to_string(), *value);
             } else {
                 return Err(RunnerError::FailedToParseIdsNameFromPath(path.clone()));
             }
@@ -1043,21 +1043,20 @@ mod tests {
     //Integration tests for initialization phase
 
     #[test]
-    /*Program used:
-    func myfunc(a: felt) -> (r: felt):
-        let b = a * 2
-        return(b)
-    end
-
-    func main():
-        let a = 1
-        let b = myfunc(a)
-        return()
-    end
-
-    main = 3
-    data = [5207990763031199744, 2, 2345108766317314046, 5189976364521848832, 1, 1226245742482522112, 3618502788666131213697322783095070105623107215331596699973092056135872020476, 2345108766317314046]
-    */
+    // Program used:
+    // func myfunc(a: felt) -> (r: felt):
+    // let b = a * 2
+    // return(b)
+    // end
+    //
+    // func main():
+    // let a = 1
+    // let b = myfunc(a)
+    // return()
+    // end
+    //
+    // main = 3
+    // data = [5207990763031199744, 2, 2345108766317314046, 5189976364521848832, 1, 1226245742482522112, 3618502788666131213697322783095070105623107215331596699973092056135872020476, 2345108766317314046]
     fn initialization_phase_no_builtins() {
         let program = Program {
             builtins: vec![],

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -1043,20 +1043,21 @@ mod tests {
     //Integration tests for initialization phase
 
     #[test]
-    // Program used:
-    // func myfunc(a: felt) -> (r: felt):
-    // let b = a * 2
-    // return(b)
-    // end
-    //
-    // func main():
-    // let a = 1
-    // let b = myfunc(a)
-    // return()
-    // end
-    //
-    // main = 3
-    // data = [5207990763031199744, 2, 2345108766317314046, 5189976364521848832, 1, 1226245742482522112, 3618502788666131213697322783095070105623107215331596699973092056135872020476, 2345108766317314046]
+    /* Program used:
+    func myfunc(a: felt) -> (r: felt):
+        let b = a * 2
+        return(b)
+    end
+
+    func main():
+        let a = 1
+        let b = myfunc(a)
+        return()
+    end
+
+    main = 3
+    data = [5207990763031199744, 2, 2345108766317314046, 5189976364521848832, 1, 1226245742482522112, 3618502788666131213697322783095070105623107215331596699973092056135872020476, 2345108766317314046]
+    */
     fn initialization_phase_no_builtins() {
         let program = Program {
             builtins: vec![],

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -35,7 +35,7 @@ struct OperandsAddresses(MaybeRelocatable, MaybeRelocatable, MaybeRelocatable);
 pub struct HintData {
     pub hint_code: String,
     //Maps the name of the variable to its reference id
-    pub ids: HashMap<String, BigInt>,
+    pub ids: HashMap<String, usize>,
     pub ap_tracking_data: ApTracking,
 }
 
@@ -76,7 +76,7 @@ pub struct VirtualMachine {
 impl HintData {
     pub fn new(
         hint_code: &str,
-        ids: HashMap<String, BigInt>,
+        ids: HashMap<String, usize>,
         ap_tracking_data: ApTracking,
     ) -> HintData {
         HintData {


### PR DESCRIPTION
## Description
This PR solves issue #226 
Reference id's from the JSON compiled programs were first modeled as a `HashMap<String, BigInt>`. With time, we discovered there was no need for the values to be of type `BigInt` because they are referring to indexes. 

## Checklist
- [x] Linked to Github Issue
