### PR TITLE
chore: remove unused import 'any_box' from tests

### DIFF
--- a/vm/src/hint_processor/builtin_hint_processor/memset_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/memset_utils.rs
@@ -57,7 +57,6 @@ mod tests {
     use super::*;
     use crate::types::relocatable::Relocatable;
     use crate::{
-        any_box,
         hint_processor::{
             builtin_hint_processor::builtin_hint_processor_definition::{
                 BuiltinHintProcessor, HintProcessorData,


### PR DESCRIPTION
# TITLE

## Description

only removing the unused `any_box` import from the test module.
Nothing else has been touched.


## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

