### PR TITLE
[DNM] Bump MacOS version used in CI job

### DIFF
--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -12,7 +12,7 @@ jobs:
     name: "Install on ${{ matrix.os }}"
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13]
+        os: [ubuntu-22.04, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
[This job](https://github.com/lambdaclass/cairo-vm/actions/runs/19276279151/job/55119558909?pr=2195) is being cancelled due to the following error:

```
This is a scheduled macos-13 brownout. The macOS-13 based runner images are being deprecated. For more details, see https://github.com/actions/runner-images/issues/13046.
--
The macOS-13 based runner images are being deprecated, consider switching to macOS-15 (macos-15-intel) or macOS 15 arm64 (macos-latest) instead. For more details see https://github.com/actions/runner-images/issues/13046
```

[Here's](https://github.com/actions/runner-images/issues/13046) the link to the related issue for easier access.

This PR fix this issue by bumping the MacOS version used in the failing CI job.