### PR TITLE
fix typo Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ You can install all of the required and optional dependencies by running the scr
 
 In order to compile programs you need to install the cairo-lang package.
 
-Running the  `make deps` (or the `make deps-macos`  if you are runnning in MacOS) command will create a virtual environment with all the required dependencies.
+Running the  `make deps` (or the `make deps-macos`  if you are running in MacOS) command will create a virtual environment with all the required dependencies.
 
 You can then activate this environment by running
  ```bash


### PR DESCRIPTION
### Fix Typo in README.md

This pull request addresses a small typographical error in the `README.md` file.

#### Changes Made:
- Corrected "runnning" to "running" in the instructions for setting up dependencies.

---

This improvement ensures better readability and professionalism in the documentation.
