### PR TITLE
Enable pipefail in macOS install script to fail on pipeline errors

### DIFF
--- a/install-scripts/install-macos.sh
+++ b/install-scripts/install-macos.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ex
+set -ex -o pipefail
 
 # Install Rust and Cargo
 curl https://sh.rustup.rs -sSf | sh -s -- -y


### PR DESCRIPTION


### Description
- **What**: Add `-o pipefail` to `install-scripts/install-macos.sh` shell options.
- **Why**: Without `pipefail`, commands like `curl ... | sh` can mask failures in the left side of the pipeline, leading to false‑positive installs and harder debugging.
- **Impact**: More reliable CI/local setup; script now exits on any pipeline error.

