### PR TITLE
Prepare for release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+#### [2.0.0] - 2025-02-26
+
 * fix: Check overflow in cairo pie address calculation [#1945](https://github.com/lambdaclass/cairo-vm/pull/1945)
 
 #### [2.0.0-rc5] - 2025-02-24

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-vm"
-version = "2.0.0-rc5"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-vm-cli"
-version = "2.0.0-rc5"
+version = "2.0.0"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-vm-tracer"
-version = "2.0.0-rc5"
+version = "2.0.0"
 dependencies = [
  "axum",
  "cairo-vm",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "cairo1-run"
-version = "2.0.0-rc5"
+version = "2.0.0"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -1676,7 +1676,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hint_accountant"
-version = "2.0.0-rc5"
+version = "2.0.0"
 dependencies = [
  "cairo-vm",
  "serde",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "hyper_threading"
-version = "2.0.0-rc5"
+version = "2.0.0"
 dependencies = [
  "cairo-vm",
  "rayon",
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-demo"
-version = "2.0.0-rc5"
+version = "2.0.0"
 dependencies = [
  "cairo-vm",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["ensure-no_std"]
 resolver = "2"
 
 [workspace.package]
-version = "2.0.0-rc5"
+version = "2.0.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/lambdaclass/cairo-vm/"
@@ -24,8 +24,8 @@ readme = "README.md"
 keywords = ["starknet", "cairo", "vm", "wasm", "no_std"]
 
 [workspace.dependencies]
-cairo-vm = { path = "./vm", version = "2.0.0-rc5", default-features = false }
-cairo-vm-tracer = { path = "./cairo-vm-tracer", version = "2.0.0-rc5", default-features = false }
+cairo-vm = { path = "./vm", version = "2.0.0", default-features = false }
+cairo-vm-tracer = { path = "./cairo-vm-tracer", version = "2.0.0", default-features = false }
 mimalloc = { version = "0.1.37", default-features = false }
 num-bigint = { version = "0.4", default-features = false, features = [
     "serde",


### PR DESCRIPTION
# TITLE

## Description

This is a second try of https://github.com/lambdaclass/cairo-vm/pull/1974 which had some issue with the ci's cache

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [X] CHANGELOG has been updated.

