### PR TITLE
add output segment to the prover input info

### DIFF
--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -1539,11 +1539,8 @@ impl CairoRunner {
             .builtin_runners
             .iter()
             .filter(|builtin| {
-                // Those segments are not treated as builtins by the prover.
-                !matches!(
-                    builtin,
-                    BuiltinRunner::SegmentArena(_) | BuiltinRunner::Output(_)
-                )
+                // This segment is not treated as builtin by the prover.
+                !matches!(builtin, BuiltinRunner::SegmentArena(_))
             })
             .map(|builtin| {
                 let (index, _) = builtin.get_memory_segment_addresses();


### PR DESCRIPTION
Apparently, the prover expects the output segment to be included among the builtin segments, if an output is present