### PR TITLE
Fix enhancement issue link in README to point to cairo-vm repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ Keeps track of the latest changes [here](CHANGELOG.md).
 
 The open-source community is a fantastic place for learning, inspiration, and creation, and this is all thanks to contributions from people like you. Your contributions are **greatly appreciated**.
 
-If you have any suggestions for how to improve the project, please feel free to fork the repo and create a pull request, or [open an issue](https://github.com/lambdaclass/starknet_in_rust/issues/new?labels=enhancement&title=feat%3A+) with the tag 'enhancement'.
+If you have any suggestions for how to improve the project, please feel free to fork the repo and create a pull request, or [open an issue](https://github.com/lambdaclass/cairo-vm/issues/new?labels=enhancement&title=feat%3A+) with the tag 'enhancement'.
 
 1. Fork the Project
 2. Create your Feature Branch (`git checkout -b feat/AmazingFeature`)


### PR DESCRIPTION
The link for opening enhancement issues in the Contributing section of the README previously pointed to the starknet_in_rust repository. This commit updates the link to direct users to the correct cairo-vm GitHub repository, ensuring that suggestions and feature requests are submitted to the appropriate project.