### PR TITLE
Prepare for 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Upcoming Changes
 
-#### [2.5.1] - 2025-09-11
+#### [2.5.0] - 2025-09-11
 
 * breaking: Store constants in Hint Data [#2191](https://github.com/lambdaclass/cairo-vm/pull/2191)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-vm"
-version = "2.5.1"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-vm-cli"
-version = "2.5.1"
+version = "2.5.0"
 dependencies = [
  "assert_matches",
  "bincode 2.0.1",
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-vm-tracer"
-version = "2.5.1"
+version = "2.5.0"
 dependencies = [
  "axum",
  "cairo-vm",
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "cairo1-run"
-version = "2.5.1"
+version = "2.5.0"
 dependencies = [
  "assert_matches",
  "bincode 2.0.1",
@@ -1654,7 +1654,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hint_accountant"
-version = "2.5.1"
+version = "2.5.0"
 dependencies = [
  "cairo-vm",
  "serde",
@@ -1735,7 +1735,7 @@ dependencies = [
 
 [[package]]
 name = "hyper_threading"
-version = "2.5.1"
+version = "2.5.0"
 dependencies = [
  "cairo-vm",
  "rayon",
@@ -3676,7 +3676,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-demo"
-version = "2.5.1"
+version = "2.5.0"
 dependencies = [
  "cairo-vm",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["ensure-no_std"]
 resolver = "2"
 
 [workspace.package]
-version = "2.5.1"
+version = "2.5.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/lambdaclass/cairo-vm/"
@@ -24,8 +24,8 @@ readme = "README.md"
 keywords = ["starknet", "cairo", "vm", "wasm", "no_std"]
 
 [workspace.dependencies]
-cairo-vm = { path = "./vm", version = "2.5.1", default-features = false }
-cairo-vm-tracer = { path = "./cairo-vm-tracer", version = "2.5.1", default-features = false }
+cairo-vm = { path = "./vm", version = "2.5.0", default-features = false }
+cairo-vm-tracer = { path = "./cairo-vm-tracer", version = "2.5.0", default-features = false }
 mimalloc = { version = "0.1.37", default-features = false }
 num-bigint = { version = "0.4", default-features = false, features = [
     "serde",


### PR DESCRIPTION
# Prepare for 2.5.0

This PR includes only https://github.com/lambdaclass/cairo-vm/pull/2191.

## BREAKING CHANGES

This PR is BREAKING, as it changes the signature of the hint processor definition.

- Instead of receiving constants on `execute_hint`, now the constants are received on `compile_hint`: https://github.com/lambdaclass/cairo-vm/blob/fec5af0d99590a05bc529388137d2e3d0141fb87/vm/src/hint_processor/hint_processor_definition.rs#L44-L45
- When compiling hints, we now need to extract the program's constants and pass them in a `Rc`: https://github.com/lambdaclass/cairo-vm/blob/fec5af0d99590a05bc529388137d2e3d0141fb87/vm/src/vm/runners/cairo_runner.rs#L647-L660

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

