### PR TITLE
Don't expect Bash for the compare script

### DIFF
--- a/src/tests/compare_vm_state.sh
+++ b/src/tests/compare_vm_state.sh
@@ -21,7 +21,7 @@ for i in $@; do
 done
 
 files=$(ls $tests_path)
-if [[ $? != 0 ]]; then
+if [ $? != 0 ]; then
     exit $?
 fi
 


### PR DESCRIPTION
The `compare_vm_state.sh` script was using a Bash-only feature for testing the exit code of `ls`, which broke the check for folder existence in the CI, effectively making it void.
Use the regular `test` (or `[`) utility instead.