### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -18,7 +18,7 @@ jobs:
       uses: dtolnay/rust-toolchain@1.87.0
       with:
           components: rustfmt, clippy
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install uv
       uses: astral-sh/setup-uv@v5
       with:

--- a/.github/workflows/cairo_1_programs.yml
+++ b/.github/workflows/cairo_1_programs.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Cargo cache
         uses: Swatinem/rust-cache@v2
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: install corelib
         run:  cd cairo1-run/ && make deps
       - name: Run tests

--- a/.github/workflows/fresh_run.yml
+++ b/.github/workflows/fresh_run.yml
@@ -35,7 +35,7 @@ jobs:
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@1.87.0

--- a/.github/workflows/fuzzer.yml
+++ b/.github/workflows/fuzzer.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         ref: ${{ github.head_ref }}
 
@@ -56,7 +56,7 @@ jobs:
 
     # Checkout current and last commit for the diff
     - name: Checkout commits
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 2
 

--- a/.github/workflows/hint_accountant.yml
+++ b/.github/workflows/hint_accountant.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Cargo cache
       uses: Swatinem/rust-cache@v2
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Check Build
       run: cargo build -p hint_accountant
     - name: Clone cairo-lang repo

--- a/.github/workflows/hyper_threading_benchmarks.yml
+++ b/.github/workflows/hyper_threading_benchmarks.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout PR
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5
@@ -52,7 +52,7 @@ jobs:
 
 
     - name: Checkout Main Branch
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         ref: 'main'
 

--- a/.github/workflows/hyperfine.yml
+++ b/.github/workflows/hyperfine.yml
@@ -23,7 +23,7 @@ jobs:
       benchmark-hashes-head: ${{ steps.export-hashes.outputs.benchmark-hashes-head }}
     steps:
       - name: Checkout base commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request[matrix.branch].sha }}
 
@@ -82,7 +82,7 @@ jobs:
 
       - name: Checkout
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request[matrix.branch].sha }}
 

--- a/.github/workflows/iai_main.yml
+++ b/.github/workflows/iai_main.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install Rust
       uses: dtolnay/rust-toolchain@1.87.0
     - name: Set up cargo cache

--- a/.github/workflows/iai_pr.yml
+++ b/.github/workflows/iai_pr.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         ref: ${{ github.event.pull_request.base.sha }}
     - name: Initialize IAI cache for ${{ github.event.pull_request.base.sha }}
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install Rust
       uses: dtolnay/rust-toolchain@1.87.0
     - name: Set up cargo cache

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install stable toolchain
       uses: dtolnay/rust-toolchain@1.87.0
     - name: Publish crate cairo-vm

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
   upload_proof_programs_symlinks:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
     - name: Create proof_programs symlinks
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -109,7 +109,7 @@ jobs:
     needs: build-programs
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - uses: actions/download-artifact@master
       with:
@@ -165,7 +165,7 @@ jobs:
     - name: Set up cargo cache
       uses: Swatinem/rust-cache@v2
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - uses: actions/download-artifact@master
       with:
@@ -214,7 +214,7 @@ jobs:
         tool: cargo-all-features
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - uses: actions/download-artifact@master
       with:
@@ -260,7 +260,7 @@ jobs:
         tool: cargo-all-features
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Download proof programs symlinks
       uses: actions/download-artifact@master
@@ -295,7 +295,7 @@ jobs:
         cache-on-failure: true
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Download proof programs symlinks
       uses: actions/download-artifact@master
@@ -333,7 +333,7 @@ jobs:
     - name: Set up cargo cache
       uses: Swatinem/rust-cache@v2
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - uses: actions/download-artifact@master
       with:
@@ -397,7 +397,7 @@ jobs:
     - name: Set up cargo cache
       uses: Swatinem/rust-cache@v2
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Build
       run: cargo b --release -p cairo-vm-cli
     # We don't read from cache because it should always miss
@@ -422,7 +422,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -495,7 +495,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Fetch release binary
       uses: actions/cache/restore@v3
@@ -541,7 +541,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Fetch results for tests with stdlib (part. 1)
       uses: actions/cache/restore@v3
@@ -755,7 +755,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - uses: actions/download-artifact@master
       with:
@@ -802,7 +802,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -832,7 +832,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5
@@ -872,7 +872,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5
@@ -924,7 +924,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-22.04, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Cargo cache
         uses: Swatinem/rust-cache@v2
@@ -46,7 +46,7 @@ jobs:
         shell: bash {0}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # we don't use swatinem because rustc isn't installed yet
       - name: Cache Rust dependencies


### PR DESCRIPTION
Bumps checkout to v5 for future-proofing against Node 24 runner updates. Requires runner v2.327.1+. Workflows compile the same.

More info: https://github.com/actions/checkout/releases/tag/v5.0.0