### PR TITLE
Make blake2s API internal

### DIFF
--- a/vm/src/hint_processor/builtin_hint_processor/blake2s_hash.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/blake2s_hash.rs
@@ -101,7 +101,7 @@ fn blake_round(mut state: Vec<u32>, message: &[u32; 16], sigma: [usize; 16]) -> 
     state
 }
 
-pub(crate) fn blake2s_compress(
+pub fn blake2s_compress(
     h: &[u32; 8],
     message: &[u32; 16],
     t0: u32,

--- a/vm/src/hint_processor/builtin_hint_processor/mod.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/mod.rs
@@ -1,6 +1,6 @@
 pub mod bigint;
-pub mod blake2s_hash;
-pub mod blake2s_utils;
+pub(crate) mod blake2s_hash;
+mod blake2s_utils;
 pub mod builtin_hint_processor_definition;
 pub mod cairo_keccak;
 pub mod dict_hint_utils;


### PR DESCRIPTION
This is a step towards moving Blake2s logic outside of the VM so that it can be used by Native or other crates without depending on the VM or repeating code.